### PR TITLE
Rename LabVIEW version input to labview_version

### DIFF
--- a/.github/actions/add-token-to-labview/README.md
+++ b/.github/actions/add-token-to-labview/README.md
@@ -8,7 +8,8 @@ This action depends on `Tooling/deployment/Create_LV_INI_Token.vi`, which is not
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) used by g-cli. |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) used by g-cli. |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
 
@@ -16,7 +17,7 @@ This action depends on `Tooling/deployment/Create_LV_INI_Token.vi`, which is not
 ```yaml
 - uses: ./.github/actions/add-token-to-labview
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
 ```

--- a/.github/actions/add-token-to-labview/README.md
+++ b/.github/actions/add-token-to-labview/README.md
@@ -9,7 +9,6 @@ This action depends on `Tooling/deployment/Create_LV_INI_Token.vi`, which is not
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) used by g-cli. |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
 

--- a/.github/actions/add-token-to-labview/action.yml
+++ b/.github/actions/add-token-to-labview/action.yml
@@ -11,14 +11,25 @@ runs:
     - name: Run AddTokenToLabVIEW.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         & "${{ github.action_path }}/AddTokenToLabVIEW.ps1" \
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
+          -MinimumSupportedLVVersion $lvVersion \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RepoRoot "${{ inputs.repo_root }}"
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true

--- a/.github/actions/add-token-to-labview/action.yml
+++ b/.github/actions/add-token-to-labview/action.yml
@@ -13,9 +13,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -26,13 +23,12 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
   repo_root:
     description: 'Workspace root path'
     required: true
+
+

--- a/.github/actions/apply-vipc/README.md
+++ b/.github/actions/apply-vipc/README.md
@@ -18,7 +18,7 @@ Ensure a runner has all required LabVIEW packages installed before building or t
 | Requirement | Notes |
 |-------------|-------|
 | **Windows runner** | LabVIEW and g-cli are Windows only. |
-| **LabVIEW 2021 (21.0)** | Must match both `minimum_supported_lv_version` and `vip_lv_version`. |
+| **LabVIEW 2021 (21.0)** | Must match both `labview_version` and `vip_lv_version`. |
 | **g-cli** in `PATH` | Used to apply the `.vipc` configuration. Install via **VIPM (JKI)** or include the executable in the runner image. |
 | **PowerShell 7** | Composite steps use PowerShell Core (`pwsh`). |
 
@@ -28,8 +28,7 @@ Ensure a runner has all required LabVIEW packages installed before building or t
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW *major* version that the repo supports. |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
-| `vip_lv_version` | **Yes** | `2021` | LabVIEW version used to apply the `.vipc` file. Usually the same as `minimum_supported_lv_version`. |
+| `vip_lv_version` | **Yes** | `2021` | LabVIEW version used to apply the `.vipc` file. Usually the same as `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | LabVIEW bitness to target. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Root path of the repository on disk. |
 | `vipc_path` | **Yes** | `Tooling/deployment/runner_dependencies.vipc` | Path (relative to `repo_root`) of the VI Package Configuration to apply. |

--- a/.github/actions/apply-vipc/README.md
+++ b/.github/actions/apply-vipc/README.md
@@ -27,7 +27,8 @@ Ensure a runner has all required LabVIEW packages installed before building or t
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW *major* version that the repo supports. |
+| `labview_version` | **Yes** | `2021` | LabVIEW *major* version that the repo supports. |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `vip_lv_version` | **Yes** | `2021` | LabVIEW version used to apply the `.vipc` file. Usually the same as `minimum_supported_lv_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | LabVIEW bitness to target. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Root path of the repository on disk. |
@@ -43,7 +44,7 @@ steps:
   - name: Install LabVIEW dependencies
     uses: ./.github/actions/apply-vipc
     with:
-      minimum_supported_lv_version: 2021
+      labview_version: 2021
       vip_lv_version: 2021
       supported_bitness: 64
       repo_root: ${{ github.workspace }}

--- a/.github/actions/apply-vipc/action.yml
+++ b/.github/actions/apply-vipc/action.yml
@@ -13,9 +13,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -28,10 +25,7 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
+    required: true
   vip_lv_version:
     description: 'VIPC LabVIEW version (2021 / 21.0)'
     required: true
@@ -44,3 +38,5 @@ inputs:
   vipc_path:
     description: 'Path under repo for the .vipc file (relative to workspace)'
     required: true
+
+

--- a/.github/actions/apply-vipc/action.yml
+++ b/.github/actions/apply-vipc/action.yml
@@ -11,16 +11,27 @@ runs:
     - name: Run ApplyVIPC.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         & "${{ github.action_path }}/ApplyVIPC.ps1" `
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -MinimumSupportedLVVersion $lvVersion `
           -VIP_LVVersion ${{ inputs.vip_lv_version }} `
           -SupportedBitness ${{ inputs.supported_bitness }} `
           -RepoRoot "${{ inputs.repo_root }}" `
           -VIPCPath "${{ inputs.vipc_path }}"
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   vip_lv_version:
     description: 'VIPC LabVIEW version (2021 / 21.0)'
     required: true

--- a/.github/actions/build-lvlibp/README.md
+++ b/.github/actions/build-lvlibp/README.md
@@ -5,7 +5,8 @@ Call **`Build_lvlibp.ps1`** to compile the editor packed library using g-cli.
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) to use. |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) to use. |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
 | `major` | **Yes** | `1` | Major version component. |
@@ -18,7 +19,7 @@ Call **`Build_lvlibp.ps1`** to compile the editor packed library using g-cli.
 ```yaml
 - uses: ./.github/actions/build-lvlibp
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
     major: 1

--- a/.github/actions/build-lvlibp/README.md
+++ b/.github/actions/build-lvlibp/README.md
@@ -6,7 +6,6 @@ Call **`Build_lvlibp.ps1`** to compile the editor packed library using g-cli.
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) to use. |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
 | `major` | **Yes** | `1` | Major version component. |

--- a/.github/actions/build-lvlibp/action.yml
+++ b/.github/actions/build-lvlibp/action.yml
@@ -11,8 +11,16 @@ runs:
     - name: Run Build_lvlibp.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         & "${{ github.action_path }}/Build_lvlibp.ps1" `
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -MinimumSupportedLVVersion $lvVersion `
           -SupportedBitness ${{ inputs.supported_bitness }} `
           -RepoRoot "${{ inputs.repo_root }}" `
           -Major ${{ inputs.major }} `
@@ -21,9 +29,12 @@ runs:
           -Build ${{ inputs.build }} `
           -Commit "${{ inputs.commit }}"
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true

--- a/.github/actions/build-lvlibp/action.yml
+++ b/.github/actions/build-lvlibp/action.yml
@@ -13,9 +13,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -31,10 +28,7 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
@@ -56,3 +50,5 @@ inputs:
   commit:
     description: 'Commit identifier'
     required: true
+
+

--- a/.github/actions/build-vip/README.md
+++ b/.github/actions/build-vip/README.md
@@ -9,7 +9,6 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root path. |
 | `vipb_path` | **Yes** | `Tooling/deployment/NI Icon editor.vipb` | Path to the VIPB file. |
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `labview_minor_revision` | No (defaults to `0`) | `0` | LabVIEW minor revision. |
 | `major` | **Yes** | `1` | Major version component. |
 | `minor` | **Yes** | `0` | Minor version component. |

--- a/.github/actions/build-vip/README.md
+++ b/.github/actions/build-vip/README.md
@@ -8,7 +8,8 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
 | `supported_bitness` | **Yes** | `64` | Target LabVIEW bitness. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root path. |
 | `vipb_path` | **Yes** | `Tooling/deployment/NI Icon editor.vipb` | Path to the VIPB file. |
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `labview_minor_revision` | No (defaults to `0`) | `0` | LabVIEW minor revision. |
 | `major` | **Yes** | `1` | Major version component. |
 | `minor` | **Yes** | `0` | Minor version component. |
@@ -25,7 +26,7 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
     vipb_path: Tooling/deployment/NI Icon editor.vipb
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     major: 1
     minor: 0
     patch: 0

