### PR TITLE
Fix VerifyIEPaths ProcessTimeoutMs

### DIFF
--- a/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
+++ b/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
@@ -24,6 +24,9 @@
 .PARAMETER StatusFileTimeoutMs
     Timeout in milliseconds to wait for the status file to appear.
 
+.PARAMETER ProcessTimeoutMs
+    Maximum time to wait for g-cli to finish in milliseconds (0 disables the timeout).
+
 .PARAMETER StatusFileArchiveDirectory
     Optional directory to archive the status file after reading. If omitted,
     the status file is deleted.
@@ -66,6 +69,10 @@ param(
     [Parameter(Mandatory = $false)]
     [ValidateRange(0, 600000)]
     [int]$StatusFileTimeoutMs = 60000,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(0, 1200000)]
+    [int]$ProcessTimeoutMs = 300000,
 
     [Parameter(Mandatory = $false)]
     [string]$StatusFileArchiveDirectory,
@@ -266,7 +273,10 @@ if (-not [string]::IsNullOrWhiteSpace($statusPathExpected) -and (Test-Path -Path
 }
 Push-Location -Path $repoRoot
 try {
-    $result = Invoke-GCliCommand -ExecutablePath $gCliPath -Arguments $gCliArgs
+    $result = Invoke-GCliCommand -ExecutablePath $gCliPath -Arguments $gCliArgs -TimeoutMs $ProcessTimeoutMs
+    if ($result.TimedOut) {
+        throw "VerifyIEPaths.vi timed out after $ProcessTimeoutMs ms."
+    }
     if ($result.ExitCode -ne 0) {
         if ($IgnoreGcliExitCode) {
             Write-Warning ("VerifyIEPaths.vi returned exit code {0}; continuing because IgnoreGcliExitCode is set." -f $result.ExitCode)

--- a/docs/powershell-dependency-scripts.md
+++ b/docs/powershell-dependency-scripts.md
@@ -40,7 +40,7 @@ Modifies a `.vipb` file and builds the final VI Package with g-cli, using versio
 Gracefully shuts down a running LabVIEW instance using g-cli's `QuitLabVIEW` command. Called throughout the pipeline to ensure LabVIEW exits cleanly.
 
 ## Invoke-MissingIEFilesFromLVInstall.ps1
-Runs `VerifyIEPaths.vi` via g-cli to validate the LabVIEW Icon API installation. The VI writes a status file to the repo root (default: `missing_IE_paths.txt`). An empty file indicates success; a comma-separated list of paths indicates missing files and should be treated as a failure. The script deletes any prior status file before running, waits for a new one (with timeout), and then deletes or archives it after reading. Use `-StatusFileArchiveDirectory` to preserve a copy. Set `-ConnectTimeoutMs` and `-StatusFileTimeoutMs` to control g-cli and status-file timing behavior.
+Runs `VerifyIEPaths.vi` via g-cli to validate the LabVIEW Icon API installation. The VI writes a status file to the repo root (default: `missing_IE_paths.txt`). An empty file indicates success; a comma-separated list of paths indicates missing files and should be treated as a failure. The script deletes any prior status file before running, waits for a new one (with timeout), and then deletes or archives it after reading. Use `-StatusFileArchiveDirectory` to preserve a copy. Set `-ConnectTimeoutMs`, `-ProcessTimeoutMs`, and `-StatusFileTimeoutMs` to control g-cli and status-file timing behavior.
 
 ## ModifyVIPBDisplayInfo.ps1
 Updates the display information inside a `.vipb` file and merges version and branding metadata. Typically called by `Build.ps1` before packaging.


### PR DESCRIPTION
Summary:
- Add ProcessTimeoutMs support to VerifyIEPaths runner so CI gate can pass it.
- Wire timeout into g-cli invocation and document the new flag.

Tests:
- Not run (parameter wiring only).