--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -13,12 +13,19 @@ runs:
       shell: pwsh
       run: |
         $ErrorActionPreference = 'Stop'
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
         $logDir = Join-Path -Path "${{ inputs.repo_root }}" -ChildPath "builds/logs"
         New-Item -ItemType Directory -Path $logDir -Force | Out-Null
         $logFile = Join-Path -Path $logDir -ChildPath "gcli-preflight.log"
 
         $gcliArgs = @(
-          "--lv-ver", "${{ inputs.minimum_supported_lv_version }}",
+          "--lv-ver", $lvVersion,
           "--arch", "${{ inputs.supported_bitness }}",
           "--connect-timeout", "60000",
           "--kill",
@@ -96,13 +103,20 @@ runs:
         DISPLAY_INFORMATION_JSON: |
           ${{ inputs.display_information_json }}
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
         $displayInformationJson = $Env:DISPLAY_INFORMATION_JSON
 
         & "${{ github.action_path }}/build_vip.ps1" `
           -SupportedBitness ${{ inputs.supported_bitness }} `
           -RepoRoot "${{ inputs.repo_root }}" `
           -VIPBPath "${{ inputs.vipb_path }}" `
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -MinimumSupportedLVVersion $lvVersion `
           -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} `
           -Major ${{ inputs.major }} `
           -Minor ${{ inputs.minor }} `
@@ -225,6 +239,9 @@ runs:
         Get-Content -Path $path | ForEach-Object { Write-Host $_ }
         Write-Host "---- end release notes ----"
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true
@@ -235,8 +252,8 @@ inputs:
     description: 'Path to the VIPB file (relative to workspace)'
     required: true
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   labview_minor_revision:
     description: 'LabVIEW minor revision (0 for 21.0)'
     required: false

--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -15,9 +15,6 @@ runs:
         $ErrorActionPreference = 'Stop'
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
         $logDir = Join-Path -Path "${{ inputs.repo_root }}" -ChildPath "builds/logs"
@@ -104,9 +101,6 @@ runs:
           ${{ inputs.display_information_json }}
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
@@ -241,7 +235,7 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
@@ -251,9 +245,6 @@ inputs:
   vipb_path:
     description: 'Path to the VIPB file (relative to workspace)'
     required: true
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
   labview_minor_revision:
     description: 'LabVIEW minor revision (0 for 21.0)'
     required: false
@@ -283,3 +274,5 @@ inputs:
     description: 'If true, fail when multiple .vip files exist after the build step'
     required: false
     default: 'true'
+
+

--- a/.github/actions/build-vip/build_vip.ps1
+++ b/.github/actions/build-vip/build_vip.ps1
@@ -86,6 +86,10 @@ catch {
     exit 1
 }
 
+# 1b) Ensure VI Package output directory exists to avoid VIPM prompts
+$vipOutputDir = Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/VI Package"
+New-Item -ItemType Directory -Path $vipOutputDir -Force | Out-Null
+
 # 2) Create release notes if needed and resolve the paths
 if (-not (Test-Path $ReleaseNotesFile)) {
     Write-Host "Release notes file '$ReleaseNotesFile' does not exist. Creating it..."

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -50,3 +50,5 @@ inputs:
   author_name:
     description: 'Author name for metadata'
     required: true
+
+

--- a/.github/actions/close-labview/README.md
+++ b/.github/actions/close-labview/README.md
@@ -6,14 +6,13 @@ Run **`Close_LabVIEW.ps1`** to terminate a running LabVIEW instance via g-cli.
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) to close. |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 
 ## Quick-start
 ```yaml
 - uses: ./.github/actions/close-labview
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     # preferred:
     # labview_version: 2021
     supported_bitness: 64

--- a/.github/actions/close-labview/README.md
+++ b/.github/actions/close-labview/README.md
@@ -5,7 +5,8 @@ Run **`Close_LabVIEW.ps1`** to terminate a running LabVIEW instance via g-cli.
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) to close. |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) to close. |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 
 ## Quick-start
@@ -13,6 +14,8 @@ Run **`Close_LabVIEW.ps1`** to terminate a running LabVIEW instance via g-cli.
 - uses: ./.github/actions/close-labview
   with:
     minimum_supported_lv_version: 2021
+    # preferred:
+    # labview_version: 2021
     supported_bitness: 64
 ```
 

--- a/.github/actions/close-labview/action.yml
+++ b/.github/actions/close-labview/action.yml
@@ -12,14 +12,25 @@ runs:
     - name: Run Close_LabVIEW.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         & "${{ github.action_path }}/Close_LabVIEW.ps1" `
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -MinimumSupportedLVVersion $lvVersion `
           -SupportedBitness ${{ inputs.supported_bitness }} `
           -TimeoutSeconds ${{ inputs.timeout_seconds }}
 inputs:
+  labview_version:
+    description: 'LabVIEW version to close (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true

--- a/.github/actions/close-labview/action.yml
+++ b/.github/actions/close-labview/action.yml
@@ -14,9 +14,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -27,10 +24,7 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to close (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
@@ -38,3 +32,5 @@ inputs:
     description: 'How long to wait for LabVIEW to exit before failing'
     required: false
     default: 120
+
+

--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -100,3 +100,5 @@ runs:
         "MINOR=$min"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
         "PATCH=$pat"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
         "IS_PRERELEASE=$isPre"  | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+
+

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -17,3 +17,5 @@ runs:
       shell: pwsh
       run: |
         & "${{ github.action_path }}/GenerateReleaseNotes.ps1" -OutputPath "${{ inputs.output_path }}"
+
+

--- a/.github/actions/icon-editor-files-in-lv-installation/Compare-IconEditorFilesCsv.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Compare-IconEditorFilesCsv.ps1
@@ -7,6 +7,7 @@ param(
     [Parameter(Mandatory)]
     [string]$AfterCsv,
 
+    [Parameter(Mandatory)]
     [string]$RepoRoot,
 
     [switch]$IncludeGitMetadata,
@@ -56,18 +57,15 @@ function Resolve-RepoRoot {
         [string]$PathOverride
     )
 
-    if (-not [string]::IsNullOrWhiteSpace($PathOverride)) {
-        if (-not (Test-Path -Path $PathOverride)) {
-            return $null
-        }
-        return (Resolve-Path -Path $PathOverride).Path
+    if ([string]::IsNullOrWhiteSpace($PathOverride)) {
+        throw "RepoRoot is required."
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE) -and (Test-Path -Path $env:GITHUB_WORKSPACE)) {
-        return (Resolve-Path -Path $env:GITHUB_WORKSPACE).Path
+    if (-not (Test-Path -Path $PathOverride)) {
+        throw "RepoRoot does not exist: $PathOverride"
     }
 
-    return $null
+    return (Resolve-Path -Path $PathOverride).Path
 }
 
 function Get-RepoRelativePath {

--- a/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
@@ -9,6 +9,7 @@ param(
     [ValidateSet('32', '64')]
     [string]$Arch,
 
+    [Parameter(Mandatory)]
     [string]$RepoRoot,
 
     [string]$CsvFileName = 'Icon_Editor_Files_In_LV_Installation_Diagnostics.csv',
@@ -29,23 +30,15 @@ function Resolve-RepoRoot {
         [string]$PathOverride
     )
 
-    if (-not [string]::IsNullOrWhiteSpace($PathOverride)) {
-        if (-not (Test-Path -Path $PathOverride)) {
-            throw "RepoRoot does not exist: $PathOverride"
-        }
-        return (Resolve-Path -Path $PathOverride).Path
+    if ([string]::IsNullOrWhiteSpace($PathOverride)) {
+        throw "RepoRoot is required."
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE) -and (Test-Path -Path $env:GITHUB_WORKSPACE)) {
-        return (Resolve-Path -Path $env:GITHUB_WORKSPACE).Path
+    if (-not (Test-Path -Path $PathOverride)) {
+        throw "RepoRoot does not exist: $PathOverride"
     }
 
-    $fallback = Join-Path $PSScriptRoot '..\..\..'
-    if (-not (Test-Path -Path $fallback)) {
-        throw "Unable to resolve repository root. Provide -RepoRoot."
-    }
-
-    return (Resolve-Path -Path $fallback).Path
+    return (Resolve-Path -Path $PathOverride).Path
 }
 
 function Resolve-CsvPath {

--- a/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
@@ -15,6 +15,7 @@ param(
     [ValidateSet('2021')]
     [string]$LabVIEWVersion = '2021',
 
+    [Parameter(Mandatory)]
     [string]$RepoRoot
 )
 
@@ -27,23 +28,15 @@ function Resolve-RepoRoot {
         [string]$PathOverride
     )
 
-    if (-not [string]::IsNullOrWhiteSpace($PathOverride)) {
-        if (-not (Test-Path -Path $PathOverride)) {
-            throw "RepoRoot does not exist: $PathOverride"
-        }
-        return (Resolve-Path -Path $PathOverride).Path
+    if ([string]::IsNullOrWhiteSpace($PathOverride)) {
+        throw "RepoRoot is required."
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE) -and (Test-Path -Path $env:GITHUB_WORKSPACE)) {
-        return (Resolve-Path -Path $env:GITHUB_WORKSPACE).Path
+    if (-not (Test-Path -Path $PathOverride)) {
+        throw "RepoRoot does not exist: $PathOverride"
     }
 
-    $fallback = Split-Path -Parent $CsvPath
-    if ($fallback -and (Test-Path -Path $fallback)) {
-        return (Resolve-Path -Path $fallback).Path
-    }
-
-    throw "Unable to resolve repository root. Provide -RepoRoot."
+    return (Resolve-Path -Path $PathOverride).Path
 }
 
 function Import-IconEditorCsv {

--- a/.github/actions/icon-editor-files-in-lv-installation/action.yml
+++ b/.github/actions/icon-editor-files-in-lv-installation/action.yml
@@ -56,3 +56,5 @@ runs:
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.run_vi.outputs.csv-path }}
+
+

--- a/.github/actions/icon-editor-files-in-lv-installation/action.yml
+++ b/.github/actions/icon-editor-files-in-lv-installation/action.yml
@@ -9,8 +9,8 @@ inputs:
     description: "Bitness (32 or 64)."
     required: true
   repo-root:
-    description: "Repository root path. Defaults to GITHUB_WORKSPACE."
-    required: false
+    description: "Repository root path (absolute)."
+    required: true
   csv-name:
     description: "CSV file name created by the VI."
     required: false

--- a/.github/actions/locate-release-assets/action.yml
+++ b/.github/actions/locate-release-assets/action.yml
@@ -41,3 +41,5 @@ runs:
         "vip_name=$($vip.Name)"         | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
         "notes_path=$($notes.FullName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
         "notes_name=$($notes.Name)"     | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+
+

--- a/.github/actions/missing-in-project/README.md
+++ b/.github/actions/missing-in-project/README.md
@@ -37,7 +37,8 @@ Results are returned as standard GitHub Action outputs so downstream jobs can d
 |------|----------|---------|-------------|
 | `lv-ver` | **Yes** | `2021` | LabVIEW *major* version number that should be used to run `MissingInProjectCLI.vi` |
 | `arch` | **Yes** | `32` or `64` | Bitness of the LabVIEW runtime to launch |
-| `project-file` | No | `source/MyPlugin.lvproj` | Path (absolute or relative to repository root) of the project to inspect. Defaults to **`lv_icon.lvproj`** |
+| `repo-root` | **Yes** | `${{ github.workspace }}` | Absolute path to the repository root. Relative paths are resolved against this. |
+| `project-file` | No | `source/MyPlugin.lvproj` | Path (absolute or relative to `repo-root`) of the project to inspect. Defaults to **`lv_icon_editor.lvproj`** |
 
 ---
 
@@ -65,6 +66,7 @@ jobs:
         with:
           lv-ver: 2021
           arch: 64
+          repo-root: ${{ github.workspace }}
 
       - name: Print report
         if: ${{ steps.mip.outputs.passed == 'false' }}
@@ -119,7 +121,7 @@ jobs:
 | Symptom | Hint |
 |---------|------|
 | *“g‑cli executable not found”* | Verify g‑cli is installed and on `PATH` |
-| *“Project file not found”* | Double‑check the value of `project-file`; relative paths are resolved against `GITHUB_WORKSPACE` |
+| *“Project file not found”* | Double‑check the value of `project-file`; relative paths are resolved against `repo-root` |
 | *Step times out* | Large projects can be slow to load; consider bumping the job’s default timeout. |
 
 ---

--- a/.github/actions/missing-in-project/action.yml
+++ b/.github/actions/missing-in-project/action.yml
@@ -70,3 +70,5 @@ runs:
           -LVVersion   "${{ inputs.lv-ver }}" `
           -Arch        "${{ inputs.arch }}" `
           -ProjectFile "${{ steps.resolve.outputs.projFile }}"
+
+

--- a/.github/actions/missing-in-project/action.yml
+++ b/.github/actions/missing-in-project/action.yml
@@ -17,12 +17,15 @@ inputs:
   arch:
     description: "Bitness (32 or 64)."
     required: true
+  repo-root:
+    description: "Repository root path (absolute)."
+    required: true
   project-file:
     description: >
       Path to the .lvproj to inspect.
-      Defaults to `lv_icon.lvproj` in the repository root.
+      Defaults to `lv_icon_editor.lvproj` in the repository root.
     required: false
-    default: lv_icon.lvproj
+    default: lv_icon_editor.lvproj
 
 outputs:
   passed:
@@ -40,9 +43,18 @@ runs:
       id: resolve
       shell: pwsh
       run: |
+        $repoRoot = '${{ inputs.repo-root }}'
+        if ([string]::IsNullOrWhiteSpace($repoRoot)) {
+          throw "repo-root is required."
+        }
+        if (-not (Test-Path $repoRoot)) {
+          throw "repo-root does not exist: $repoRoot"
+        }
+        $repoRoot = (Resolve-Path -Path $repoRoot).Path
+
         $pf = '${{ inputs.project-file }}'
         if (-not [System.IO.Path]::IsPathRooted($pf)) {
-          $pf = Join-Path $Env:GITHUB_WORKSPACE $pf
+          $pf = Join-Path $repoRoot $pf
         }
         if (-not (Test-Path $pf)) {
           throw "Project file not found: $pf"

--- a/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
+++ b/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
@@ -309,6 +309,28 @@ else {
     Set-VipbElementValue -ParentNode $advancedSettings -ElementName "License_Agreement_Filepath" -Value ''
 }
 
+# Ensure we don't accidentally ship local build artifacts (logs, diagnostics) in the VI package.
+# The VIPB already excludes many non-shipping folders, but TestResults is intentionally used by
+# CI/local tooling and should never be included in the built VIP.
+try {
+    $sourceFiles = $advancedSettings.SelectSingleNode('Source_Files')
+    if ($null -ne $sourceFiles) {
+        $existing = $sourceFiles.SelectNodes('Exclusions/Path') | Where-Object { $_.InnerText -eq 'TestResults' }
+        if (-not $existing -or $existing.Count -eq 0) {
+            $exclusion = $vipbXml.CreateElement('Exclusions')
+            $pathNode = $vipbXml.CreateElement('Path')
+            $pathNode.InnerText = 'TestResults'
+            [void]$exclusion.AppendChild($pathNode)
+            [void]$sourceFiles.AppendChild($exclusion)
+        }
+    } else {
+        Write-Warning "VIPB does not contain an Advanced_Settings/Source_Files section; cannot enforce TestResults exclusion."
+    }
+}
+catch {
+    Write-Warning ("Failed to enforce TestResults exclusion in VIPB. {0}" -f $_.Exception.Message)
+}
+
 # Warn about any DisplayInformation JSON keys we don't yet handle
 $recognizedKeys = @(
     'Company Name',

--- a/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
+++ b/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
@@ -273,11 +273,9 @@ Set-VipbElementValue -ParentNode $descriptionSettings -ElementName "Description"
 
 # Update optional license reference (resolve to an actual file path when possible)
 $licenseAgreementInput = $jsonObj.'License Agreement Name'
+$resolvedLicensePath = $null
 if (-not [string]::IsNullOrWhiteSpace($licenseAgreementInput)) {
     $candidatePath = $licenseAgreementInput
-    $relativePath  = $licenseAgreementInput
-    $resolvedLicensePath = $null
-
     if (-not [System.IO.Path]::IsPathRooted($candidatePath)) {
         $candidatePath = Join-Path -Path $ResolvedRepoRoot -ChildPath $licenseAgreementInput
     }
@@ -287,24 +285,28 @@ if (-not [string]::IsNullOrWhiteSpace($licenseAgreementInput)) {
             $resolvedLicensePath = (Resolve-Path -Path $candidatePath -ErrorAction Stop).Path
         }
         catch {
-            Write-Warning "Unable to resolve license file path '$candidatePath'. Using literal value instead."
+            Write-Warning "Unable to resolve license file path '$candidatePath'."
         }
     }
     else {
-        Write-Warning "License agreement path '$licenseAgreementInput' does not exist relative to the repository. Skipping license assignment."
+        Write-Warning "License agreement path '$licenseAgreementInput' does not exist relative to the repository."
     }
+}
 
-    if ($resolvedLicensePath) {
-        try {
-            $vipbDirectory = Split-Path -Parent $ResolvedVIPBPath
-            $relativePath = [System.IO.Path]::GetRelativePath($vipbDirectory, $resolvedLicensePath)
-        }
-        catch {
-            Write-Warning "Unable to compute a relative license path from '$ResolvedVIPBPath'. Using absolute path instead."
-            $relativePath = $resolvedLicensePath
-        }
-        Set-VipbElementValue -ParentNode $advancedSettings -ElementName "License_Agreement_Filepath" -Value $relativePath
+if ($resolvedLicensePath) {
+    $relativePath = $resolvedLicensePath
+    try {
+        $vipbDirectory = Split-Path -Parent $ResolvedVIPBPath
+        $relativePath = [System.IO.Path]::GetRelativePath($vipbDirectory, $resolvedLicensePath)
     }
+    catch {
+        Write-Warning "Unable to compute a relative license path from '$ResolvedVIPBPath'. Using absolute path instead."
+    }
+    Set-VipbElementValue -ParentNode $advancedSettings -ElementName "License_Agreement_Filepath" -Value $relativePath
+}
+else {
+    # Ensure VIP builds don't depend on any local license file by default.
+    Set-VipbElementValue -ParentNode $advancedSettings -ElementName "License_Agreement_Filepath" -Value ''
 }
 
 # Warn about any DisplayInformation JSON keys we don't yet handle

--- a/.github/actions/modify-vipb-display-info/README.md
+++ b/.github/actions/modify-vipb-display-info/README.md
@@ -8,7 +8,8 @@ Execute **`ModifyVIPBDisplayInfo.ps1`** to merge metadata into a `.vipb` file be
 | `supported_bitness` | **Yes** | `64` | Target LabVIEW bitness. |
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root path. |
 | `vipb_path` | **Yes** | `Tooling/deployment/NI Icon editor.vipb` | Path to the VIPB file. |
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `labview_minor_revision` | No (defaults to `0`) | `0` | LabVIEW minor revision. |
 | `major` | **Yes** | `1` | Major version component. |
 | `minor` | **Yes** | `0` | Minor version component. |
@@ -25,7 +26,7 @@ Execute **`ModifyVIPBDisplayInfo.ps1`** to merge metadata into a `.vipb` file be
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
     vipb_path: Tooling/deployment/NI Icon editor.vipb
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     major: 1
     minor: 0
     patch: 0

--- a/.github/actions/modify-vipb-display-info/README.md
+++ b/.github/actions/modify-vipb-display-info/README.md
@@ -9,7 +9,6 @@ Execute **`ModifyVIPBDisplayInfo.ps1`** to merge metadata into a `.vipb` file be
 | `repo_root` | **Yes** | `${{ github.workspace }}` | Repository root path. |
 | `vipb_path` | **Yes** | `Tooling/deployment/NI Icon editor.vipb` | Path to the VIPB file. |
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `labview_minor_revision` | No (defaults to `0`) | `0` | LabVIEW minor revision. |
 | `major` | **Yes** | `1` | Major version component. |
 | `minor` | **Yes** | `0` | Minor version component. |

--- a/.github/actions/modify-vipb-display-info/action.yml
+++ b/.github/actions/modify-vipb-display-info/action.yml
@@ -15,12 +15,19 @@ runs:
         DISPLAY_INFORMATION_JSON: |
           ${{ inputs.display_information_json }}
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
         $displayInformationJson = $Env:DISPLAY_INFORMATION_JSON
         & "${{ github.action_path }}/ModifyVIPBDisplayInfo.ps1" `
           -SupportedBitness ${{ inputs.supported_bitness }} `
           -RepoRoot "${{ inputs.repo_root }}" `
           -VIPBPath "${{ inputs.vipb_path }}" `
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -MinimumSupportedLVVersion $lvVersion `
           -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} `
           -Major ${{ inputs.major }} `
           -Minor ${{ inputs.minor }} `
@@ -30,6 +37,9 @@ runs:
           -ReleaseNotesFile "${{ inputs.release_notes_file }}" `
           -DisplayInformationJSON $displayInformationJson
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true
@@ -40,8 +50,8 @@ inputs:
     description: 'Path to the VIPB file (relative to workspace)'
     required: true
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   labview_minor_revision:
     description: 'LabVIEW minor revision (0 for 21.0)'
     required: false

--- a/.github/actions/modify-vipb-display-info/action.yml
+++ b/.github/actions/modify-vipb-display-info/action.yml
@@ -17,9 +17,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
         $displayInformationJson = $Env:DISPLAY_INFORMATION_JSON
@@ -39,7 +36,7 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
@@ -49,9 +46,6 @@ inputs:
   vipb_path:
     description: 'Path to the VIPB file (relative to workspace)'
     required: true
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
   labview_minor_revision:
     description: 'LabVIEW minor revision (0 for 21.0)'
     required: false
@@ -77,3 +71,5 @@ inputs:
   display_information_json:
     description: 'DisplayInformation JSON string'
     required: true
+
+

--- a/.github/actions/prepare-labview-source/README.md
+++ b/.github/actions/prepare-labview-source/README.md
@@ -5,7 +5,8 @@ Runs **`Prepare_LabVIEW_source.ps1`** to unpack and configure project sources be
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 
@@ -13,7 +14,7 @@ Runs **`Prepare_LabVIEW_source.ps1`** to unpack and configure project sources be
 ```yaml
 - uses: ./.github/actions/prepare-labview-source
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
 ```

--- a/.github/actions/prepare-labview-source/README.md
+++ b/.github/actions/prepare-labview-source/README.md
@@ -6,7 +6,6 @@ Runs **`Prepare_LabVIEW_source.ps1`** to unpack and configure project sources be
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 

--- a/.github/actions/prepare-labview-source/action.yml
+++ b/.github/actions/prepare-labview-source/action.yml
@@ -11,14 +11,25 @@ runs:
     - name: Run Prepare_LabVIEW_source.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         & "${{ github.action_path }}/Prepare_LabVIEW_source.ps1" \
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
+          -MinimumSupportedLVVersion $lvVersion \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RepoRoot "${{ inputs.repo_root }}"
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true

--- a/.github/actions/prepare-labview-source/action.yml
+++ b/.github/actions/prepare-labview-source/action.yml
@@ -13,9 +13,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -26,13 +23,12 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
   repo_root:
     description: 'Workspace root path'
     required: false
+
+

--- a/.github/actions/rename-file/action.yml
+++ b/.github/actions/rename-file/action.yml
@@ -22,3 +22,5 @@ inputs:
   new_filename:
     description: 'New file name or path'
     required: true
+
+

--- a/.github/actions/restore-setup-lv-source/README.md
+++ b/.github/actions/restore-setup-lv-source/README.md
@@ -6,7 +6,6 @@ Run **`RestoreSetupLVSource.ps1`** to restore packaged LabVIEW sources and remov
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 

--- a/.github/actions/restore-setup-lv-source/README.md
+++ b/.github/actions/restore-setup-lv-source/README.md
@@ -5,7 +5,8 @@ Run **`RestoreSetupLVSource.ps1`** to restore packaged LabVIEW sources and remov
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 
@@ -13,7 +14,7 @@ Run **`RestoreSetupLVSource.ps1`** to restore packaged LabVIEW sources and remov
 ```yaml
 - uses: ./.github/actions/restore-setup-lv-source
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
 ```

--- a/.github/actions/restore-setup-lv-source/action.yml
+++ b/.github/actions/restore-setup-lv-source/action.yml
@@ -11,14 +11,25 @@ runs:
     - name: Run RestoreSetupLVSource.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         & "${{ github.action_path }}/RestoreSetupLVSource.ps1" \
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
+          -MinimumSupportedLVVersion $lvVersion \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RepoRoot "${{ inputs.repo_root }}"
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true

--- a/.github/actions/restore-setup-lv-source/action.yml
+++ b/.github/actions/restore-setup-lv-source/action.yml
@@ -13,9 +13,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -26,13 +23,12 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
   repo_root:
     description: 'Workspace root path'
     required: false
+
+

--- a/.github/actions/revert-development-mode/README.md
+++ b/.github/actions/revert-development-mode/README.md
@@ -7,7 +7,7 @@ Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after develop
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
 | `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
-| `supported_bitness` | No | `64` | LabVIEW bitness (32 or 64). Omit to run both. |
+| `supported_bitness` | **Yes** | `64` | LabVIEW bitness (32 or 64). |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 
 ## Quick-start

--- a/.github/actions/revert-development-mode/README.md
+++ b/.github/actions/revert-development-mode/README.md
@@ -5,7 +5,8 @@ Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after develop
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | No | `2021` | LabVIEW 2021 (21.0) only. |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | No | `64` | LabVIEW bitness (32 or 64). Omit to run both. |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 
@@ -13,7 +14,7 @@ Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after develop
 ```yaml
 - uses: ./.github/actions/revert-development-mode
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
 ```

--- a/.github/actions/revert-development-mode/README.md
+++ b/.github/actions/revert-development-mode/README.md
@@ -6,7 +6,6 @@ Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after develop
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `64` | LabVIEW bitness (32 or 64). |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 

--- a/.github/actions/revert-development-mode/action.yml
+++ b/.github/actions/revert-development-mode/action.yml
@@ -13,9 +13,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -33,14 +30,12 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
-    default: '2021'
+    required: true
   supported_bitness:
     description: 'LabVIEW bitness (32 or 64).'
     required: true
   repo_root:
     description: 'Workspace root path'
     required: false
+
+

--- a/.github/actions/revert-development-mode/action.yml
+++ b/.github/actions/revert-development-mode/action.yml
@@ -27,9 +27,7 @@ runs:
           $scriptArgs.RepoRoot = "${{ inputs.repo_root }}"
         }
 
-        if ("${{ inputs.supported_bitness }}" -ne "") {
-          $scriptArgs.SupportedBitness = "${{ inputs.supported_bitness }}"
-        }
+        $scriptArgs.SupportedBitness = "${{ inputs.supported_bitness }}"
 
         & "${{ github.action_path }}/RevertDevelopmentMode.ps1" @scriptArgs
 inputs:
@@ -41,8 +39,8 @@ inputs:
     required: false
     default: '2021'
   supported_bitness:
-    description: 'LabVIEW bitness (32 or 64). Defaults to both when omitted.'
-    required: false
+    description: 'LabVIEW bitness (32 or 64).'
+    required: true
   repo_root:
     description: 'Workspace root path'
     required: false

--- a/.github/actions/revert-development-mode/action.yml
+++ b/.github/actions/revert-development-mode/action.yml
@@ -11,8 +11,16 @@ runs:
     - name: Run RevertDevelopmentMode.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         $scriptArgs = @{
-          MinimumSupportedLVVersion = "${{ inputs.minimum_supported_lv_version }}"
+          MinimumSupportedLVVersion = $lvVersion
         }
 
         if ("${{ inputs.repo_root }}" -ne "") {
@@ -25,8 +33,11 @@ runs:
 
         & "${{ github.action_path }}/RevertDevelopmentMode.ps1" @scriptArgs
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0) only'
+    description: 'Deprecated. Use labview_version.'
     required: false
     default: '2021'
   supported_bitness:

--- a/.github/actions/run-unit-tests/README.md
+++ b/.github/actions/run-unit-tests/README.md
@@ -7,7 +7,7 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
 |------|----------|---------|-------------|
 | `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
-| `project_path` | **Yes** | `${{ github.workspace }}/lv_icon_editor.lvproj` | Path to the LabVIEW project. |
+| `project_path` | **Yes** | `${{ env.REPO_ROOT }}/lv_icon_editor.lvproj` | Absolute path to the LabVIEW project. |
 
 ## Quick-start
 ```yaml
@@ -15,7 +15,7 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
   with:
     minimum_supported_lv_version: 2021
     supported_bitness: 64
-    project_path: ${{ github.workspace }}/lv_icon_editor.lvproj
+    project_path: ${{ env.REPO_ROOT }}/lv_icon_editor.lvproj
 ```
 
 ## License

--- a/.github/actions/run-unit-tests/README.md
+++ b/.github/actions/run-unit-tests/README.md
@@ -5,7 +5,8 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `project_path` | **Yes** | `${{ env.REPO_ROOT }}/lv_icon_editor.lvproj` | Absolute path to the LabVIEW project. |
 
@@ -13,7 +14,7 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
 ```yaml
 - uses: ./.github/actions/run-unit-tests
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     supported_bitness: 64
     project_path: ${{ env.REPO_ROOT }}/lv_icon_editor.lvproj
 ```

--- a/.github/actions/run-unit-tests/README.md
+++ b/.github/actions/run-unit-tests/README.md
@@ -6,7 +6,6 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0). |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `project_path` | **Yes** | `${{ env.REPO_ROOT }}/lv_icon_editor.lvproj` | Absolute path to the LabVIEW project. |
 

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -13,9 +13,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -26,13 +23,12 @@ runs:
 inputs:
   labview_version:
     description: 'LabVIEW version to run (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
+    required: true
   supported_bitness:
     description: '32 or 64'
     required: true
   project_path:
     description: 'Path to the LabVIEW project (.lvproj)'
     required: true
+
+

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -11,14 +11,25 @@ runs:
     - name: Run RunUnitTests.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         & "${{ github.action_path }}/RunUnitTests.ps1" `
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -MinimumSupportedLVVersion $lvVersion `
           -SupportedBitness ${{ inputs.supported_bitness }} `
           -ProjectPath "${{ inputs.project_path }}"
 inputs:
+  labview_version:
+    description: 'LabVIEW version to run (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0)'
-    required: true
+    description: 'Deprecated. Use labview_version.'
+    required: false
   supported_bitness:
     description: '32 or 64'
     required: true

--- a/.github/actions/set-development-mode/README.md
+++ b/.github/actions/set-development-mode/README.md
@@ -6,7 +6,6 @@ Execute **`Set_Development_Mode.ps1`** to prepare the repository for active deve
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
-| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | **Yes** | `64` | LabVIEW bitness (32 or 64). |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 

--- a/.github/actions/set-development-mode/README.md
+++ b/.github/actions/set-development-mode/README.md
@@ -5,7 +5,8 @@ Execute **`Set_Development_Mode.ps1`** to prepare the repository for active deve
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `minimum_supported_lv_version` | No | `2021` | LabVIEW 2021 (21.0) only. |
+| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
+| `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
 | `supported_bitness` | No | `64` | LabVIEW bitness (32 or 64). Omit to run both. |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 
@@ -13,7 +14,7 @@ Execute **`Set_Development_Mode.ps1`** to prepare the repository for active deve
 ```yaml
 - uses: ./.github/actions/set-development-mode
   with:
-    minimum_supported_lv_version: 2021
+    labview_version: 2021
     supported_bitness: 64
     repo_root: ${{ github.workspace }}
 ```

--- a/.github/actions/set-development-mode/README.md
+++ b/.github/actions/set-development-mode/README.md
@@ -7,7 +7,7 @@ Execute **`Set_Development_Mode.ps1`** to prepare the repository for active deve
 |------|----------|---------|-------------|
 | `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
 | `minimum_supported_lv_version` | No | `2021` | Deprecated. Use `labview_version`. |
-| `supported_bitness` | No | `64` | LabVIEW bitness (32 or 64). Omit to run both. |
+| `supported_bitness` | **Yes** | `64` | LabVIEW bitness (32 or 64). |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 
 ## Quick-start

--- a/.github/actions/set-development-mode/action.yml
+++ b/.github/actions/set-development-mode/action.yml
@@ -3,11 +3,7 @@ description: "Runs Set_Development_Mode.ps1 to configure the repo for developmen
 inputs:
   labview_version:
     description: 'LabVIEW version to target (2021/21.0 only).'
-    required: false
-  minimum_supported_lv_version:
-    description: 'Deprecated. Use labview_version.'
-    required: false
-    default: '2021'
+    required: true
   supported_bitness:
     description: 'LabVIEW bitness (32 or 64).'
     required: true
@@ -27,9 +23,6 @@ runs:
       run: |
         $lvVersion = "${{ inputs.labview_version }}"
         if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
-        }
-        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
           throw "labview_version is required."
         }
 
@@ -44,3 +37,5 @@ runs:
         $scriptArgs.SupportedBitness = "${{ inputs.supported_bitness }}"
 
         & "${{ github.action_path }}/Set_Development_Mode.ps1" @scriptArgs
+
+

--- a/.github/actions/set-development-mode/action.yml
+++ b/.github/actions/set-development-mode/action.yml
@@ -9,8 +9,8 @@ inputs:
     required: false
     default: '2021'
   supported_bitness:
-    description: 'LabVIEW bitness (32 or 64). Defaults to both when omitted.'
-    required: false
+    description: 'LabVIEW bitness (32 or 64).'
+    required: true
   repo_root:
     description: 'Workspace root path'
     required: false
@@ -41,8 +41,6 @@ runs:
           $scriptArgs.RepoRoot = "${{ inputs.repo_root }}"
         }
 
-        if ("${{ inputs.supported_bitness }}" -ne "") {
-          $scriptArgs.SupportedBitness = "${{ inputs.supported_bitness }}"
-        }
+        $scriptArgs.SupportedBitness = "${{ inputs.supported_bitness }}"
 
         & "${{ github.action_path }}/Set_Development_Mode.ps1" @scriptArgs

--- a/.github/actions/set-development-mode/action.yml
+++ b/.github/actions/set-development-mode/action.yml
@@ -1,8 +1,11 @@
 name: "Set Development Mode"
 description: "Runs Set_Development_Mode.ps1 to configure the repo for development."
 inputs:
+  labview_version:
+    description: 'LabVIEW version to target (2021/21.0 only).'
+    required: false
   minimum_supported_lv_version:
-    description: 'LabVIEW 2021 (21.0) only'
+    description: 'Deprecated. Use labview_version.'
     required: false
     default: '2021'
   supported_bitness:
@@ -22,8 +25,16 @@ runs:
     - name: Run Set_Development_Mode.ps1
       shell: pwsh
       run: |
+        $lvVersion = "${{ inputs.labview_version }}"
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          $lvVersion = "${{ inputs.minimum_supported_lv_version }}"
+        }
+        if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+          throw "labview_version is required."
+        }
+
         $scriptArgs = @{
-          MinimumSupportedLVVersion = "${{ inputs.minimum_supported_lv_version }}"
+          MinimumSupportedLVVersion = $lvVersion
         }
 
         if ("${{ inputs.repo_root }}" -ne "") {

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -17,3 +17,5 @@ inputs:
   repo_root:
     description: 'Workspace root path'
     required: true
+
+

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -44,33 +44,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-${{ matrix.bitness }}-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          $projectPath = Join-Path $worktree 'lv_icon_editor.lvproj'
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          "PROJECT_PATH=$projectPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness ${{ matrix.bitness }}
       - name: Initialize VerifyIEPaths archive folder
         shell: pwsh
         run: |
@@ -127,31 +105,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-64-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 64
       - name: Apply VIPC (2021 x64)
         if: needs.changes.outputs.vipc == 'true'
         shell: pwsh
@@ -183,31 +141,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-32-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 32
       - name: Apply VIPC (2021 x86)
         if: needs.changes.outputs.vipc == 'true'
         shell: pwsh
@@ -269,33 +207,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-${{ matrix.bitness }}-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          $projectPath = Join-Path $worktree 'lv_icon_editor.lvproj'
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          "PROJECT_PATH=$projectPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness ${{ matrix.bitness }}
       - name: Enable Development Mode (2021 ${{ matrix.bitness }}-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
@@ -353,31 +269,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-32-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 32
       - name: Enable Development Mode (2021 32-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
@@ -444,31 +340,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-64-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 64
       - name: Enable Development Mode (2021 64-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
@@ -535,33 +411,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-64-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          $projectPath = Join-Path $worktree 'lv_icon_editor.lvproj'
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          "PROJECT_PATH=$projectPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 64
       - name: Generate release notes
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   dev-mode-gate:
-    name: Verify IE Paths Gate (2021 ${{ matrix.bitness }}-bit)
+    name: Verify IE Paths Gate (LV ${{ matrix.bitness }}-bit)
     runs-on: self-hosted-windows-lv
     strategy:
       fail-fast: false
@@ -53,11 +53,11 @@ jobs:
         shell: pwsh
         run: |
           New-Item -Path "$env:RUNNER_TEMP\\verify-iepaths" -ItemType Directory -Force | Out-Null
-      - name: Verify IE Paths (2021 ${{ matrix.bitness }}-bit)
+      - name: Verify IE Paths (LV ${{ matrix.bitness }}-bit)
         shell: pwsh
         run: |
           pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:REPO_ROOT\\Tooling\\Invoke-MissingIEFilesFromLVInstall.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }} `
             -RepoRoot $env:REPO_ROOT `
             -ConnectTimeoutMs 180000 `
@@ -97,7 +97,7 @@ jobs:
               - '**/*.vipc'
 
   apply-deps-2021-x64:
-    name: Apply VIPC (2021 x64)
+    name: Apply VIPC (LV x64)
     needs: changes
     runs-on: self-hosted-windows-lv
     steps:
@@ -110,14 +110,14 @@ jobs:
         shell: pwsh
         run: |
           & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 64
-      - name: Apply VIPC (2021 x64)
+      - name: Apply VIPC (LV x64)
         if: needs.changes.outputs.vipc == 'true'
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github\\actions\\apply-vipc\\ApplyVIPC.ps1" `
-            -MinimumSupportedLVVersion 2021 `
-            -VIP_LVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
+            -VIP_LVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 64 `
             -RepoRoot "$env:REPO_ROOT" `
             -VIPCPath ".github/actions/apply-vipc/runner_dependencies.vipc"
@@ -133,7 +133,7 @@ jobs:
           }
 
   apply-deps-2021-x86:
-    name: Apply VIPC (2021 x86)
+    name: Apply VIPC (LV x86)
     needs: [apply-deps-2021-x64, changes]
     runs-on: self-hosted-windows-lv
     steps:
@@ -146,14 +146,14 @@ jobs:
         shell: pwsh
         run: |
           & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 32
-      - name: Apply VIPC (2021 x86)
+      - name: Apply VIPC (LV x86)
         if: needs.changes.outputs.vipc == 'true'
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github\\actions\\apply-vipc\\ApplyVIPC.ps1" `
-            -MinimumSupportedLVVersion 2021 `
-            -VIP_LVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
+            -VIP_LVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 32 `
             -RepoRoot "$env:REPO_ROOT" `
             -VIPCPath ".github/actions/apply-vipc/runner_dependencies.vipc"
@@ -189,12 +189,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   missing-in-project:
-    name: Test Missing-In-Project (2021)
+    name: Test Missing-In-Project (LV)
     needs: apply-deps-2021-x86
     uses: ./.github/workflows/test-missing-in-project-windows.yml
 
   test-2021:
-    name: Run Unit Tests (2021 ${{ matrix.bitness }}-bit)
+    name: Run Unit Tests (LV ${{ matrix.bitness }}-bit)
     needs: missing-in-project
     runs-on: self-hosted-windows-lv
     strategy:
@@ -212,23 +212,23 @@ jobs:
         shell: pwsh
         run: |
           & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness ${{ matrix.bitness }}
-      - name: Enable Development Mode (2021 ${{ matrix.bitness }}-bit)
+      - name: Enable Development Mode (LV ${{ matrix.bitness }}-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/set-development-mode/Set_Development_Mode.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }} `
             -RepoRoot "$env:REPO_ROOT"
-      - name: Run Unit Tests (2021 ${{ matrix.bitness }}-bit)
+      - name: Run Unit Tests (LV ${{ matrix.bitness }}-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/run-unit-tests/RunUnitTests.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }} `
             -ProjectPath "$env:PROJECT_PATH"
-      - name: Upload unit test report (2021 ${{ matrix.bitness }}-bit)
+      - name: Upload unit test report (LV ${{ matrix.bitness }}-bit)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -236,20 +236,20 @@ jobs:
           path: ${{ env.REPO_ROOT }}/.github/actions/run-unit-tests/UnitTestReport.xml
           if-no-files-found: warn
       - if: always()
-        name: Revert Development Mode (2021 ${{ matrix.bitness }}-bit)
+        name: Revert Development Mode (LV ${{ matrix.bitness }}-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/revert-development-mode/RevertDevelopmentMode.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }} `
             -RepoRoot "$env:REPO_ROOT"
       - if: always()
-        name: Close LabVIEW 2021 ${{ matrix.bitness }}-bit after unit tests
+        name: Close LabVIEW ${{ matrix.bitness }}-bit after unit tests
         shell: pwsh
         run: |
           & "$env:REPO_ROOT\\.github\\actions\\close-labview\\Close_LabVIEW.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }}
       - name: Cleanup worktree
         if: always()
@@ -274,20 +274,20 @@ jobs:
         shell: pwsh
         run: |
           & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 32
-      - name: Enable Development Mode (2021 32-bit)
+      - name: Enable Development Mode (LV 32-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/set-development-mode/Set_Development_Mode.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 32 `
             -RepoRoot "$env:REPO_ROOT"
-      - name: Build PPL (2021 32-bit)
+      - name: Build PPL (LV 32-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/build-lvlibp/Build_lvlibp.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 32 `
             -RepoRoot "$env:REPO_ROOT" `
             -Major ${{ needs.version.outputs.MAJOR }} `
@@ -295,7 +295,7 @@ jobs:
             -Patch ${{ needs.version.outputs.PATCH }} `
             -Build ${{ needs.version.outputs.BUILD }} `
             -Commit "${{ github.sha }}"
-      - name: Rename PPL (2021 32-bit)
+      - name: Rename PPL (LV 32-bit)
         shell: pwsh
         run: |
           & "$env:REPO_ROOT\\.github\\actions\\rename-file\\Rename-file.ps1" `
@@ -306,21 +306,21 @@ jobs:
         with:
           name: lv_icon_x86.lvlibp
           path: ${{ env.REPO_ROOT }}/resource/plugins/lv_icon_x86.lvlibp
-      - name: Revert Development Mode (2021 32-bit)
+      - name: Revert Development Mode (LV 32-bit)
         if: always()
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/revert-development-mode/RevertDevelopmentMode.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 32 `
             -RepoRoot "$env:REPO_ROOT"
-      - name: Close LabVIEW (2021 32-bit)
+      - name: Close LabVIEW (LV 32-bit)
         if: always()
         shell: pwsh
         run: |
           & "$env:REPO_ROOT\\.github\\actions\\close-labview\\Close_LabVIEW.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 32
       - name: Cleanup worktree
         if: always()
@@ -345,20 +345,20 @@ jobs:
         shell: pwsh
         run: |
           & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" -Bitness 64
-      - name: Enable Development Mode (2021 64-bit)
+      - name: Enable Development Mode (LV 64-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/set-development-mode/Set_Development_Mode.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 64 `
             -RepoRoot "$env:REPO_ROOT"
-      - name: Build PPL (2021 64-bit)
+      - name: Build PPL (LV 64-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/build-lvlibp/Build_lvlibp.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 64 `
             -RepoRoot "$env:REPO_ROOT" `
             -Major ${{ needs.version.outputs.MAJOR }} `
@@ -366,7 +366,7 @@ jobs:
             -Patch ${{ needs.version.outputs.PATCH }} `
             -Build ${{ needs.version.outputs.BUILD }} `
             -Commit "${{ github.sha }}"
-      - name: Rename PPL (2021 64-bit)
+      - name: Rename PPL (LV 64-bit)
         shell: pwsh
         run: |
           & "$env:REPO_ROOT\\.github\\actions\\rename-file\\Rename-file.ps1" `
@@ -377,21 +377,21 @@ jobs:
         with:
           name: lv_icon_x64.lvlibp
           path: ${{ env.REPO_ROOT }}/resource/plugins/lv_icon_x64.lvlibp
-      - name: Revert Development Mode (2021 64-bit)
+      - name: Revert Development Mode (LV 64-bit)
         if: always()
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github/actions/revert-development-mode/RevertDevelopmentMode.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 64 `
             -RepoRoot "$env:REPO_ROOT"
-      - name: Close LabVIEW (2021 64-bit)
+      - name: Close LabVIEW (LV 64-bit)
         if: always()
         shell: pwsh
         run: |
           & "$env:REPO_ROOT\\.github\\actions\\close-labview\\Close_LabVIEW.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 64
       - name: Cleanup worktree
         if: always()
@@ -482,7 +482,7 @@ jobs:
 
           $json = $info | ConvertTo-Json -Depth 5 -Compress
           "json=$json" >> $Env:GITHUB_OUTPUT
-      - name: Modify VIPB display info (LV2021 64-bit)
+      - name: Modify VIPB display info (LV 64-bit)
         shell: pwsh
         env:
           DISPLAY_INFORMATION_JSON: |
@@ -493,8 +493,8 @@ jobs:
             -SupportedBitness 64 `
             -RepoRoot "$env:REPO_ROOT" `
             -VIPBPath "Tooling/deployment/NI Icon editor.vipb" `
-            -MinimumSupportedLVVersion 2021 `
-            -LabVIEWMinorRevision 0 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
+            -LabVIEWMinorRevision $env:LABVIEW_MINOR_REVISION `
             -Major ${{ needs.version.outputs.MAJOR }} `
             -Minor ${{ needs.version.outputs.MINOR }} `
             -Patch ${{ needs.version.outputs.PATCH }} `
@@ -502,7 +502,7 @@ jobs:
             -Commit "${{ github.sha }}" `
             -ReleaseNotesFile "$env:REPO_ROOT\\Tooling\\deployment\\release_notes.md" `
             -DisplayInformationJSON $displayInformationJson
-      - name: Build VI Package (LV2021 64-bit)
+      - name: Build VI Package (LV 64-bit)
         shell: pwsh
         env:
           DISPLAY_INFORMATION_JSON: |
@@ -513,8 +513,8 @@ jobs:
             -SupportedBitness 64 `
             -RepoRoot "$env:REPO_ROOT" `
             -VIPBPath "Tooling/deployment/NI Icon editor.vipb" `
-            -MinimumSupportedLVVersion 2021 `
-            -LabVIEWMinorRevision 0 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
+            -LabVIEWMinorRevision $env:LABVIEW_MINOR_REVISION `
             -Major ${{ needs.version.outputs.MAJOR }} `
             -Minor ${{ needs.version.outputs.MINOR }} `
             -Patch ${{ needs.version.outputs.PATCH }} `
@@ -594,7 +594,7 @@ jobs:
         shell: pwsh
         run: |
           & "$env:REPO_ROOT\\.github\\actions\\close-labview\\Close_LabVIEW.ps1" `
-            -MinimumSupportedLVVersion 2021 `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness 64
       - name: Validate tag matches computed version (if provided)
         if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.dispatch_tag != ''
@@ -623,6 +623,7 @@ jobs:
             git -C "$env:GITHUB_WORKSPACE" worktree remove --force "$env:REPO_ROOT" 2>$null
             git -C "$env:GITHUB_WORKSPACE" worktree prune
           }
+
 
 
 

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1,8 +1,8 @@
 name: CI Pipeline (Composite)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
 
 on:
   push:

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -474,7 +474,6 @@ jobs:
               $Env:REPO_URL
             }
             "Legal Copyright" = "© $(Get-Date -Format yyyy) $($Env:COMPANY)"
-            "License Agreement Name" = "LICENSE"
             "Product Description Summary" = $description
             "Product Description" = $description
             "Release Notes - Change Log" = $releaseNotes
@@ -570,6 +569,12 @@ jobs:
           "vip_path=$($vip.FullName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
           "vip_name=$($vip.Name)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
           "vip_artifact=$([System.IO.Path]::GetFileNameWithoutExtension($vip.Name))" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+      - name: Inspect VI Package contents (zip paths)
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File "$env:REPO_ROOT\\Tooling\\Inspect-VipPackage.ps1" `
+            -VipPath "${{ steps.locate-vip.outputs.vip_path }}" `
+            -WriteSummary
       - name: Upload release notes
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1,7 +1,7 @@
 name: CI Pipeline (Composite)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -21,8 +21,7 @@ on:
       bitness:
         description: "LabVIEW bitness to target (32 or 64)."
         type: string
-        required: false
-        default: "64"
+        required: true
       sequence_id:
         description: "Optional sequence identifier for deterministic run tracking."
         type: string
@@ -56,7 +55,7 @@ on:
           - "2021"
       bitness:
         description: "LabVIEW bitness."
-        required: false
+        required: true
         default: "64"
         type: choice
         options:

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -135,9 +135,11 @@ jobs:
             SupportedBitness          = '64'
           }
 
-          if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-            $scriptArgs.RepoRoot = $env:GITHUB_WORKSPACE
+          if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+            throw "GITHUB_WORKSPACE is required to resolve RepoRoot."
           }
+
+          $scriptArgs.RepoRoot = $env:GITHUB_WORKSPACE
 
           if ($mode -eq 'enable') {
             & ./.github/actions/set-development-mode/Set_Development_Mode.ps1 @scriptArgs
@@ -170,9 +172,11 @@ jobs:
             SupportedBitness          = '32'
           }
 
-          if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-            $scriptArgs.RepoRoot = $env:GITHUB_WORKSPACE
+          if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+            throw "GITHUB_WORKSPACE is required to resolve RepoRoot."
           }
+
+          $scriptArgs.RepoRoot = $env:GITHUB_WORKSPACE
 
           if ($mode -eq 'enable') {
             & ./.github/actions/set-development-mode/Set_Development_Mode.ps1 @scriptArgs

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -9,8 +9,12 @@ on:
         type: string
         required: true
         default: "enable"
+      labview_version:
+        description: "LabVIEW version to target (2021/21.0 only)."
+        type: string
+        required: false
       minimum_supported_lv_version:
-        description: "LabVIEW major version (2021 only)."
+        description: "Deprecated. Use labview_version."
         type: string
         required: false
         default: "2021"
@@ -36,8 +40,15 @@ on:
         options:
           - enable
           - disable
+      labview_version:
+        description: "LabVIEW version."
+        required: false
+        default: "2021"
+        type: choice
+        options:
+          - "2021"
       minimum_supported_lv_version:
-        description: "LabVIEW major version."
+        description: "Deprecated. Use labview_version."
         required: false
         default: "2021"
         type: choice
@@ -62,12 +73,12 @@ run-name: ${{
     format('DevMode {0} {1}-bit LV{2} seq={3}', 
       github.event.inputs.mode == 'enable' && 'enable' || 'disable',
       github.event.inputs.bitness || '64',
-      github.event.inputs.minimum_supported_lv_version || '2021',
+      github.event.inputs.labview_version || github.event.inputs.minimum_supported_lv_version || '2021',
       github.event.inputs.sequence_id || 'none') || 
     format('DevMode {0} {1}-bit LV{2} seq={3}', 
       inputs.mode == 'enable' && 'enable' || 'disable',
       inputs.bitness || '64',
-      inputs.minimum_supported_lv_version || '2021',
+      inputs.labview_version || inputs.minimum_supported_lv_version || '2021',
       inputs.sequence_id || 'none') }}
 
 jobs:
@@ -84,11 +95,11 @@ jobs:
         format('{0} {1}-bit Dev Mode LV{2}', 
           github.event.inputs.mode == 'enable' && 'Enable' || 'Disable',
           github.event.inputs.bitness || '64',
-          github.event.inputs.minimum_supported_lv_version || '2021') || 
+          github.event.inputs.labview_version || github.event.inputs.minimum_supported_lv_version || '2021') || 
         format('{0} {1}-bit Dev Mode LV{2}', 
           inputs.mode == 'enable' && 'Enable' || 'Disable',
           inputs.bitness || '64',
-          inputs.minimum_supported_lv_version || '2021') }}
+          inputs.labview_version || inputs.minimum_supported_lv_version || '2021') }}
 
     runs-on: [self-hosted-windows-lv]
     env:
@@ -120,10 +131,16 @@ jobs:
         run: |
           if ("${{ github.event_name }}" -eq "workflow_dispatch") {
             $mode = '${{ github.event.inputs.mode }}'
-            $lvVersion = '${{ github.event.inputs.minimum_supported_lv_version }}'
+            $lvVersion = '${{ github.event.inputs.labview_version }}'
+            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+              $lvVersion = '${{ github.event.inputs.minimum_supported_lv_version }}'
+            }
           } else {
             $mode = '${{ inputs.mode }}'
-            $lvVersion = '${{ inputs.minimum_supported_lv_version }}'
+            $lvVersion = '${{ inputs.labview_version }}'
+            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+              $lvVersion = '${{ inputs.minimum_supported_lv_version }}'
+            }
           }
 
           if ([string]::IsNullOrWhiteSpace($lvVersion)) {
@@ -157,10 +174,16 @@ jobs:
         run: |
           if ("${{ github.event_name }}" -eq "workflow_dispatch") {
             $mode = '${{ github.event.inputs.mode }}'
-            $lvVersion = '${{ github.event.inputs.minimum_supported_lv_version }}'
+            $lvVersion = '${{ github.event.inputs.labview_version }}'
+            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+              $lvVersion = '${{ github.event.inputs.minimum_supported_lv_version }}'
+            }
           } else {
             $mode = '${{ inputs.mode }}'
-            $lvVersion = '${{ inputs.minimum_supported_lv_version }}'
+            $lvVersion = '${{ inputs.labview_version }}'
+            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
+              $lvVersion = '${{ inputs.minimum_supported_lv_version }}'
+            }
           }
 
           if ([string]::IsNullOrWhiteSpace($lvVersion)) {

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -12,12 +12,7 @@ on:
       labview_version:
         description: "LabVIEW version to target (2021/21.0 only)."
         type: string
-        required: false
-      minimum_supported_lv_version:
-        description: "Deprecated. Use labview_version."
-        type: string
-        required: false
-        default: "2021"
+        required: true
       bitness:
         description: "LabVIEW bitness to target (32 or 64)."
         type: string
@@ -41,14 +36,7 @@ on:
           - disable
       labview_version:
         description: "LabVIEW version."
-        required: false
-        default: "2021"
-        type: choice
-        options:
-          - "2021"
-      minimum_supported_lv_version:
-        description: "Deprecated. Use labview_version."
-        required: false
+        required: true
         default: "2021"
         type: choice
         options:
@@ -72,12 +60,12 @@ run-name: ${{
     format('DevMode {0} {1}-bit LV{2} seq={3}', 
       github.event.inputs.mode == 'enable' && 'enable' || 'disable',
       github.event.inputs.bitness || '64',
-      github.event.inputs.labview_version || github.event.inputs.minimum_supported_lv_version || '2021',
+      github.event.inputs.labview_version || '2021',
       github.event.inputs.sequence_id || 'none') || 
     format('DevMode {0} {1}-bit LV{2} seq={3}', 
       inputs.mode == 'enable' && 'enable' || 'disable',
       inputs.bitness || '64',
-      inputs.labview_version || inputs.minimum_supported_lv_version || '2021',
+      inputs.labview_version || '2021',
       inputs.sequence_id || 'none') }}
 
 jobs:
@@ -94,11 +82,11 @@ jobs:
         format('{0} {1}-bit Dev Mode LV{2}', 
           github.event.inputs.mode == 'enable' && 'Enable' || 'Disable',
           github.event.inputs.bitness || '64',
-          github.event.inputs.labview_version || github.event.inputs.minimum_supported_lv_version || '2021') || 
+          github.event.inputs.labview_version || '2021') || 
         format('{0} {1}-bit Dev Mode LV{2}', 
           inputs.mode == 'enable' && 'Enable' || 'Disable',
           inputs.bitness || '64',
-          inputs.labview_version || inputs.minimum_supported_lv_version || '2021') }}
+          inputs.labview_version || '2021') }}
 
     runs-on: [self-hosted-windows-lv]
     env:
@@ -131,15 +119,9 @@ jobs:
           if ("${{ github.event_name }}" -eq "workflow_dispatch") {
             $mode = '${{ github.event.inputs.mode }}'
             $lvVersion = '${{ github.event.inputs.labview_version }}'
-            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-              $lvVersion = '${{ github.event.inputs.minimum_supported_lv_version }}'
-            }
           } else {
             $mode = '${{ inputs.mode }}'
             $lvVersion = '${{ inputs.labview_version }}'
-            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-              $lvVersion = '${{ inputs.minimum_supported_lv_version }}'
-            }
           }
 
           if ([string]::IsNullOrWhiteSpace($lvVersion)) {
@@ -174,15 +156,9 @@ jobs:
           if ("${{ github.event_name }}" -eq "workflow_dispatch") {
             $mode = '${{ github.event.inputs.mode }}'
             $lvVersion = '${{ github.event.inputs.labview_version }}'
-            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-              $lvVersion = '${{ github.event.inputs.minimum_supported_lv_version }}'
-            }
           } else {
             $mode = '${{ inputs.mode }}'
             $lvVersion = '${{ inputs.labview_version }}'
-            if ([string]::IsNullOrWhiteSpace($lvVersion)) {
-              $lvVersion = '${{ inputs.minimum_supported_lv_version }}'
-            }
           }
 
           if ([string]::IsNullOrWhiteSpace($lvVersion)) {

--- a/.github/workflows/test-missing-in-project-windows.yml
+++ b/.github/workflows/test-missing-in-project-windows.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        lv-version: ["2021"]
         bitness:    ["32","64"]
 
     steps:
@@ -25,15 +24,14 @@ jobs:
         shell: pwsh
         run: |
           & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" `
-            -Bitness ${{ matrix.bitness }} `
-            -Variant "${{ matrix.lv-version }}"
+            -Bitness ${{ matrix.bitness }}
 
-      - name: Enable Development Mode (LV${{ matrix.lv-version }} ${{ matrix.bitness }}-bit)
+      - name: Enable Development Mode (LV ${{ matrix.bitness }}-bit)
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github\\actions\\set-development-mode\\Set_Development_Mode.ps1" `
-            -MinimumSupportedLVVersion ${{ matrix.lv-version }} `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }} `
             -RepoRoot "$env:REPO_ROOT"
 
@@ -50,13 +48,13 @@ jobs:
           Write-Host "Using project file: $env:PROJECT_PATH"
           "project_file=$env:PROJECT_PATH" >> $env:GITHUB_OUTPUT
 
-      - name: Missing‑In‑Project (LV${{ matrix.lv-version }} ${{ matrix.bitness }}-bit)
+      - name: Missing‑In‑Project (LV ${{ matrix.bitness }}-bit)
         id: mip
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github\\actions\\missing-in-project\\Invoke-MissingInProjectCLI.ps1" `
-            -LVVersion   "${{ matrix.lv-version }}" `
+            -LVVersion   "$env:LABVIEW_VERSION_YEAR" `
             -Arch        "${{ matrix.bitness }}" `
             -ProjectFile "${{ steps.proj.outputs.project_file }}"
 
@@ -78,11 +76,11 @@ jobs:
           echo "ℹ️  Using project file: $env:PROJ_FILE" >> $GITHUB_STEP_SUMMARY
 
           if ("${{ steps.mip.outputs.passed }}" -eq "true") {
-            echo "✅ Nothing missing for ${{ matrix.lv-version }}‑${{ matrix.bitness }}" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Nothing missing for $env:LABVIEW_VERSION_YEAR‑${{ matrix.bitness }}" >> $GITHUB_STEP_SUMMARY
             exit 0
           }
 
-          echo "### ❌ Missing files for ${{ matrix.lv-version }}‑${{ matrix.bitness }}" >> $GITHUB_STEP_SUMMARY
+          echo "### ❌ Missing files for $env:LABVIEW_VERSION_YEAR‑${{ matrix.bitness }}" >> $GITHUB_STEP_SUMMARY
           if (-not [string]::IsNullOrWhiteSpace($env:MISSING_CSV)) {
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Missing files (CSV):" >> $GITHUB_STEP_SUMMARY
@@ -104,27 +102,27 @@ jobs:
         if: always() && steps.mip.outputs.passed != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: missing-files-${{ matrix.lv-version }}-${{ matrix.bitness }}
+          name: missing-files-${{ matrix.bitness }}
           path: ${{ env.REPO_ROOT }}/.github/actions/missing-in-project/missing_files.txt
           if-no-files-found: ignore
       # Cleanup
-      - name: Revert Development Mode (LV${{ matrix.lv-version }} ${{ matrix.bitness }}-bit)
+      - name: Revert Development Mode (LV ${{ matrix.bitness }}-bit)
         if: always()
         shell: pwsh
         working-directory: ${{ env.REPO_ROOT }}
         run: |
           & ".github\\actions\\revert-development-mode\\RevertDevelopmentMode.ps1" `
-            -MinimumSupportedLVVersion ${{ matrix.lv-version }} `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }} `
             -RepoRoot "$env:REPO_ROOT"
-      - name: Close LabVIEW (LV${{ matrix.lv-version }} ${{ matrix.bitness }}-bit)
+      - name: Close LabVIEW (LV ${{ matrix.bitness }}-bit)
         if: always()
         shell: pwsh
         run: |
           & "$env:REPO_ROOT\\.github\\actions\\close-labview\\Close_LabVIEW.ps1" `
-            -MinimumSupportedLVVersion ${{ matrix.lv-version }} `
+            -MinimumSupportedLVVersion $env:LABVIEW_VERSION_YEAR `
             -SupportedBitness ${{ matrix.bitness }}
-      - name: Cleanup temp files (LV${{ matrix.lv-version }} ${{ matrix.bitness }}-bit)
+      - name: Cleanup temp files (LV ${{ matrix.bitness }}-bit)
         if: always()
         shell: pwsh
         run: |

--- a/.github/workflows/test-missing-in-project-windows.yml
+++ b/.github/workflows/test-missing-in-project-windows.yml
@@ -20,33 +20,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set worktree root (runner-scoped)
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_ROOT)) {
-            $rootBase = $env:RUNNER_WORKSPACE
-            if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
-              $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
-            }
-            if ([string]::IsNullOrWhiteSpace($rootBase)) {
-              $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
-            }
-            $root = Join-Path $rootBase 'w'
-            New-Item -Path $root -ItemType Directory -Force | Out-Null
-            "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          }
       - name: Create short-path worktree
         id: worktree
         shell: pwsh
         run: |
-          $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($env:GITHUB_JOB))).Replace('-','').Substring(0,8)
-          $name = "ci-$jobHash-${{ matrix.lv-version }}-${{ matrix.bitness }}-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
-          $worktreeRoot = & "$env:GITHUB_WORKSPACE\Tooling\Ensure-WorktreeRoot.ps1"
-          $targetPath = Join-Path $worktreeRoot $name
-          $worktree = & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktree.ps1" -Ref $env:GITHUB_SHA -Path $targetPath
-          $projectPath = Join-Path $worktree 'lv_icon_editor.lvproj'
-          "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
-          "PROJECT_PATH=$projectPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+          & "$env:GITHUB_WORKSPACE\Tooling\New-CIWorktreeForJob.ps1" `
+            -Bitness ${{ matrix.bitness }} `
+            -Variant "${{ matrix.lv-version }}"
 
       - name: Enable Development Mode (LV${{ matrix.lv-version }} ${{ matrix.bitness }}-bit)
         shell: pwsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ Example: `C:\dev\ci-D170BDEE-64-21534416929-1`
 The workflow exports:
 - `REPO_ROOT` → worktree path (authoritative for all scripts)
 - `PROJECT_PATH` → `$REPO_ROOT\lv_icon_editor.lvproj`
+- `LABVIEW_VERSION_YEAR` / `LABVIEW_MINOR_REVISION` → derived from `.lvversion` (e.g., `21.0` → `2021` and minor `0`)
+
+Note: CI reads `.lvversion` from `REPO_ROOT` as the canonical LabVIEW version for runs.
 
 Helper used by CI:
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,16 @@ Prune stale worktree metadata (after deleting folders manually):
 git worktree prune
 ```
 
+## Run CI for a specific commit (workflow_dispatch)
+Use the helper to target a specific commit without relying on PR pushes:
+```
+pwsh -NoProfile -File .\Tooling\Run-CICompositeForCommit.ps1 -Sha <commit>
+```
+
+Notes:
+- The script creates a temporary branch under `ci-run/<shortsha>` and dispatches the workflow.
+- Use `-CleanupRemote` if you want the temporary branch deleted after dispatch.
+
 ## Background automation safety
 Some automation may be running in the background and must not be killed. Do not terminate `g-cli` or `LabVIEW` processes unless you have explicit confirmation it is safe.
 - Before running a new step, record active processes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Notes:
 ## CI worktree naming (ci-composite.yml)
 CI jobs create short-path worktrees under `LVIE_WORKTREE_ROOT` with a deterministic name:
 - `ci-<jobhash>-<bitness>-<runid>-<attempt>`
+- Some workflows insert an extra variant token (e.g. LabVIEW version) between `<jobhash>` and `<bitness>`.
 - `jobhash` is the first 8 chars of the SHA1 of `GITHUB_JOB` (prevents collisions across jobs).
 - `bitness` is `32` or `64`.
 Example: `C:\dev\ci-D170BDEE-64-21534416929-1`
@@ -53,6 +54,11 @@ Example: `C:\dev\ci-D170BDEE-64-21534416929-1`
 The workflow exports:
 - `REPO_ROOT` → worktree path (authoritative for all scripts)
 - `PROJECT_PATH` → `$REPO_ROOT\lv_icon_editor.lvproj`
+
+Helper used by CI:
+```
+pwsh -NoProfile -File .\Tooling\New-CIWorktreeForJob.ps1 -Bitness 64
+```
 
 ## Local CI Parity (recommended)
 Run the local parity script that mirrors `ci-composite.yml`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Override:
 Preflight requirement:
 - If the chosen worktree root does not exist, ask the user to create it before proceeding.
 - For CI/self-hosted runners, ensure the directory is pre-created; fail fast with a clear message if missing.
+ - Local parity scripts hard-fail if `RepoRoot` is not under the worktree root; set `LVIE_WORKTREE_ROOT` or run from a worktree path.
 
 Example preflight (PowerShell):
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,17 @@ Notes:
 - Use `-Name` to label the worktree directory.
 - Use `-WorktreeRoot` (or `LVIE_WORKTREE_ROOT`) to override the default.
 
+## CI worktree naming (ci-composite.yml)
+CI jobs create short-path worktrees under `LVIE_WORKTREE_ROOT` with a deterministic name:
+- `ci-<jobhash>-<bitness>-<runid>-<attempt>`
+- `jobhash` is the first 8 chars of the SHA1 of `GITHUB_JOB` (prevents collisions across jobs).
+- `bitness` is `32` or `64`.
+Example: `C:\dev\ci-D170BDEE-64-21534416929-1`
+
+The workflow exports:
+- `REPO_ROOT` → worktree path (authoritative for all scripts)
+- `PROJECT_PATH` → `$REPO_ROOT\lv_icon_editor.lvproj`
+
 ## Local CI Parity (recommended)
 Run the local parity script that mirrors `ci-composite.yml`:
 ```

--- a/Test/ModifyVIPBDisplayInfo.Tests.ps1
+++ b/Test/ModifyVIPBDisplayInfo.Tests.ps1
@@ -81,6 +81,8 @@ Describe "ModifyVIPBDisplayInfo.ps1" {
         $generalSettings = $vipbXml.VI_Package_Builder_Settings.Library_General_Settings
         $descriptionSettings = $vipbXml.VI_Package_Builder_Settings.Advanced_Settings.Description
         $licenseSetting = $vipbXml.VI_Package_Builder_Settings.Advanced_Settings.License_Agreement_Filepath
+        $sourceFiles = $vipbXml.VI_Package_Builder_Settings.Advanced_Settings.Source_Files
+        $exclusionPaths = @($sourceFiles.Exclusions) | ForEach-Object { $_.Path }
 
         $generalSettings.Company_Name | Should -Be $displayInformation."Company Name"
         $generalSettings.Product_Name | Should -Be $displayInformation."Product Name"
@@ -90,5 +92,6 @@ Describe "ModifyVIPBDisplayInfo.ps1" {
         $descriptionSettings.Release_Notes | Should -Be $releaseNotesContent
         $descriptionSettings.Description | Should -Match "Commit: deadbeef"
         $licenseSetting | Should -Be ''
+        $exclusionPaths | Should -Contain 'TestResults'
     }
 }

--- a/Test/ModifyVIPBDisplayInfo.Tests.ps1
+++ b/Test/ModifyVIPBDisplayInfo.Tests.ps1
@@ -1,27 +1,52 @@
-$PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
-$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
-$scriptPath = Join-Path $repoRoot ".github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1"
-$fixtureSource = Join-Path $repoRoot "Test/fixtures/modify-vipb/fixture.vipb"
-$tempRoot = Join-Path $repoRoot "Test/tmp"
-
 Describe "ModifyVIPBDisplayInfo.ps1" {
     BeforeAll {
-        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        # Pester runs discovery and execution in separate scopes; compute paths at execution time.
+        function Find-RepoRoot {
+            param([string]$StartPath)
+
+            $dir = $StartPath
+            while ($dir -and (Test-Path -Path $dir)) {
+                if ((Test-Path (Join-Path $dir ".git")) -or (Test-Path (Join-Path $dir ".lvversion"))) {
+                    return (Resolve-Path -Path $dir).Path
+                }
+
+                $parent = Split-Path -Parent $dir
+                if ($parent -eq $dir) {
+                    break
+                }
+                $dir = $parent
+            }
+
+            throw "Unable to locate repository root from '$StartPath'."
+        }
+
+        $startPath = $PSScriptRoot
+        if ([string]::IsNullOrWhiteSpace($startPath)) {
+            $startPath = (Get-Location).Path
+        }
+
+        $script:repoRoot = Find-RepoRoot -StartPath $startPath
+        $script:scriptPath = Join-Path $script:repoRoot ".github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1"
+        # Use the repository VIPB as the fixture source; copy into a temp file per test.
+        $script:fixtureSource = Join-Path $script:repoRoot "Tooling/deployment/NI Icon editor.vipb"
+        $script:tempRoot = Join-Path $script:repoRoot "Test/tmp"
+
+        New-Item -ItemType Directory -Path $script:tempRoot -Force | Out-Null
     }
 
     AfterAll {
-        if (Test-Path $tempRoot) {
-            Remove-Item -Path $tempRoot -Recurse -Force
+        if ($script:tempRoot -and (Test-Path $script:tempRoot)) {
+            Remove-Item -Path $script:tempRoot -Recurse -Force
         }
     }
 
     It "updates VIPB metadata according to DisplayInformation JSON" {
-        $vipbPath = Join-Path $tempRoot ("fixture_{0}.vipb" -f ([guid]::NewGuid().ToString("N")))
-        Copy-Item -Path $fixtureSource -Destination $vipbPath
+        $vipbPath = Join-Path $script:tempRoot ("fixture_{0}.vipb" -f ([guid]::NewGuid().ToString("N")))
+        Copy-Item -Path $script:fixtureSource -Destination $vipbPath
 
-        $releaseNotesPath = Join-Path $tempRoot ("release_notes_{0}.md" -f ([guid]::NewGuid().ToString("N")))
+        $releaseNotesPath = Join-Path $script:tempRoot ("release_notes_{0}.md" -f ([guid]::NewGuid().ToString("N")))
         $releaseNotesContent = "Release notes content from file"
-        Set-Content -Path $releaseNotesPath -Value $releaseNotesContent
+        Set-Content -Path $releaseNotesPath -Value $releaseNotesContent -NoNewline
 
         $displayInformation = [ordered]@{
             "Company Name"                 = "svelderrainruiz"
@@ -31,17 +56,16 @@ Describe "ModifyVIPBDisplayInfo.ps1" {
             "Author Name (Person or Company)" = "svelderrainruiz/labview-icon-editor"
             "Product Homepage (URL)"       = "https://github.com/svelderrainruiz/labview-icon-editor"
             "Legal Copyright"              = "© 2025 svelderrainruiz"
-            "License Agreement Name"       = "LICENSE"
             "Release Notes - Change Log"   = $releaseNotesContent
             "Package Version"              = @{ major = 1; minor = 4; patch = 1; build = 1194 }
         }
 
         $displayInformationJson = $displayInformation | ConvertTo-Json -Depth 5
-        $relativeVipbPath = [System.IO.Path]::GetRepoRoot($repoRoot, $vipbPath)
+        $relativeVipbPath = [System.IO.Path]::GetRelativePath($script:repoRoot, $vipbPath)
 
-        & $scriptPath `
+        & $script:scriptPath `
             -SupportedBitness 64 `
-            -RepoRoot $repoRoot `
+            -RepoRoot $script:repoRoot `
             -VIPBPath $relativeVipbPath `
             -MinimumSupportedLVVersion 2021 `
             -LabVIEWMinorRevision 0 `
@@ -57,7 +81,6 @@ Describe "ModifyVIPBDisplayInfo.ps1" {
         $generalSettings = $vipbXml.VI_Package_Builder_Settings.Library_General_Settings
         $descriptionSettings = $vipbXml.VI_Package_Builder_Settings.Advanced_Settings.Description
         $licenseSetting = $vipbXml.VI_Package_Builder_Settings.Advanced_Settings.License_Agreement_Filepath
-        $expectedLicensePath = [System.IO.Path]::GetRelativePath((Split-Path -Parent $vipbPath), (Join-Path $repoRoot "LICENSE"))
 
         $generalSettings.Company_Name | Should -Be $displayInformation."Company Name"
         $generalSettings.Product_Name | Should -Be $displayInformation."Product Name"
@@ -66,6 +89,6 @@ Describe "ModifyVIPBDisplayInfo.ps1" {
         $descriptionSettings.URL | Should -Be $displayInformation."Product Homepage (URL)"
         $descriptionSettings.Release_Notes | Should -Be $releaseNotesContent
         $descriptionSettings.Description | Should -Match "Commit: deadbeef"
-        $licenseSetting | Should -Be $expectedLicensePath
+        $licenseSetting | Should -Be ''
     }
 }

--- a/Tooling/Inspect-VipPackage.ps1
+++ b/Tooling/Inspect-VipPackage.ps1
@@ -1,0 +1,253 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+  Inspects a VI Package (.vip) as a zip file and reports internal path usage.
+
+.DESCRIPTION
+  A .vip file is a zip container. This script opens it and reports:
+    - The longest internal entry paths (zip entry names)
+    - Any entries that look like they contain absolute paths
+    - Any entries that contain runner/workspace path fragments (heuristic)
+
+  This is useful to diagnose accidental "preserve full path" packaging that can
+  cause Windows path-length failures or slow down VIPM builds.
+
+.PARAMETER VipPath
+  Path to the .vip file to inspect.
+
+.PARAMETER TopLongest
+  Number of longest entries to print.
+
+.PARAMETER WarnPathLength
+  Emits a warning if any internal entry path length is >= this value.
+
+.PARAMETER FailPathLength
+  If set to a value > 0, fails if any internal entry path length is >= this value.
+
+.PARAMETER FailOnAbsolutePaths
+  If set, fails when any entry name looks like an absolute path (drive/UNC/leading slash).
+
+.PARAMETER WriteSummary
+  If running in GitHub Actions, writes a summary to $GITHUB_STEP_SUMMARY.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$VipPath,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 200)]
+    [int]$TopLongest = 25,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 4096)]
+    [int]$WarnPathLength = 200,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateRange(0, 4096)]
+    [int]$FailPathLength = 0,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$FailOnAbsolutePaths,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$WriteSummary
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-SummaryLine {
+    param([string]$Line)
+
+    if (-not $WriteSummary) { return }
+    if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) { return }
+
+    $Line | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+
+$VipPath = [System.IO.Path]::GetFullPath($VipPath)
+if (-not (Test-Path -LiteralPath $VipPath -PathType Leaf)) {
+    throw "VI Package not found: $VipPath"
+}
+
+try {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+}
+catch {
+    # PowerShell 7 usually already has it, but keep a clear error if missing.
+    throw "Failed to load System.IO.Compression.FileSystem. $_"
+}
+
+Write-Host ("Inspecting VI Package (as zip): {0}" -f $VipPath)
+Write-SummaryLine "## VI Package Inspection"
+Write-SummaryLine ""
+Write-SummaryLine ('- VIP: `{0}`' -f $VipPath)
+
+$archive = $null
+try {
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($VipPath)
+
+    $entryInfos =
+        $archive.Entries |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_.FullName) } |
+        Where-Object { -not $_.FullName.EndsWith('/') } |
+        ForEach-Object {
+            [pscustomobject]@{
+                Name           = $_.FullName
+                NameLength     = $_.FullName.Length
+                UncompressedB  = $_.Length
+                CompressedB    = $_.CompressedLength
+            }
+        }
+
+    $entryCount = @($entryInfos).Count
+    $maxLen = ($entryInfos | Measure-Object -Property NameLength -Maximum).Maximum
+    $avgLen = [Math]::Round(($entryInfos | Measure-Object -Property NameLength -Average).Average, 2)
+
+    Write-Host ("Entries: {0}" -f $entryCount)
+    Write-Host ("Max internal path length: {0}" -f $maxLen)
+    Write-Host ("Avg internal path length: {0}" -f $avgLen)
+
+    Write-SummaryLine ("- Entries: **{0}**" -f $entryCount)
+    Write-SummaryLine ("- Max internal path length: **{0}**" -f $maxLen)
+    Write-SummaryLine ("- Avg internal path length: **{0}**" -f $avgLen)
+
+    if ($maxLen -ge $WarnPathLength) {
+        Write-Warning ("Max internal entry path length ({0}) is >= warn threshold ({1})." -f $maxLen, $WarnPathLength)
+        Write-SummaryLine ("- :warning: Max internal entry path length ({0}) is >= warn threshold ({1})." -f $maxLen, $WarnPathLength)
+    }
+
+    if ($FailPathLength -gt 0 -and $maxLen -ge $FailPathLength) {
+        Write-Error ("Max internal entry path length ({0}) is >= fail threshold ({1})." -f $maxLen, $FailPathLength)
+        exit 1
+    }
+
+    $sorted = $entryInfos | Sort-Object NameLength -Descending
+    $top = $sorted | Select-Object -First $TopLongest
+
+    Write-Host ""
+    Write-Host ("Top {0} longest internal paths:" -f $TopLongest)
+    foreach ($row in $top) {
+        Write-Host ("{0,4}  {1}" -f $row.NameLength, $row.Name)
+    }
+
+    Write-SummaryLine ""
+    Write-SummaryLine ("### Top {0} Longest Internal Paths" -f $TopLongest)
+    Write-SummaryLine ""
+    Write-SummaryLine "|Len|Entry|"
+    Write-SummaryLine "|---:|---|"
+    foreach ($row in $top) {
+        $escaped = ($row.Name -replace '\|', '\|')
+        Write-SummaryLine ('|{0}|`{1}`|' -f $row.NameLength, $escaped)
+    }
+
+    # Detect obvious build/test artifacts inside the VIP (these should not ship).
+    $artifactFragments = @(
+        '/testresults/',
+        '/builds/'
+    )
+
+    $artifactEntries = @()
+    foreach ($e in $entryInfos) {
+        $normLower = ($e.Name -replace '\\', '/').ToLowerInvariant()
+        foreach ($frag in $artifactFragments) {
+            if ($normLower.Contains($frag)) {
+                $artifactEntries += $e
+                break
+            }
+        }
+    }
+
+    if ($artifactEntries.Count -gt 0) {
+        Write-Warning ("VIP contains {0} entries that look like build/test artifacts (e.g. TestResults/builds)." -f $artifactEntries.Count)
+
+        $sample = $artifactEntries | Sort-Object NameLength -Descending | Select-Object -First 25
+        foreach ($row in $sample) {
+            Write-Host ("ARTIFACT  {0,4}  {1}" -f $row.NameLength, $row.Name)
+        }
+
+        Write-SummaryLine ""
+        Write-SummaryLine "### Build/Test Artifacts Detected"
+        Write-SummaryLine ""
+        Write-SummaryLine (":warning: VIP contains **{0}** entries that look like build/test artifacts (e.g. `TestResults`, `builds`)." -f $artifactEntries.Count)
+        Write-SummaryLine ""
+        Write-SummaryLine "|Len|Entry|"
+        Write-SummaryLine "|---:|---|"
+        foreach ($row in $sample) {
+            $escaped = ($row.Name -replace '\|', '\|')
+            Write-SummaryLine ('|{0}|`{1}`|' -f $row.NameLength, $escaped)
+        }
+    }
+
+    # Heuristic checks for accidental absolute paths embedded into zip entry names.
+    # Zip entries typically use forward slashes, but some creators can emit backslashes.
+    $driveRegex = '(?i)(^|[\\/])[a-z]:[\\/]'
+    $uncRegex = '^(?:\\\\\\\\|//)[^\\/]+[\\/]'
+    $leadingSlash = '^/'
+
+    $runnerFragments = @(
+        'actions-runner/_work',
+        'actions-runner\\_work',
+        'github/workspace',
+        'github\\workspace'
+    )
+
+    # Use an explicit loop to avoid any ambiguity with nested pipeline scoping.
+    $suspicious = @()
+    foreach ($e in $entryInfos) {
+        $n = $e.Name
+        $nLower = $n.ToLowerInvariant()
+
+        $hit = $false
+        if ($n -match $driveRegex) { $hit = $true }
+        elseif ($n -match $uncRegex) { $hit = $true }
+        elseif ($n -match $leadingSlash) { $hit = $true }
+        else {
+            foreach ($frag in $runnerFragments) {
+                if ([string]::IsNullOrWhiteSpace($frag)) { continue }
+                if ($nLower.Contains($frag.ToLowerInvariant())) { $hit = $true; break }
+            }
+        }
+
+        if ($hit) { $suspicious += $e }
+    }
+
+    if ($suspicious.Count -gt 0) {
+        Write-Warning ("Found {0} suspicious zip entries that look like absolute/runner paths." -f $suspicious.Count)
+        Write-SummaryLine ""
+        Write-SummaryLine ("### Suspicious Paths")
+        Write-SummaryLine ""
+        Write-SummaryLine (":warning: Found **{0}** suspicious zip entries that look like absolute/runner paths." -f $suspicious.Count)
+        Write-SummaryLine ""
+
+        $sample = $suspicious | Sort-Object NameLength -Descending | Select-Object -First 25
+        foreach ($row in $sample) {
+            Write-Host ("SUSPICIOUS {0,4}  {1}" -f $row.NameLength, $row.Name)
+        }
+
+        Write-SummaryLine "|Len|Entry|"
+        Write-SummaryLine "|---:|---|"
+        foreach ($row in $sample) {
+            $escaped = ($row.Name -replace '\|', '\|')
+            Write-SummaryLine ('|{0}|`{1}`|' -f $row.NameLength, $escaped)
+        }
+
+        if ($FailOnAbsolutePaths) {
+            Write-Error "FailOnAbsolutePaths is set and suspicious entries were found."
+            exit 1
+        }
+    } else {
+        Write-Host "No suspicious absolute/runner path fragments detected in zip entry names."
+        Write-SummaryLine ""
+        Write-SummaryLine "### Suspicious Paths"
+        Write-SummaryLine ""
+        Write-SummaryLine "No suspicious absolute/runner path fragments detected in zip entry names."
+    }
+}
+catch {
+    throw "Failed to inspect VIP as a zip. If needed, copy and rename the .vip to .zip and inspect manually. Error: $_"
+}
+finally {
+    if ($null -ne $archive) { $archive.Dispose() }
+}

--- a/Tooling/New-CIWorktreeForJob.ps1
+++ b/Tooling/New-CIWorktreeForJob.ps1
@@ -57,12 +57,6 @@ param(
     [string]$JobName,
 
     [Parameter(Mandatory = $false)]
-    [string]$RunId,
-
-    [Parameter(Mandatory = $false)]
-    [string]$RunAttempt,
-
-    [Parameter(Mandatory = $false)]
     [string]$ProjectFile = 'lv_icon_editor.lvproj',
 
     [Parameter(Mandatory = $false)]
@@ -137,22 +131,6 @@ if ([string]::IsNullOrWhiteSpace($jobName)) {
     throw "JobName is required to compute the worktree name."
 }
 
-$runId = $RunId
-if ([string]::IsNullOrWhiteSpace($runId)) {
-    $runId = $env:GITHUB_RUN_ID
-}
-if ([string]::IsNullOrWhiteSpace($runId)) {
-    $runId = 'local'
-}
-
-$runAttempt = $RunAttempt
-if ([string]::IsNullOrWhiteSpace($runAttempt)) {
-    $runAttempt = $env:GITHUB_RUN_ATTEMPT
-}
-if ([string]::IsNullOrWhiteSpace($runAttempt)) {
-    $runAttempt = '1'
-}
-
 $ref = $Ref
 if ([string]::IsNullOrWhiteSpace($ref)) {
     $ref = $env:GITHUB_SHA
@@ -194,9 +172,9 @@ $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::
 
 $variantToken = if ([string]::IsNullOrWhiteSpace($Variant)) { $null } else { $Variant }
 $name = if ($variantToken) {
-    "ci-$jobHash-$variantToken-$Bitness-$runId-$runAttempt"
+    "ci-$jobHash-$variantToken-$Bitness"
 } else {
-    "ci-$jobHash-$Bitness-$runId-$runAttempt"
+    "ci-$jobHash-$Bitness"
 }
 
 $targetPath = Join-Path $root $name
@@ -209,6 +187,31 @@ if (-not (Test-Path -Path $ensureScript)) {
 $worktreeScript = Join-Path $repoRoot 'Tooling/New-CIWorktree.ps1'
 if (-not (Test-Path -Path $worktreeScript)) {
     throw "New-CIWorktree.ps1 not found at $worktreeScript"
+}
+
+# If a previous run was cancelled, the worktree folder may still exist.
+# Reuse the *same* short path across runs for deterministic paths and to
+# avoid accumulating stale worktree folders under the root.
+if (Test-Path -Path $targetPath) {
+    Write-Host ("Cleaning existing worktree at {0}" -f $targetPath)
+
+    try {
+        git -C $repoRoot worktree remove --force $targetPath 2>$null | Out-Null
+    }
+    catch {
+        # Ignore; directory may not be registered as a worktree.
+    }
+
+    try {
+        git -C $repoRoot worktree prune 2>$null | Out-Null
+    }
+    catch {
+        # Ignore; prune can fail if the main worktree is busy.
+    }
+
+    if (Test-Path -Path $targetPath) {
+        Remove-Item -Path $targetPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }
 
 $worktree = & $worktreeScript -Ref $ref -Path $targetPath -WorktreeRoot $root

--- a/Tooling/New-CIWorktreeForJob.ps1
+++ b/Tooling/New-CIWorktreeForJob.ps1
@@ -82,6 +82,78 @@ function Resolve-RepoRoot {
     return (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
 }
 
+function Normalize-PathString {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $Path
+    }
+
+    $full = [System.IO.Path]::GetFullPath($Path)
+    if ($full.Length -gt 3 -and $full.EndsWith('\')) {
+        $full = $full.TrimEnd('\')
+    }
+
+    return $full
+}
+
+function Get-RegisteredWorktreePaths {
+    param([string]$RepoRoot)
+
+    $paths = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    try {
+        $lines = & git -C $RepoRoot worktree list --porcelain 2>$null
+        foreach ($line in $lines) {
+            if ($line -like 'worktree *') {
+                $path = $line.Substring(9).Trim()
+                if (-not [string]::IsNullOrWhiteSpace($path)) {
+                    $paths.Add($path) | Out-Null
+                }
+            }
+        }
+    }
+    catch {
+        # If git fails, leave the set empty and allow cleanup to be conservative.
+    }
+
+    return $paths
+}
+
+function Invoke-WorktreeRetentionCleanup {
+    param(
+        [string]$Root,
+        [string]$RepoRoot,
+        [string]$TargetPath,
+        [int]$RetentionDays
+    )
+
+    if ($RetentionDays -le 0) {
+        return
+    }
+
+    if (-not (Test-Path -Path $Root -PathType Container)) {
+        return
+    }
+
+    $cutoff = (Get-Date).AddDays(-$RetentionDays)
+    $registered = Get-RegisteredWorktreePaths -RepoRoot $RepoRoot
+
+    Get-ChildItem -Path $Root -Directory -Force | Where-Object {
+        $_.Name -like 'ci-*' -and
+        $_.LastWriteTime -lt $cutoff -and
+        (-not $registered.Contains($_.FullName)) -and
+        ($_.FullName -ne $TargetPath)
+    } | ForEach-Object {
+        try {
+            Write-Host ("Removing stale worktree folder: {0}" -f $_.FullName)
+            Remove-Item -Path $_.FullName -Recurse -Force -ErrorAction Stop
+        }
+        catch {
+            Write-Warning ("Failed to remove stale worktree folder: {0}. {1}" -f $_.FullName, $_.Exception.Message)
+        }
+    }
+}
+
 function Resolve-LabVIEWVersionInfo {
     param([string]$VersionPath)
 
@@ -166,6 +238,7 @@ $root = [System.IO.Path]::GetFullPath($root)
 if (-not $rootIsExplicit) {
     New-Item -Path $root -ItemType Directory -Force | Out-Null
 }
+$root = Normalize-PathString -Path $root
 
 $hashBytes = [System.Text.Encoding]::UTF8.GetBytes($jobName)
 $jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash($hashBytes)).Replace('-', '').Substring(0, 8)
@@ -178,6 +251,7 @@ $name = if ($variantToken) {
 }
 
 $targetPath = Join-Path $root $name
+$targetPath = Normalize-PathString -Path $targetPath
 
 $ensureScript = Join-Path $repoRoot 'Tooling/Ensure-WorktreeRoot.ps1'
 if (-not (Test-Path -Path $ensureScript)) {
@@ -187,6 +261,19 @@ if (-not (Test-Path -Path $ensureScript)) {
 $worktreeScript = Join-Path $repoRoot 'Tooling/New-CIWorktree.ps1'
 if (-not (Test-Path -Path $worktreeScript)) {
     throw "New-CIWorktree.ps1 not found at $worktreeScript"
+}
+
+$retentionDays = $null
+if (-not [string]::IsNullOrWhiteSpace($env:LVIE_WORKTREE_RETENTION_DAYS)) {
+    if (-not [int]::TryParse($env:LVIE_WORKTREE_RETENTION_DAYS, [ref]$retentionDays)) {
+        throw "LVIE_WORKTREE_RETENTION_DAYS must be an integer (got '$env:LVIE_WORKTREE_RETENTION_DAYS')."
+    }
+} elseif ($env:GITHUB_ACTIONS -eq 'true') {
+    $retentionDays = 7
+}
+
+if ($null -ne $retentionDays) {
+    Invoke-WorktreeRetentionCleanup -Root $root -RepoRoot $repoRoot -TargetPath $targetPath -RetentionDays $retentionDays
 }
 
 # If a previous run was cancelled, the worktree folder may still exist.
@@ -215,7 +302,18 @@ if (Test-Path -Path $targetPath) {
 }
 
 $worktree = & $worktreeScript -Ref $ref -Path $targetPath -WorktreeRoot $root
+$worktree = Normalize-PathString -Path $worktree
+
+if (-not (Test-Path -Path $worktree)) {
+    throw "Worktree path does not exist after creation: $worktree"
+}
+
 $projectPath = Join-Path $worktree $ProjectFile
+$projectPath = Normalize-PathString -Path $projectPath
+
+if (-not (Test-Path -Path $projectPath)) {
+    throw "Project file not found at $projectPath"
+}
 
 $lvInfo = Resolve-LabVIEWVersionInfo -VersionPath (Join-Path $worktree '.lvversion')
 

--- a/Tooling/New-CIWorktreeForJob.ps1
+++ b/Tooling/New-CIWorktreeForJob.ps1
@@ -88,6 +88,45 @@ function Resolve-RepoRoot {
     return (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
 }
 
+function Resolve-LabVIEWVersionInfo {
+    param([string]$VersionPath)
+
+    if (-not (Test-Path -Path $VersionPath)) {
+        throw ".lvversion not found at $VersionPath"
+    }
+
+    $raw = (Get-Content -Raw -Path $VersionPath).Trim()
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw ".lvversion is empty at $VersionPath"
+    }
+
+    if (-not ($raw -match '^(?<major>\d{2,4})(?:\.(?<minor>\d+))?$')) {
+        throw ".lvversion value '$raw' is invalid. Expected formats like '21.0' or '2021.0'."
+    }
+
+    $majorRaw = [int]$Matches['major']
+    $minor = if ($Matches['minor']) { [int]$Matches['minor'] } else { 0 }
+
+    if ($majorRaw -ge 2000) {
+        $year = $majorRaw
+        $numericMajor = $majorRaw - 2000
+    } else {
+        $numericMajor = $majorRaw
+        $year = 2000 + $majorRaw
+    }
+
+    if ($numericMajor -lt 0) {
+        throw ".lvversion value '$raw' produced an invalid LabVIEW numeric major."
+    }
+
+    [pscustomobject]@{
+        Raw            = $raw
+        Year           = $year
+        MinorRevision  = $minor
+        NumericVersion = "$numericMajor.$minor"
+    }
+}
+
 $repoRoot = Resolve-RepoRoot -BasePath $RepoRoot
 
 $jobName = $JobName
@@ -175,11 +214,18 @@ if (-not (Test-Path -Path $worktreeScript)) {
 $worktree = & $worktreeScript -Ref $ref -Path $targetPath -WorktreeRoot $root
 $projectPath = Join-Path $worktree $ProjectFile
 
+$lvInfo = Resolve-LabVIEWVersionInfo -VersionPath (Join-Path $worktree '.lvversion')
+
 if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_ENV)) {
     "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
     "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
     "PROJECT_PATH=$projectPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+    "LABVIEW_VERSION_RAW=$($lvInfo.Raw)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+    "LABVIEW_VERSION_YEAR=$($lvInfo.Year)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+    "LABVIEW_MINOR_REVISION=$($lvInfo.MinorRevision)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+    "LABVIEW_NUMERIC_VERSION=$($lvInfo.NumericVersion)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
 }
 
 Write-Host ("Worktree created: {0}" -f $worktree)
+Write-Host ("LabVIEW version: {0} (year {1}, minor {2})" -f $lvInfo.Raw, $lvInfo.Year, $lvInfo.MinorRevision)
 Write-Output $worktree

--- a/Tooling/New-CIWorktreeForJob.ps1
+++ b/Tooling/New-CIWorktreeForJob.ps1
@@ -1,0 +1,185 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Creates a short-path worktree for a CI job and exports REPO_ROOT/PROJECT_PATH.
+
+.DESCRIPTION
+    Centralizes CI worktree creation so workflows only need to pass a bitness and
+    (optionally) a variant label. The script resolves the worktree root, creates
+    a deterministic folder name, calls New-CIWorktree.ps1, and exports:
+      - LVIE_WORKTREE_ROOT
+      - REPO_ROOT
+      - PROJECT_PATH
+
+.PARAMETER Bitness
+    LabVIEW bitness (32 or 64). Required.
+
+.PARAMETER Variant
+    Optional additional label included in the worktree folder name (e.g. 2021).
+
+.PARAMETER Ref
+    Git ref to check out. Defaults to GITHUB_SHA or HEAD.
+
+.PARAMETER JobName
+    Job name used to compute the job hash. Defaults to GITHUB_JOB.
+
+.PARAMETER RunId
+    Run ID. Defaults to GITHUB_RUN_ID.
+
+.PARAMETER RunAttempt
+    Run attempt. Defaults to GITHUB_RUN_ATTEMPT.
+
+.PARAMETER ProjectFile
+    Project file name to export as PROJECT_PATH. Defaults to lv_icon_editor.lvproj.
+
+.PARAMETER WorktreeRoot
+    Optional explicit worktree root. If omitted, LVIE_WORKTREE_ROOT or a
+    runner-scoped default is used.
+
+.PARAMETER RepoRoot
+    Optional explicit repo root. If omitted, GITHUB_WORKSPACE or the script
+    location is used.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('32', '64')]
+    [string]$Bitness,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Variant,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Ref,
+
+    [Parameter(Mandatory = $false)]
+    [string]$JobName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RunId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RunAttempt,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ProjectFile = 'lv_icon_editor.lvproj',
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    param([string]$BasePath)
+
+    if (-not [string]::IsNullOrWhiteSpace($BasePath)) {
+        return [System.IO.Path]::GetFullPath($BasePath)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+        return [System.IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+    }
+
+    return (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+}
+
+$repoRoot = Resolve-RepoRoot -BasePath $RepoRoot
+
+$jobName = $JobName
+if ([string]::IsNullOrWhiteSpace($jobName)) {
+    $jobName = $env:GITHUB_JOB
+}
+if ([string]::IsNullOrWhiteSpace($jobName)) {
+    throw "JobName is required to compute the worktree name."
+}
+
+$runId = $RunId
+if ([string]::IsNullOrWhiteSpace($runId)) {
+    $runId = $env:GITHUB_RUN_ID
+}
+if ([string]::IsNullOrWhiteSpace($runId)) {
+    $runId = 'local'
+}
+
+$runAttempt = $RunAttempt
+if ([string]::IsNullOrWhiteSpace($runAttempt)) {
+    $runAttempt = $env:GITHUB_RUN_ATTEMPT
+}
+if ([string]::IsNullOrWhiteSpace($runAttempt)) {
+    $runAttempt = '1'
+}
+
+$ref = $Ref
+if ([string]::IsNullOrWhiteSpace($ref)) {
+    $ref = $env:GITHUB_SHA
+}
+if ([string]::IsNullOrWhiteSpace($ref)) {
+    $ref = 'HEAD'
+}
+
+$root = $WorktreeRoot
+$rootIsExplicit = $false
+if ([string]::IsNullOrWhiteSpace($root)) {
+    $root = $env:LVIE_WORKTREE_ROOT
+}
+if (-not [string]::IsNullOrWhiteSpace($root)) {
+    $rootIsExplicit = $true
+}
+
+if ([string]::IsNullOrWhiteSpace($root)) {
+    $rootBase = $env:RUNNER_WORKSPACE
+    if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+        $rootBase = Split-Path -Parent (Split-Path -Parent $env:GITHUB_WORKSPACE)
+    }
+    if ([string]::IsNullOrWhiteSpace($rootBase) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+        $rootBase = Split-Path -Parent $env:GITHUB_WORKSPACE
+    }
+    if ([string]::IsNullOrWhiteSpace($rootBase)) {
+        throw "Worktree root could not be resolved. Set LVIE_WORKTREE_ROOT or pass -WorktreeRoot."
+    }
+    $root = Join-Path $rootBase 'w'
+}
+
+$root = [System.IO.Path]::GetFullPath($root)
+if (-not $rootIsExplicit) {
+    New-Item -Path $root -ItemType Directory -Force | Out-Null
+}
+
+$hashBytes = [System.Text.Encoding]::UTF8.GetBytes($jobName)
+$jobHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash($hashBytes)).Replace('-', '').Substring(0, 8)
+
+$variantToken = if ([string]::IsNullOrWhiteSpace($Variant)) { $null } else { $Variant }
+$name = if ($variantToken) {
+    "ci-$jobHash-$variantToken-$Bitness-$runId-$runAttempt"
+} else {
+    "ci-$jobHash-$Bitness-$runId-$runAttempt"
+}
+
+$targetPath = Join-Path $root $name
+
+$ensureScript = Join-Path $repoRoot 'Tooling/Ensure-WorktreeRoot.ps1'
+if (-not (Test-Path -Path $ensureScript)) {
+    throw "Ensure-WorktreeRoot.ps1 not found at $ensureScript"
+}
+
+$worktreeScript = Join-Path $repoRoot 'Tooling/New-CIWorktree.ps1'
+if (-not (Test-Path -Path $worktreeScript)) {
+    throw "New-CIWorktree.ps1 not found at $worktreeScript"
+}
+
+$worktree = & $worktreeScript -Ref $ref -Path $targetPath -WorktreeRoot $root
+$projectPath = Join-Path $worktree $ProjectFile
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_ENV)) {
+    "LVIE_WORKTREE_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+    "REPO_ROOT=$worktree" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+    "PROJECT_PATH=$projectPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding ascii
+}
+
+Write-Host ("Worktree created: {0}" -f $worktree)
+Write-Output $worktree

--- a/Tooling/Pester/DevModeCycle.ps1
+++ b/Tooling/Pester/DevModeCycle.ps1
@@ -34,7 +34,7 @@ function Start-DevModeRun {
         '--repo', $Repo,
         '--ref', $Ref,
         '-f', "mode=$Mode",
-        '-f', "minimum_supported_lv_version=$LabVIEWVersion",
+        '-f', "labview_version=$LabVIEWVersion",
         '-f', "sequence_id=$SequenceId"
     )
 

--- a/Tooling/Run-CICompositeForCommit.ps1
+++ b/Tooling/Run-CICompositeForCommit.ps1
@@ -1,0 +1,100 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Trigger CI Pipeline (Composite) for a specific commit by creating a temp branch.
+
+.DESCRIPTION
+    Creates (or reuses) a short-lived branch on the remote that points to the
+    specified commit, then triggers workflow_dispatch for that ref.
+
+.PARAMETER Sha
+    Commit SHA (or any rev-parse-able ref). Required.
+
+.PARAMETER BranchPrefix
+    Prefix for the temporary branch name. Default: ci-run.
+
+.PARAMETER Remote
+    Remote name to push to. Default: origin.
+
+.PARAMETER WorkflowName
+    Workflow display name for gh workflow run. Default: CI Pipeline (Composite).
+
+.PARAMETER Force
+    Force-update the remote branch if it already exists.
+
+.PARAMETER CleanupRemote
+    If set, delete the remote branch after dispatching the workflow.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Sha,
+
+    [Parameter(Mandatory = $false)]
+    [string]$BranchPrefix = 'ci-run',
+
+    [Parameter(Mandatory = $false)]
+    [string]$Remote = 'origin',
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorkflowName = 'CI Pipeline (Composite)',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Force,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$CleanupRemote
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Git {
+    param([string[]]$Args)
+    $output = & git @Args 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Args -join ' ') failed: $output"
+    }
+    return $output
+}
+
+function Ensure-Gh {
+    $null = & gh --version 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "GitHub CLI (gh) not found or not authenticated."
+    }
+}
+
+$repoRoot = Invoke-Git @('rev-parse', '--show-toplevel')
+Set-Location $repoRoot
+
+Ensure-Gh
+
+$fullSha = Invoke-Git @('rev-parse', '--verify', "$Sha^{commit}")
+$shortSha = Invoke-Git @('rev-parse', '--short', $fullSha)
+
+$branchName = "{0}/{1}" -f $BranchPrefix.TrimEnd('/'), $shortSha.Trim()
+
+$existing = Invoke-Git @('ls-remote', '--heads', $Remote, $branchName)
+if (-not [string]::IsNullOrWhiteSpace($existing) -and -not $Force) {
+    $suffix = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $branchName = "{0}/{1}-{2}" -f $BranchPrefix.TrimEnd('/'), $shortSha.Trim(), $suffix
+}
+
+$refSpec = "{0}:refs/heads/{1}" -f $fullSha.Trim(), $branchName
+if ($Force) {
+    $refSpec = "+$refSpec"
+}
+
+Write-Host ("Pushing {0} to {1}/{2}" -f $fullSha.Trim(), $Remote, $branchName)
+Invoke-Git @('push', $Remote, $refSpec) | Out-Host
+
+Write-Host ("Triggering workflow '{0}' on ref '{1}'..." -f $WorkflowName, $branchName)
+& gh workflow run $WorkflowName --ref $branchName | Out-Host
+
+if ($CleanupRemote) {
+    Write-Host ("Deleting remote branch {0}/{1}" -f $Remote, $branchName)
+    Invoke-Git @('push', $Remote, '--delete', $branchName) | Out-Host
+}
+
+Write-Host ("Done. Ref: {0}" -f $branchName)

--- a/Tooling/Run-CICompositeLocal-Auto.ps1
+++ b/Tooling/Run-CICompositeLocal-Auto.ps1
@@ -148,6 +148,17 @@ if (-not (Test-Path -Path $runScript)) {
     throw "Run-CICompositeLocal.ps1 not found at $runScript"
 }
 
+$resolvedWorktreeRoot = $null
+$ensureWorktreeScript = Join-Path $repoRoot 'Tooling/Ensure-WorktreeRoot.ps1'
+if ($UseWorktree) {
+    if (-not (Test-Path -Path $ensureWorktreeScript)) {
+        throw "Ensure-WorktreeRoot.ps1 not found at $ensureWorktreeScript"
+    }
+
+    $resolvedWorktreeRoot = & $ensureWorktreeScript -WorktreeRoot $WorktreeRoot
+    $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+}
+
 $runRepoRoot = $repoRoot
 if ($UseWorktree) {
     $worktreeScript = Join-Path $repoRoot 'Tooling/New-CIWorktree.ps1'
@@ -156,8 +167,24 @@ if ($UseWorktree) {
     }
 
     $suffix = if ([string]::IsNullOrWhiteSpace($WorktreeName)) { "ci-parity-auto-{0}" -f (Get-Date -Format 'yyyyMMdd-HHmmss') } else { $WorktreeName }
-    $runRepoRoot = & $worktreeScript -Ref HEAD -Name $suffix -WorktreeRoot $WorktreeRoot
+    $runRepoRoot = & $worktreeScript -Ref HEAD -Name $suffix -WorktreeRoot $resolvedWorktreeRoot
     Write-Host ("Using worktree: {0}" -f $runRepoRoot)
+}
+
+$worktreeRoot = $env:LVIE_WORKTREE_ROOT
+if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
+    $worktreeRoot = 'C:\dev'
+}
+$worktreeRootFull = [System.IO.Path]::GetFullPath($worktreeRoot)
+if (-not $worktreeRootFull.EndsWith('\')) {
+    $worktreeRootFull += '\'
+}
+$runRepoRootFull = [System.IO.Path]::GetFullPath($runRepoRoot)
+if (-not $runRepoRootFull.EndsWith('\')) {
+    $runRepoRootFull += '\'
+}
+if (-not $runRepoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $runRepoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
 }
 
 $logRoot = Join-Path $repoRoot 'TestResults/agent-logs'

--- a/Tooling/Run-CICompositeLocal.ps1
+++ b/Tooling/Run-CICompositeLocal.ps1
@@ -492,7 +492,7 @@ if (-not $repoRootFull.EndsWith('\')) {
     $repoRootFull += '\'
 }
 if (-not $repoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
-    Write-Warning ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $repoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
+    throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $repoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
 }
 Push-Location -Path $repoRoot
 $script:RunFailed = $false

--- a/Tooling/Run-CICompositeLocal.ps1
+++ b/Tooling/Run-CICompositeLocal.ps1
@@ -419,7 +419,6 @@ function Get-DisplayInformationJson {
         "Author Name (Person or Company)" = $meta.FullName
         "Product Homepage (URL)" = if ([string]::IsNullOrWhiteSpace($meta.Url)) { "" } else { $meta.Url }
         "Legal Copyright" = "(c) $(Get-Date -Format yyyy) $($meta.Owner)"
-        "License Agreement Name" = "LICENSE"
         "Product Description Summary" = $description
         "Product Description" = $description
         "Release Notes - Change Log" = $releaseNotes

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -105,7 +105,6 @@ That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. Th
 | --- | --- |
 | `supported_bitness` | `32` or `64`; selects the VI Package bitness. |
 | `labview_version` | LabVIEW 2021 (21.0). |
-| `minimum_supported_lv_version` | Deprecated. Use `labview_version`. |
 | `labview_minor_revision` | LabVIEW minor revision (defaults to `0`). |
 | `major` | Major version component. |
 | `minor` | Minor version component. |

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -104,7 +104,8 @@ That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. Th
 | Input | Description |
 | --- | --- |
 | `supported_bitness` | `32` or `64`; selects the VI Package bitness. |
-| `minimum_supported_lv_version` | LabVIEW 2021 (21.0). |
+| `labview_version` | LabVIEW 2021 (21.0). |
+| `minimum_supported_lv_version` | Deprecated. Use `labview_version`. |
 | `labview_minor_revision` | LabVIEW minor revision (defaults to `0`). |
 | `major` | Major version component. |
 | `minor` | Minor version component. |
@@ -272,7 +273,7 @@ components remain unchanged and only the build number increases.
   ```yaml
   - uses: ./.github/actions/run-unit-tests
     with:
-      minimum_supported_lv_version: ${{ matrix['lv-version'] }}
+      labview_version: ${{ matrix['lv-version'] }}
       supported_bitness:            ${{ matrix.bitness }}
   ```
 - Ensure they pass before building the `.vip`. If they fail, the script can exit with a non-zero code, stopping the workflow run.

--- a/docs/ci/actions/development-mode-toggle.md
+++ b/docs/ci/actions/development-mode-toggle.md
@@ -23,7 +23,7 @@ You do **not** need to copy/paste the entire workflow snippet here, as it’s al
    - Go to the "Actions" tab on your (or your fork's) GitHub repository.
    - Select the **"Toggle Development Mode"** workflow.
    - Click "Run workflow" and choose either `enable` or `disable` from the dropdown.
-   - LabVIEW version is fixed to **2021** (`labview_version`; `minimum_supported_lv_version` is deprecated but still accepted).
+   - LabVIEW version is fixed to **2021** (`labview_version`).
    - Choose a bitness (`bitness`, default `64`).
    - This will execute the PowerShell scripts ([`Set_Development_Mode.ps1`](../../../.github/actions/set-development-mode/Set_Development_Mode.ps1) or [`RevertDevelopmentMode.ps1`](../../../.github/actions/revert-development-mode/RevertDevelopmentMode.ps1)) on the **target self-hosted runner** (your personal machine or a shared machine).
 
@@ -35,7 +35,6 @@ You do **not** need to copy/paste the entire workflow snippet here, as it’s al
    - Use a `workflow_call` reference (detailed examples below).
    - Pass the input parameter `mode` set to `enable` or `disable`.
    - Pass `labview_version: 2021` if you include the input (other values are not supported).
-   - `minimum_supported_lv_version` is a deprecated alias.
    - Pass `bitness` (`32` or `64`) to select the LabVIEW bitness.
    - The runner that calls it will be the one switched into (or out of) dev mode.
 

--- a/docs/ci/actions/development-mode-toggle.md
+++ b/docs/ci/actions/development-mode-toggle.md
@@ -23,7 +23,7 @@ You do **not** need to copy/paste the entire workflow snippet here, as it’s al
    - Go to the "Actions" tab on your (or your fork's) GitHub repository.
    - Select the **"Toggle Development Mode"** workflow.
    - Click "Run workflow" and choose either `enable` or `disable` from the dropdown.
-   - LabVIEW version is fixed to **2021** (`minimum_supported_lv_version` remains for compatibility; keep it set to `2021`).
+   - LabVIEW version is fixed to **2021** (`labview_version`; `minimum_supported_lv_version` is deprecated but still accepted).
    - (Optional) Choose a bitness (`bitness`, default `64`).
    - This will execute the PowerShell scripts ([`Set_Development_Mode.ps1`](../../../.github/actions/set-development-mode/Set_Development_Mode.ps1) or [`RevertDevelopmentMode.ps1`](../../../.github/actions/revert-development-mode/RevertDevelopmentMode.ps1)) on the **target self-hosted runner** (your personal machine or a shared machine).
 
@@ -34,7 +34,8 @@ You do **not** need to copy/paste the entire workflow snippet here, as it’s al
 3. **Triggering from Another Workflow**
    - Use a `workflow_call` reference (detailed examples below).
    - Pass the input parameter `mode` set to `enable` or `disable`.
-   - Pass `minimum_supported_lv_version: 2021` if you include the input (other values are not supported).
+   - Pass `labview_version: 2021` if you include the input (other values are not supported).
+   - `minimum_supported_lv_version` is a deprecated alias.
    - Optionally pass `bitness` (`32` or `64`) to select the LabVIEW bitness.
    - The runner that calls it will be the one switched into (or out of) dev mode.
 
@@ -60,7 +61,7 @@ If you have another workflow file (e.g., `my-other-workflow.yml`) in the same re
             uses: ./.github/workflows/development-mode-toggle.yml
             with:
               mode: enable
-              minimum_supported_lv_version: 2021
+              labview_version: 2021
               bitness: 64
 
 1. `uses: ./.github/workflows/development-mode-toggle.yml` – Tells GitHub to run a local reusable workflow found in your repo.
@@ -83,7 +84,7 @@ If you store “Development mode toggle” in a separate public repo, you can re
             uses: <owner>/<repo>/.github/workflows/development-mode-toggle.yml@main
             with:
               mode: disable
-              minimum_supported_lv_version: 2021
+              labview_version: 2021
               bitness: 64
 
 1. Replace `<owner>/<repo>` with the actual GitHub account and repository name (for example, `ni/my-shared-workflows`).
@@ -107,7 +108,7 @@ If a collaborator forked your original repo, they might keep the workflow in the
             uses: <your-fork>/<repo>/.github/workflows/development-mode-toggle.yml@my-feature-branch
             with:
               mode: enable
-              minimum_supported_lv_version: 2021
+              labview_version: 2021
               bitness: 64
 
 Here, you might see something like `githubuser/labview-icon-editor-fork/.github/workflows/development-mode-toggle.yml@feature-xyz`. Again, you pass the `mode` input as needed. Whenever upstream changes are made to the scripts, the fork owner can **pull** to update their local `.github/workflows/development-mode-toggle.yml` file.

--- a/docs/ci/actions/development-mode-toggle.md
+++ b/docs/ci/actions/development-mode-toggle.md
@@ -24,7 +24,7 @@ You do **not** need to copy/paste the entire workflow snippet here, as it’s al
    - Select the **"Toggle Development Mode"** workflow.
    - Click "Run workflow" and choose either `enable` or `disable` from the dropdown.
    - LabVIEW version is fixed to **2021** (`labview_version`; `minimum_supported_lv_version` is deprecated but still accepted).
-   - (Optional) Choose a bitness (`bitness`, default `64`).
+   - Choose a bitness (`bitness`, default `64`).
    - This will execute the PowerShell scripts ([`Set_Development_Mode.ps1`](../../../.github/actions/set-development-mode/Set_Development_Mode.ps1) or [`RevertDevelopmentMode.ps1`](../../../.github/actions/revert-development-mode/RevertDevelopmentMode.ps1)) on the **target self-hosted runner** (your personal machine or a shared machine).
 
 2. **Important Note for Testing**
@@ -36,7 +36,7 @@ You do **not** need to copy/paste the entire workflow snippet here, as it’s al
    - Pass the input parameter `mode` set to `enable` or `disable`.
    - Pass `labview_version: 2021` if you include the input (other values are not supported).
    - `minimum_supported_lv_version` is a deprecated alias.
-   - Optionally pass `bitness` (`32` or `64`) to select the LabVIEW bitness.
+   - Pass `bitness` (`32` or `64`) to select the LabVIEW bitness.
    - The runner that calls it will be the one switched into (or out of) dev mode.
 
 ## 3. Examples: Calling This Workflow

--- a/docs/ci/actions/injecting-repo-org-to-vi-package.md
+++ b/docs/ci/actions/injecting-repo-org-to-vi-package.md
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-lvlibp
         with:
-          minimum_supported_lv_version: 2021
+          labview_version: 2021
           supported_bitness: ${{ matrix.bitness }}
           repo_root: ${{ github.workspace }}
           major: ${{ needs.version.outputs.MAJOR }}
@@ -97,7 +97,7 @@ jobs:
       - uses: ./.github/actions/modify-vipb-display-info
         with:
           vipb_path: .github/actions/build-vi-package/NI Icon editor.vipb
-          minimum_supported_lv_version: 2021
+          labview_version: 2021
           labview_minor_revision: 0
           repo_root: ${{ github.workspace }}
           supported_bitness: 64
@@ -110,7 +110,7 @@ jobs:
           display_information_json: ${{ steps.display-info.outputs.json }}
       - uses: ./.github/actions/build-vi-package
         with:
-          minimum_supported_lv_version: 2021
+          labview_version: 2021
           labview_minor_revision: 0
           supported_bitness: 64
           major: ${{ needs.version.outputs.MAJOR }}

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -155,6 +155,16 @@ With your runner online:
 5. **Review the `.vip`**
    - Download from **Artifacts**. Publishing to a GitHub release requires a separate workflow.
 
+#### Worktree naming (CI)
+CI jobs run from short-path worktrees to avoid Windows path limits. Each job creates:
+- `ci-<jobhash>-<bitness>-<runid>-<attempt>`
+- `jobhash` = first 8 chars of SHA1(`GITHUB_JOB`) to keep job names unique.
+- Example: `C:\dev\ci-D170BDEE-64-21534416929-1`
+
+The workflow exports:
+- `REPO_ROOT` → worktree path (authoritative for scripts)
+- `PROJECT_PATH` → `$REPO_ROOT\lv_icon_editor.lvproj`
+
 
 <a name="example-developer-workflow"></a>
 ### 5. Example Developer Workflow

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -166,6 +166,16 @@ The workflow exports:
 - `REPO_ROOT` → worktree path (authoritative for scripts)
 - `PROJECT_PATH` → `$REPO_ROOT\lv_icon_editor.lvproj`
 
+#### Run CI for a specific commit (workflow_dispatch)
+If you need deterministic runs for a specific commit, use the helper script:
+```
+pwsh -NoProfile -File .\Tooling\Run-CICompositeForCommit.ps1 -Sha <commit>
+```
+
+Notes:
+- The script creates a temporary `ci-run/<shortsha>` branch and dispatches the workflow on it.
+- Use `-CleanupRemote` to delete the temporary branch after dispatch.
+
 
 <a name="example-developer-workflow"></a>
 ### 5. Example Developer Workflow

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -85,7 +85,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
 1. **Development Mode Toggle**  
    - `mode: enable` → calls `Set_Development_Mode.ps1`.  
    - `mode: disable` → calls `RevertDevelopmentMode.ps1`.  
-   - Optional `labview_version` (default `2021`, only `2021` is supported; `minimum_supported_lv_version` is deprecated).
+   - `labview_version` (default `2021`, only `2021` is supported).
    - Great for reconfiguring LabVIEW for local dev vs. distribution builds.
 
 2. **CI Pipeline (Composite)**
@@ -165,6 +165,9 @@ CI jobs run from short-path worktrees to avoid Windows path limits. Each job cre
 The workflow exports:
 - `REPO_ROOT` → worktree path (authoritative for scripts)
 - `PROJECT_PATH` → `$REPO_ROOT\lv_icon_editor.lvproj`
+- `LABVIEW_VERSION_YEAR` / `LABVIEW_MINOR_REVISION` → derived from `.lvversion` (e.g., `21.0` → `2021` and minor `0`)
+
+CI treats `.lvversion` in `REPO_ROOT` as the canonical LabVIEW version for the run.
 
 #### Run CI for a specific commit (workflow_dispatch)
 If you need deterministic runs for a specific commit, use the helper script:

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -85,7 +85,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
 1. **Development Mode Toggle**  
    - `mode: enable` → calls `Set_Development_Mode.ps1`.  
    - `mode: disable` → calls `RevertDevelopmentMode.ps1`.  
-   - Optional `minimum_supported_lv_version` (default `2021`, only `2021` is supported).
+   - Optional `labview_version` (default `2021`, only `2021` is supported; `minimum_supported_lv_version` is deprecated).
    - Great for reconfiguring LabVIEW for local dev vs. distribution builds.
 
 2. **CI Pipeline (Composite)**
@@ -138,7 +138,7 @@ With your runner online:
 
 1. **Enable Dev Mode** (if needed)
    - **Actions → Development Mode Toggle**, set `mode: enable`.
-   - `minimum_supported_lv_version` is fixed to `2021` if provided.
+   - `labview_version` is fixed to `2021` if provided.
 
 2. **Run Tests via CI Pipeline (Composite)**
    - Execute the workflow and review the **test** job logs to confirm all unit tests pass.
@@ -150,7 +150,7 @@ With your runner online:
 
 4. **Disable Dev Mode** (if used)  
    - `mode: disable` reverts your LabVIEW environment.
-   - Keep `minimum_supported_lv_version` set to `2021` if you include it.
+   - Keep `labview_version` set to `2021` if you include it.
 
 5. **Review the `.vip`**
    - Download from **Artifacts**. Publishing to a GitHub release requires a separate workflow.

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -159,6 +159,7 @@ With your runner online:
 CI jobs run from short-path worktrees to avoid Windows path limits. Each job creates:
 - `ci-<jobhash>-<bitness>-<runid>-<attempt>`
 - `jobhash` = first 8 chars of SHA1(`GITHUB_JOB`) to keep job names unique.
+- Some workflows insert an extra variant token (e.g. LabVIEW version) between `<jobhash>` and `<bitness>`.
 - Example: `C:\dev\ci-D170BDEE-64-21534416929-1`
 
 The workflow exports:

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -142,7 +142,7 @@ You’ll typically name the workflow file **`development-mode-toggle.yml`**. Its
 1. **Trigger Manually**  
    - Go to the **Actions** tab, select the "Development Mode Toggle" workflow, click "Run workflow."  
    - Choose `enable` or `disable` to run the corresponding PowerShell script (`Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`).  
-   - LabVIEW version is fixed to **2021** (`labview_version`; `minimum_supported_lv_version` is deprecated).  
+   - LabVIEW version is fixed to **2021** (`labview_version`).  
    - Choose a bitness (`bitness`, default `64`).  
    - The workflow runs on your self-hosted runner (e.g., labeled `self-hosted-windows-lv`).  
 

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -143,7 +143,7 @@ You’ll typically name the workflow file **`development-mode-toggle.yml`**. Its
    - Go to the **Actions** tab, select the "Development Mode Toggle" workflow, click "Run workflow."  
    - Choose `enable` or `disable` to run the corresponding PowerShell script (`Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`).  
    - LabVIEW version is fixed to **2021** (`labview_version`; `minimum_supported_lv_version` is deprecated).  
-   - (Optional) Choose a bitness (`bitness`, default `64`).  
+   - Choose a bitness (`bitness`, default `64`).  
    - The workflow runs on your self-hosted runner (e.g., labeled `self-hosted-windows-lv`).  
 
 2. **Important Note for Testing**  
@@ -153,7 +153,7 @@ You’ll typically name the workflow file **`development-mode-toggle.yml`**. Its
 3. **Trigger from Another Workflow**  
    - You can call this workflow using `workflow_call`. Pass the input parameter `mode` = `enable` or `disable`.  
    - Pass `labview_version: 2021` if you include the input (other values are not supported).  
-   - Optionally pass `bitness` (`32` or `64`) to select the LabVIEW bitness.  
+   - Pass `bitness` (`32` or `64`) to select the LabVIEW bitness.  
    - The same runner used by the calling job is toggled accordingly.
 
 <a name="413-examples-calling-this-workflow"></a>

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -142,7 +142,7 @@ You’ll typically name the workflow file **`development-mode-toggle.yml`**. Its
 1. **Trigger Manually**  
    - Go to the **Actions** tab, select the "Development Mode Toggle" workflow, click "Run workflow."  
    - Choose `enable` or `disable` to run the corresponding PowerShell script (`Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`).  
-   - LabVIEW version is fixed to **2021** (`minimum_supported_lv_version` remains for compatibility; keep it set to `2021`).  
+   - LabVIEW version is fixed to **2021** (`labview_version`; `minimum_supported_lv_version` is deprecated).  
    - (Optional) Choose a bitness (`bitness`, default `64`).  
    - The workflow runs on your self-hosted runner (e.g., labeled `self-hosted-windows-lv`).  
 
@@ -152,7 +152,7 @@ You’ll typically name the workflow file **`development-mode-toggle.yml`**. Its
 
 3. **Trigger from Another Workflow**  
    - You can call this workflow using `workflow_call`. Pass the input parameter `mode` = `enable` or `disable`.  
-   - Pass `minimum_supported_lv_version: 2021` if you include the input (other values are not supported).  
+   - Pass `labview_version: 2021` if you include the input (other values are not supported).  
    - Optionally pass `bitness` (`32` or `64`) to select the LabVIEW bitness.  
    - The same runner used by the calling job is toggled accordingly.
 
@@ -173,7 +173,7 @@ jobs:
         uses: ./.github/workflows/development-mode-toggle.yml
         with:
           mode: enable
-          minimum_supported_lv_version: 2021
+          labview_version: 2021
           bitness: 64
 ```
 
@@ -191,7 +191,7 @@ jobs:
         uses: <owner>/<repo>/.github/workflows/development-mode-toggle.yml@main
         with:
           mode: disable
-          minimum_supported_lv_version: 2021
+          labview_version: 2021
           bitness: 64
 ```
 
@@ -209,7 +209,7 @@ jobs:
         uses: <your-fork>/<repo>/.github/workflows/development-mode-toggle.yml@my-feature-branch
         with:
           mode: enable
-          minimum_supported_lv_version: 2021
+          labview_version: 2021
           bitness: 64
 ```
 


### PR DESCRIPTION
## Summary
- CI + local derive the LabVIEW version from `.lvversion` (21.0) and export `LABVIEW_VERSION_YEAR` / `LABVIEW_MINOR_REVISION` via `Tooling/New-CIWorktreeForJob.ps1`.
- Centralize short-path worktree creation for Windows jobs; export `REPO_ROOT` / `PROJECT_PATH` and run steps from the worktree.
- Harden worktree env paths:
  - Normalize `REPO_ROOT`/`PROJECT_PATH` (no double slashes) and fail fast if the worktree/project path does not exist.
  - Add retention cleanup for stale `ci-*` worktrees (defaults to 7 days on GitHub Actions; override with `LVIE_WORKTREE_RETENTION_DAYS`).
- Harden VI Package builds:
  - Remove the License Agreement field from generated display-info JSON and clear `License_Agreement_Filepath` in the VIPB (this repo does not provide an EULA/License Agreement file).
  - Exclude `TestResults/` from VIP source files to avoid shipping CI artifacts and inflating build times.
  - Add `Tooling/Inspect-VipPackage.ps1` + CI step to inspect `.vip` contents (internal path lengths + suspicious absolute/runner fragments).

## Why
- Fixes Build VI Package failures caused by a missing license-agreement file.
- Avoids confusing path logs and enforces a strict, portable `REPO_ROOT`/`PROJECT_PATH` contract.
- Reduces CI flakiness from long/unique worktree paths (cache misses) and prevents the worktree root (`w`) from growing unbounded when runs are cancelled.

## Testing
- Local FULL parity (both 64/32):
  - `pwsh -NoProfile -ExecutionPolicy Bypass -File .\Tooling\Run-CICompositeLocal.ps1 -LabVIEWVersion 2021 -EnsureCleanState`
- Pester:
  - `pwsh -NoProfile -Command "Invoke-Pester -Path .\Test\ModifyVIPBDisplayInfo.Tests.ps1 -CI"`
- VIP inspection:
  - `pwsh -NoProfile -File .\Tooling\Inspect-VipPackage.ps1 -VipPath .\builds\"VI Package"\*.vip`
- Worktree env smoke (local):
  - `pwsh -NoProfile -File .\Tooling\New-CIWorktreeForJob.ps1 -Bitness 64 -Variant smoke`
