### PR TITLE
Add worktree guardrails and artifact isolation

### DIFF
--- a/.github/actions/add-token-to-labview/AddTokenToLabVIEW.ps1
+++ b/.github/actions/add-token-to-labview/AddTokenToLabVIEW.ps1
@@ -8,7 +8,7 @@
     LabVIEW to locate local project libraries during development or builds.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     Target bitness of the LabVIEW environment ("32" or "64").
@@ -21,15 +21,30 @@
 #>
 
 param(
-    [ValidateSet('2021')]
+    [Alias('LabVIEWVersion')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$MinimumSupportedLVVersion = '2021',
     [string]$SupportedBitness,
     [string]$RepoRoot
 )
 
+$labviewYear = $MinimumSupportedLVVersion
+if ($RepoRoot) {
+    $versionHelper = Join-Path -Path $RepoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
+    if (Test-Path -Path $versionHelper) {
+        . $versionHelper
+        $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $RepoRoot
+        $labviewYear = $versionInfo.Year
+    }
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
+
 # Construct the command
 $script = @"
-g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness -v "$RepoRoot\Tooling\deployment\Create_LV_INI_Token.vi" -- "LabVIEW" "Localhost.LibraryPaths" "$RepoRoot"
+g-cli --lv-ver $labviewYear --arch $SupportedBitness -v "$RepoRoot\Tooling\deployment\Create_LV_INI_Token.vi" -- "LabVIEW" "Localhost.LibraryPaths" "$RepoRoot"
 "@
 
 Write-Output "Executing the following command:"

--- a/.github/actions/add-token-to-labview/action.yml
+++ b/.github/actions/add-token-to-labview/action.yml
@@ -22,7 +22,7 @@ runs:
           -RepoRoot "${{ inputs.repo_root }}"
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'

--- a/.github/actions/apply-vipc/ApplyVIPC.ps1
+++ b/.github/actions/apply-vipc/ApplyVIPC.ps1
@@ -39,14 +39,24 @@ try {
     $ResolvedRepoRoot = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
     Write-Verbose "ResolvedRepoRoot: $ResolvedRepoRoot"
 
-    $worktreeGuard = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
-    if (Test-Path -Path $worktreeGuard) {
-        . $worktreeGuard
-        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $ResolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'ApplyVIPC'
-        Write-WorktreeContext -RepoRoot $ResolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'ApplyVIPC'
-        if ($resolvedWorktreeRoot) {
-            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    $preflightScript = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\Invoke-Preflight.ps1'
+    if (Test-Path -Path $preflightScript) {
+        . $preflightScript
+        $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+        $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $ResolvedRepoRoot -Path $PSCommandPath } else { $null }
+        $preflight = Invoke-Preflight `
+            -RepoRoot $ResolvedRepoRoot `
+            -WorktreeRoot $WorktreeRoot `
+            -LabVIEWVersion $MinimumSupportedLVVersion `
+            -LabVIEWBitness $SupportedBitness `
+            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+            -AutoWorktree:$false `
+            -ScriptPath $relativeScript `
+            -ScriptArguments $scriptArgs
+        if ($preflight.Reinvoked) {
+            return
         }
+        $ResolvedRepoRoot = $preflight.RepoRoot
     }
 
     Write-Verbose "Building full path for the .vipc file..."

--- a/.github/actions/apply-vipc/ApplyVIPC.ps1
+++ b/.github/actions/apply-vipc/ApplyVIPC.ps1
@@ -18,7 +18,9 @@ Param (
     [ValidateSet('32', '64')]
     [string]$SupportedBitness,
     [string]$RepoRoot,
-    [string]$VIPCPath
+    [string]$VIPCPath,
+    [string]$WorktreeRoot,
+    [switch]$SkipWorktreeRootCheck
 )
 
 Write-Verbose "Script Name: $($MyInvocation.MyCommand.Definition)"
@@ -34,8 +36,18 @@ Write-Verbose " - VIPCPath:                  $VIPCPath"
 # -------------------------
 try {
     Write-Verbose "Attempting to resolve the 'RepoRoot'..."
-    $ResolvedRepoRoot = Resolve-Path -Path $RepoRoot -ErrorAction Stop
+    $ResolvedRepoRoot = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
     Write-Verbose "ResolvedRepoRoot: $ResolvedRepoRoot"
+
+    $worktreeGuard = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
+    if (Test-Path -Path $worktreeGuard) {
+        . $worktreeGuard
+        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $ResolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'ApplyVIPC'
+        Write-WorktreeContext -RepoRoot $ResolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'ApplyVIPC'
+        if ($resolvedWorktreeRoot) {
+            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+        }
+    }
 
     Write-Verbose "Building full path for the .vipc file..."
     $ResolvedVIPCPath = Join-Path -Path $ResolvedRepoRoot -ChildPath $VIPCPath -ErrorAction Stop

--- a/.github/actions/apply-vipc/ApplyVIPC.ps1
+++ b/.github/actions/apply-vipc/ApplyVIPC.ps1
@@ -9,9 +9,11 @@
 
 [CmdletBinding()]  # Enables -Verbose and other common parameters
 Param (
-    [ValidateSet('2021')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$MinimumSupportedLVVersion = '2021',
-    [ValidateSet('2021')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$VIP_LVVersion = '2021',
     [ValidateSet('32', '64')]
     [string]$SupportedBitness,
@@ -63,23 +65,30 @@ catch {
 # 2) Build LabVIEW Version Strings
 # -------------------------
 Write-Verbose "Determining LabVIEW version strings..."
-switch ("$VIP_LVVersion-$SupportedBitness") {
-    "2021-64" { $VIP_LVVersion_A = "21.0 (64-bit)" }
-    "2021-32" { $VIP_LVVersion_A = "21.0" }
-    default {
-        Write-Error "Only LabVIEW 2021 (21.0) is supported for VIPC application."
-        exit 1
+
+function Get-VipmVersionString {
+    param(
+        [string]$NumericVersion,
+        [string]$Bitness
+    )
+
+    if ($Bitness -eq '64') {
+        return "$NumericVersion (64-bit)"
     }
+    return $NumericVersion
 }
 
-switch ("$MinimumSupportedLVVersion-$SupportedBitness") {
-    "2021-64" { $VIP_LVVersion_B = "21.0 (64-bit)" }
-    "2021-32" { $VIP_LVVersion_B = "21.0" }
-    default {
-        Write-Error "Only LabVIEW 2021 (21.0) is supported for VIPC application."
-        exit 1
-    }
+$versionHelper = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
+if (-not (Test-Path -Path $versionHelper)) {
+    throw "LabVIEW version helper not found at $versionHelper"
 }
+. $versionHelper
+
+$minInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $ResolvedRepoRoot
+$vipInfo = Get-LabVIEWVersionInfo -VersionInput $VIP_LVVersion -RepoRoot $ResolvedRepoRoot
+
+$VIP_LVVersion_B = Get-VipmVersionString -NumericVersion $minInfo.NumericVersion -Bitness $SupportedBitness
+$VIP_LVVersion_A = Get-VipmVersionString -NumericVersion $vipInfo.NumericVersion -Bitness $SupportedBitness
 
 Write-Output "Applying dependencies for LabVIEW $VIP_LVVersion_B..."
 Write-Verbose "VIP_LVVersion_A (for primary LVVersion): $VIP_LVVersion_A"
@@ -90,7 +99,7 @@ Write-Verbose "VIP_LVVersion_B (for minimum LVVersion): $VIP_LVVersion_B"
 # -------------------------
 Write-Verbose "Constructing g-cli vipc command list..."
 $vipVersions = @($VIP_LVVersion_B)
-if ($VIP_LVVersion -ne $MinimumSupportedLVVersion) {
+if ($vipInfo.NumericVersion -ne $minInfo.NumericVersion -or $vipInfo.Year -ne $minInfo.Year) {
     Write-Verbose "VIP_LVVersion and MinimumSupportedLVVersion differ; adding commands for $VIP_LVVersion_A..."
     $vipVersions += $VIP_LVVersion_A
 }
@@ -100,7 +109,7 @@ if ($VIP_LVVersion -ne $MinimumSupportedLVVersion) {
 # -------------------------
 try {
     foreach ($vipVersion in $vipVersions) {
-        $targetLvVer = if ($vipVersion -eq $VIP_LVVersion_A) { $VIP_LVVersion } else { $MinimumSupportedLVVersion }
+        $targetLvVer = if ($vipVersion -eq $VIP_LVVersion_A) { $vipInfo.Year } else { $minInfo.Year }
         $vipcArgs = @(
             '--lv-ver', $targetLvVer,
             '--arch', $SupportedBitness,

--- a/.github/actions/apply-vipc/action.yml
+++ b/.github/actions/apply-vipc/action.yml
@@ -24,10 +24,10 @@ runs:
           -VIPCPath "${{ inputs.vipc_path }}"
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   vip_lv_version:
-    description: 'VIPC LabVIEW version (2021 / 21.0)'
+    description: 'VIPC LabVIEW version (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'

--- a/.github/actions/build-lvlibp/Build_lvlibp.ps1
+++ b/.github/actions/build-lvlibp/Build_lvlibp.ps1
@@ -56,14 +56,25 @@ $resolvedRepoRoot = $RepoRoot
 if ($resolvedRepoRoot) {
     $resolvedRepoRoot = (Resolve-Path -Path $resolvedRepoRoot -ErrorAction Stop).Path
     $RepoRoot = $resolvedRepoRoot
-    $worktreeGuard = Join-Path -Path $resolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
-    if (Test-Path -Path $worktreeGuard) {
-        . $worktreeGuard
-        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $resolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Build_lvlibp'
-        Write-WorktreeContext -RepoRoot $resolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Build_lvlibp'
-        if ($resolvedWorktreeRoot) {
-            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    $preflightScript = Join-Path -Path $resolvedRepoRoot -ChildPath 'Tooling\Invoke-Preflight.ps1'
+    if (Test-Path -Path $preflightScript) {
+        . $preflightScript
+        $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+        $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $resolvedRepoRoot -Path $PSCommandPath } else { $null }
+        $preflight = Invoke-Preflight `
+            -RepoRoot $resolvedRepoRoot `
+            -WorktreeRoot $WorktreeRoot `
+            -LabVIEWVersion $MinimumSupportedLVVersion `
+            -LabVIEWBitness $SupportedBitness `
+            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+            -AutoWorktree:$false `
+            -ScriptPath $relativeScript `
+            -ScriptArguments $scriptArgs
+        if ($preflight.Reinvoked) {
+            return
         }
+        $resolvedRepoRoot = $preflight.RepoRoot
+        $RepoRoot = $resolvedRepoRoot
     }
 }
 

--- a/.github/actions/build-lvlibp/Build_lvlibp.ps1
+++ b/.github/actions/build-lvlibp/Build_lvlibp.ps1
@@ -40,6 +40,8 @@ param(
     [string]$MinimumSupportedLVVersion = '2021',
     [string]$SupportedBitness,
     [string]$RepoRoot,
+    [string]$WorktreeRoot,
+    [switch]$SkipWorktreeRootCheck,
     [Int32]$Major,
     [Int32]$Minor,
     [Int32]$Patch,
@@ -49,6 +51,21 @@ param(
 
 Write-Output "PPL Version: $Major.$Minor.$Patch.$Build"
 Write-Output "Commit: $Commit"
+
+$resolvedRepoRoot = $RepoRoot
+if ($resolvedRepoRoot) {
+    $resolvedRepoRoot = (Resolve-Path -Path $resolvedRepoRoot -ErrorAction Stop).Path
+    $RepoRoot = $resolvedRepoRoot
+    $worktreeGuard = Join-Path -Path $resolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
+    if (Test-Path -Path $worktreeGuard) {
+        . $worktreeGuard
+        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $resolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Build_lvlibp'
+        Write-WorktreeContext -RepoRoot $resolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Build_lvlibp'
+        if ($resolvedWorktreeRoot) {
+            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+        }
+    }
+}
 
 $labviewYear = $MinimumSupportedLVVersion
 if ($RepoRoot) {

--- a/.github/actions/build-lvlibp/Build_lvlibp.ps1
+++ b/.github/actions/build-lvlibp/Build_lvlibp.ps1
@@ -7,7 +7,7 @@
     g-cli, embedding the provided version information and commit identifier.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     Bitness of the LabVIEW environment ("32" or "64").
@@ -34,7 +34,9 @@
     .\Build_lvlibp.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RepoRoot "C:\labview-icon-editor" -Major 1 -Minor 0 -Patch 0 -Build 0 -Commit "Placeholder"
 #>
 param(
-    [ValidateSet('2021')]
+    [Alias('LabVIEWVersion')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$MinimumSupportedLVVersion = '2021',
     [string]$SupportedBitness,
     [string]$RepoRoot,
@@ -48,9 +50,22 @@ param(
 Write-Output "PPL Version: $Major.$Minor.$Patch.$Build"
 Write-Output "Commit: $Commit"
 
+$labviewYear = $MinimumSupportedLVVersion
+if ($RepoRoot) {
+    $versionHelper = Join-Path -Path $RepoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
+    if (Test-Path -Path $versionHelper) {
+        . $versionHelper
+        $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $RepoRoot
+        $labviewYear = $versionInfo.Year
+    }
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
+
 # Construct the command
 $script = @"
-g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness lvbuildspec -- -v "$Major.$Minor.$Patch.$Build" -p "$RepoRoot\lv_icon_editor.lvproj" -b "Editor Packed Library"
+g-cli --lv-ver $labviewYear --arch $SupportedBitness lvbuildspec -- -v "$Major.$Minor.$Patch.$Build" -p "$RepoRoot\lv_icon_editor.lvproj" -b "Editor Packed Library"
 "@
 Write-Output "Executing the following command:"
 Write-Output $script
@@ -60,7 +75,7 @@ Invoke-Expression $script
 
 # Check the exit code
 if ($LASTEXITCODE -ne 0) {
-    g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness QuitLabVIEW
+    g-cli --lv-ver $labviewYear --arch $SupportedBitness QuitLabVIEW
     Write-Host "Build failed with exit code $LASTEXITCODE."
     exit 1
 } else {

--- a/.github/actions/build-lvlibp/action.yml
+++ b/.github/actions/build-lvlibp/action.yml
@@ -27,7 +27,7 @@ runs:
           -Commit "${{ inputs.commit }}"
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'

--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -234,7 +234,7 @@ runs:
         Write-Host "---- end release notes ----"
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'
@@ -246,7 +246,7 @@ inputs:
     description: 'Path to the VIPB file (relative to workspace)'
     required: true
   labview_minor_revision:
-    description: 'LabVIEW minor revision (0 for 21.0)'
+    description: 'LabVIEW minor revision (e.g., 0 for 21.0)'
     required: false
     default: '0'
   major:

--- a/.github/actions/build-vip/build_vip.ps1
+++ b/.github/actions/build-vip/build_vip.ps1
@@ -89,19 +89,34 @@ catch {
     exit 1
 }
 
-# 1a) Worktree guard (optional for local runs)
-$worktreeGuard = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $ResolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'build_vip'
-    Write-WorktreeContext -RepoRoot $ResolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'build_vip'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+# 1a) Worktree preflight (optional for local runs)
+$preflightScript = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $ResolvedRepoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $ResolvedRepoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $MinimumSupportedLVVersion `
+        -LabVIEWBitness $SupportedBitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$false `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs
+    if ($preflight.Reinvoked) {
+        return
     }
+    $ResolvedRepoRoot = $preflight.RepoRoot
 }
 
 # 1b) Ensure VI Package output directory exists to avoid VIPM prompts
-$vipOutputDir = Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/VI Package"
+$artifactRoot = $env:LVIE_ARTIFACT_ROOT
+$vipOutputDir = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
+    Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/VI Package"
+} else {
+    Join-Path -Path $artifactRoot -ChildPath "builds/VI Package"
+}
 New-Item -ItemType Directory -Path $vipOutputDir -Force | Out-Null
 
 # 2) Create release notes if needed and resolve the paths
@@ -124,7 +139,11 @@ catch {
 }
 
 # 3a) Ensure build log directory exists for troubleshooting
-$LogDirectory = Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/logs"
+$LogDirectory = if ([string]::IsNullOrWhiteSpace($artifactRoot)) {
+    Join-Path -Path $ResolvedRepoRoot -ChildPath "builds/logs"
+} else {
+    Join-Path -Path $artifactRoot -ChildPath "builds/logs"
+}
 New-Item -ItemType Directory -Path $LogDirectory -Force | Out-Null
 
 # 3) Calculate the LabVIEW version string
@@ -223,3 +242,17 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Successfully built VI package: $ResolvedVIPBPath"
+
+if (-not [string]::IsNullOrWhiteSpace($artifactRoot)) {
+    try {
+        $vipCandidates = Get-ChildItem -Path $ResolvedRepoRoot -Recurse -Filter *.vip -ErrorAction SilentlyContinue
+        $latestVip = $vipCandidates | Sort-Object -Property LastWriteTime -Descending | Select-Object -First 1
+        if ($latestVip) {
+            $targetPath = Join-Path $vipOutputDir $latestVip.Name
+            Copy-Item -Path $latestVip.FullName -Destination $targetPath -Force
+            Write-Host ("Copied .vip to artifact root: {0}" -f $targetPath)
+        }
+    } catch {
+        Write-Warning ("Failed to copy .vip to artifact root: {0}" -f $_.Exception.Message)
+    }
+}

--- a/.github/actions/build-vip/build_vip.ps1
+++ b/.github/actions/build-vip/build_vip.ps1
@@ -50,6 +50,8 @@ param (
     [string]$SupportedBitness,
     [string]$RepoRoot,
     [string]$VIPBPath,
+    [string]$WorktreeRoot,
+    [switch]$SkipWorktreeRootCheck,
 
     [Alias('LabVIEWVersion')]
     [ValidateRange(2000, 2100)]
@@ -74,7 +76,7 @@ param (
 
 # 1) Resolve paths
 try {
-    $ResolvedRepoRoot = Resolve-Path -Path $RepoRoot -ErrorAction Stop
+    $ResolvedRepoRoot = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
     $ResolvedVIPBPath = Join-Path -Path $ResolvedRepoRoot -ChildPath $VIPBPath -ErrorAction Stop
 }
 catch {
@@ -85,6 +87,17 @@ catch {
     }
     $errorObject | ConvertTo-Json -Depth 10
     exit 1
+}
+
+# 1a) Worktree guard (optional for local runs)
+$worktreeGuard = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $ResolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'build_vip'
+    Write-WorktreeContext -RepoRoot $ResolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'build_vip'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
 }
 
 # 1b) Ensure VI Package output directory exists to avoid VIPM prompts

--- a/.github/actions/build-vip/build_vip.ps1
+++ b/.github/actions/build-vip/build_vip.ps1
@@ -16,10 +16,10 @@
     Relative path to the VIPB file to update.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW major version (2021 only; 21.0).
+    LabVIEW major version year (e.g., 2021).
 
 .PARAMETER LabVIEWMinorRevision
-    Minor revision number of LabVIEW (0 for 21.0).
+    Minor revision number of LabVIEW (e.g., 0 for 21.0).
 
 .PARAMETER Major
     Major version component for the package.
@@ -51,11 +51,12 @@ param (
     [string]$RepoRoot,
     [string]$VIPBPath,
 
-    [ValidateSet(2021)]
+    [Alias('LabVIEWVersion')]
+    [ValidateRange(2000, 2100)]
     [int]$MinimumSupportedLVVersion,
 
-    [ValidateSet("0")]
-    [string]$LabVIEWMinorRevision = "0",
+    [ValidateRange(0, 99)]
+    [int]$LabVIEWMinorRevision = 0,
 
     [int]$Major,
     [int]$Minor,

--- a/.github/actions/build/Build.ps1
+++ b/.github/actions/build/Build.ps1
@@ -49,7 +49,12 @@ param(
     [string]$CompanyName,
 
     [Parameter(Mandatory = $true)]
-    [string]$AuthorName
+    [string]$AuthorName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 # Helper function to verify a file/folder path exists
@@ -110,6 +115,17 @@ try {
 
     # Validate needed folders
     Assert-PathExists $RepoRoot "RepoRoot"
+    $repoRootResolved = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
+    $RepoRoot = $repoRootResolved
+    $worktreeGuard = Join-Path -Path $repoRootResolved -ChildPath 'Tooling\support\WorktreeGuard.ps1'
+    if (Test-Path -Path $worktreeGuard) {
+        . $worktreeGuard
+        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Build'
+        Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Build'
+        if ($resolvedWorktreeRoot) {
+            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+        }
+    }
     Assert-PathExists "$RepoRoot\resource\plugins" "Plugins folder"
 
     $ActionsPath = Split-Path -Parent $PSScriptRoot

--- a/.github/actions/build/Build.ps1
+++ b/.github/actions/build/Build.ps1
@@ -117,14 +117,25 @@ try {
     Assert-PathExists $RepoRoot "RepoRoot"
     $repoRootResolved = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
     $RepoRoot = $repoRootResolved
-    $worktreeGuard = Join-Path -Path $repoRootResolved -ChildPath 'Tooling\support\WorktreeGuard.ps1'
-    if (Test-Path -Path $worktreeGuard) {
-        . $worktreeGuard
-        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Build'
-        Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Build'
-        if ($resolvedWorktreeRoot) {
-            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    $preflightScript = Join-Path -Path $repoRootResolved -ChildPath 'Tooling\Invoke-Preflight.ps1'
+    if (Test-Path -Path $preflightScript) {
+        . $preflightScript
+        $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+        $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $PSCommandPath } else { $null }
+        $preflight = Invoke-Preflight `
+            -RepoRoot $repoRootResolved `
+            -WorktreeRoot $WorktreeRoot `
+            -LabVIEWVersion '2021' `
+            -LabVIEWBitness 'both' `
+            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+            -AutoWorktree:$false `
+            -ScriptPath $relativeScript `
+            -ScriptArguments $scriptArgs
+        if ($preflight.Reinvoked) {
+            return
         }
+        $repoRootResolved = $preflight.RepoRoot
+        $RepoRoot = $repoRootResolved
     }
     Assert-PathExists "$RepoRoot\resource\plugins" "Plugins folder"
 

--- a/.github/actions/close-labview/Close_LabVIEW.ps1
+++ b/.github/actions/close-labview/Close_LabVIEW.ps1
@@ -7,7 +7,7 @@
     version and bitness, ensuring the application exits cleanly.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     Bitness of the LabVIEW instance ("32" or "64").
@@ -16,7 +16,9 @@
     .\Close_LabVIEW.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64"
 #>
 param(
-    [ValidateSet('2021')]
+    [Alias('LabVIEWVersion')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$MinimumSupportedLVVersion = '2021',
     [string]$SupportedBitness,
     [ValidateRange(5, 600)]
@@ -27,6 +29,17 @@ param(
 $ErrorActionPreference = 'Stop'
 $scriptStart = Get-Date
 $metricsPathResolved = if ($MetricsPath) { $MetricsPath } elseif ($env:LABVIEW_CLOSE_METRICS_PATH) { $env:LABVIEW_CLOSE_METRICS_PATH } else { $null }
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
 
 function Ensure-CsvHeader {
     param(
@@ -61,7 +74,7 @@ function Write-CloseMetric {
     Ensure-CsvHeader -Path $metricsPathResolved -Header 'timestamp,version,bitness,had_process_before,outcome,duration_seconds'
     $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $duration = [Math]::Round(((Get-Date) - $scriptStart).TotalSeconds, 2)
-    "{0},{1},{2},{3},{4},{5}" -f $timestamp, $MinimumSupportedLVVersion, $SupportedBitness, $HadProcess, $Outcome, $duration | Add-Content -Path $metricsPathResolved
+    "{0},{1},{2},{3},{4},{5}" -f $timestamp, $labviewYear, $SupportedBitness, $HadProcess, $Outcome, $duration | Add-Content -Path $metricsPathResolved
 }
 
 function Get-LabVIEWInstallRoot {
@@ -184,15 +197,15 @@ function Wait-ForLabVIEWExit {
 }
 
 $otherInstances = Get-CimInstance Win32_Process -Filter "Name='LabVIEW.exe'" -ErrorAction SilentlyContinue |
-    Where-Object { $_.ExecutablePath -and $_.ExecutablePath -notmatch [regex]::Escape((Get-LabVIEWInstallRoot -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness)) }
+    Where-Object { $_.ExecutablePath -and $_.ExecutablePath -notmatch [regex]::Escape((Get-LabVIEWInstallRoot -Version $labviewYear -Bitness $SupportedBitness)) }
 
-$targetBefore = Get-TargetLabVIEWProcesses -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness
+$targetBefore = Get-TargetLabVIEWProcesses -Version $labviewYear -Bitness $SupportedBitness
 if (-not $targetBefore -or $targetBefore.Count -eq 0) {
     if ($otherInstances) {
-        Write-Host "No matching LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) instance found. Other LabVIEW instances are running; skipping QuitLabVIEW."
+        Write-Host "No matching LabVIEW $labviewYear ($SupportedBitness-bit) instance found. Other LabVIEW instances are running; skipping QuitLabVIEW."
     }
     else {
-        Write-Host "LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) closed or not running."
+        Write-Host "LabVIEW $labviewYear ($SupportedBitness-bit) closed or not running."
     }
     Write-CloseMetric -Outcome 'skipped' -HadProcess $false
     exit 0
@@ -200,17 +213,17 @@ if (-not $targetBefore -or $targetBefore.Count -eq 0) {
 
 $closeOutcome = 'quit'
 try {
-    Invoke-SafeQuitLabVIEW -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness
+    Invoke-SafeQuitLabVIEW -Version $labviewYear -Bitness $SupportedBitness
 }
 catch {
     Write-Warning ("QuitLabVIEW failed: {0}" -f $_.Exception.Message)
     $closeOutcome = 'error'
 }
 
-if (-not (Wait-ForLabVIEWExit -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness -TimeoutSeconds $TimeoutSeconds)) {
-    $targets = Get-TargetLabVIEWProcesses -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness
+if (-not (Wait-ForLabVIEWExit -Version $labviewYear -Bitness $SupportedBitness -TimeoutSeconds $TimeoutSeconds)) {
+    $targets = Get-TargetLabVIEWProcesses -Version $labviewYear -Bitness $SupportedBitness
     if ($targets -and $targets.Count -gt 0) {
-        Write-Warning "LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) did not exit in time; force closing by PID."
+        Write-Warning "LabVIEW $labviewYear ($SupportedBitness-bit) did not exit in time; force closing by PID."
         foreach ($proc in $targets) {
             try {
                 Stop-Process -Id $proc.ProcessId -Force -ErrorAction Stop
@@ -220,8 +233,8 @@ if (-not (Wait-ForLabVIEWExit -Version $MinimumSupportedLVVersion -Bitness $Supp
             }
         }
 
-        if (-not (Wait-ForLabVIEWExit -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness -TimeoutSeconds 15)) {
-            Write-Error "LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) did not exit after forced close."
+        if (-not (Wait-ForLabVIEWExit -Version $labviewYear -Bitness $SupportedBitness -TimeoutSeconds 15)) {
+            Write-Error "LabVIEW $labviewYear ($SupportedBitness-bit) did not exit after forced close."
             Write-CloseMetric -Outcome 'error' -HadProcess $true
             exit 1
         }
@@ -229,5 +242,5 @@ if (-not (Wait-ForLabVIEWExit -Version $MinimumSupportedLVVersion -Bitness $Supp
     }
 }
 
-Write-Host "LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) closed or not running."
+Write-Host "LabVIEW $labviewYear ($SupportedBitness-bit) closed or not running."
 Write-CloseMetric -Outcome $closeOutcome -HadProcess $true

--- a/.github/actions/close-labview/action.yml
+++ b/.github/actions/close-labview/action.yml
@@ -23,7 +23,7 @@ runs:
           -TimeoutSeconds ${{ inputs.timeout_seconds }}
 inputs:
   labview_version:
-    description: 'LabVIEW version to close (2021/21.0 only).'
+    description: 'LabVIEW version to close (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'

--- a/.github/actions/icon-editor-files-in-lv-installation/Compare-IconEditorFilesCsv.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Compare-IconEditorFilesCsv.ps1
@@ -12,7 +12,11 @@ param(
 
     [switch]$IncludeGitMetadata,
 
-    [string]$SummaryTitle = 'Icon Editor Files Diff'
+    [string]$SummaryTitle = 'Icon Editor Files Diff',
+
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -221,14 +225,22 @@ if (-not (Ensure-SummaryFile -SummaryPath $summaryPath)) {
     return
 }
 
-$repoRootResolved = $null
+$repoRootResolved = Resolve-RepoRoot -PathOverride $RepoRoot
+$worktreeGuard = Join-Path $repoRootResolved 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Compare-IconEditorFilesCsv'
+    Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Compare-IconEditorFilesCsv'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $script:RepoRootResolved = $null
 $script:GitEnabled = $false
 $script:GitMetadataCache = @{}
 $gitColumns = @()
 
 if ($IncludeGitMetadata) {
-    $repoRootResolved = Resolve-RepoRoot -PathOverride $RepoRoot
     if ($repoRootResolved -and (Get-Command git -ErrorAction SilentlyContinue)) {
         $insideRepo = & git -C $repoRootResolved rev-parse --is-inside-work-tree 2>$null
         if ($LASTEXITCODE -eq 0 -and $insideRepo -eq 'true') {

--- a/.github/actions/icon-editor-files-in-lv-installation/Compare-IconEditorFilesCsv.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Compare-IconEditorFilesCsv.ps1
@@ -226,14 +226,24 @@ if (-not (Ensure-SummaryFile -SummaryPath $summaryPath)) {
 }
 
 $repoRootResolved = Resolve-RepoRoot -PathOverride $RepoRoot
-$worktreeGuard = Join-Path $repoRootResolved 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Compare-IconEditorFilesCsv'
-    Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Compare-IconEditorFilesCsv'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$preflightScript = Join-Path $repoRootResolved 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRootResolved `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion '' `
+        -LabVIEWBitness '' `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$false `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRootResolved = $preflight.RepoRoot
 }
 $script:RepoRootResolved = $null
 $script:GitEnabled = $false

--- a/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
@@ -203,14 +203,24 @@ try {
     }
 
     $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
-    $worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-    if (Test-Path -Path $worktreeGuard) {
-        . $worktreeGuard
-        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Invoke-GetPathsToIconEditorFilesInLVInstallationCLI'
-        Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Invoke-GetPathsToIconEditorFilesInLVInstallationCLI'
-        if ($resolvedWorktreeRoot) {
-            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    $preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+    if (Test-Path -Path $preflightScript) {
+        . $preflightScript
+        $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+        $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+        $preflight = Invoke-Preflight `
+            -RepoRoot $repoRoot `
+            -WorktreeRoot $WorktreeRoot `
+            -LabVIEWVersion $LVVersion `
+            -LabVIEWBitness $Arch `
+            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+            -AutoWorktree:$false `
+            -ScriptPath $relativeScript `
+            -ScriptArguments $scriptArgs
+        if ($preflight.Reinvoked) {
+            return
         }
+        $repoRoot = $preflight.RepoRoot
     }
     $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
     if (Test-Path -Path $versionHelper) {
@@ -226,7 +236,11 @@ try {
         throw "VI not found: $viPath"
     }
 
-    $csvPath = Resolve-CsvPath -Root $repoRoot -FileName $CsvFileName
+    $csvRoot = if ([string]::IsNullOrWhiteSpace($env:LVIE_ARTIFACT_ROOT)) { $repoRoot } else { $env:LVIE_ARTIFACT_ROOT }
+    if (-not (Test-Path -Path $csvRoot)) {
+        $null = New-Item -ItemType Directory -Path $csvRoot -Force
+    }
+    $csvPath = Resolve-CsvPath -Root $csvRoot -FileName $CsvFileName
     $bitnessCsvName = "{0}_{1}.csv" -f $diagnosticsBaseName, $Arch
     $bitnessCsvNameNoExt = "{0}_{1}" -f $diagnosticsBaseName, $Arch
     $defaultCsvPath = Join-Path $repoRoot $defaultCsvName

--- a/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
@@ -2,7 +2,6 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [ValidateSet('2021')]
     [string]$LVVersion,
 
     [Parameter(Mandatory)]
@@ -24,6 +23,7 @@ $ErrorActionPreference = 'Stop'
 $headers = @('File Path', 'Bytes', 'Last modified')
 $diagnosticsBaseName = 'Icon_Editor_Files_In_LV_Installation_Diagnostics'
 $defaultCsvName = "$diagnosticsBaseName.csv"
+$labviewYear = $LVVersion
 
 function Resolve-RepoRoot {
     param(
@@ -104,7 +104,7 @@ function Invoke-IconEditorDiagnostics {
     }
 
     $gCliArgs = @(
-        '--lv-ver', $LVVersion,
+        '--lv-ver', $labviewYear,
         '--arch', $Arch
     )
 
@@ -183,7 +183,7 @@ function Write-GitHubOutputs {
 
 function Safe-QuitLabVIEW {
     try {
-        & g-cli --lv-ver $LVVersion --arch $Arch QuitLabVIEW | Out-Null
+        & g-cli --lv-ver $labviewYear --arch $Arch QuitLabVIEW | Out-Null
     }
     catch {
         Write-Warning ("Failed to close LabVIEW: {0}" -f $_.Exception.Message)
@@ -199,6 +199,15 @@ try {
     }
 
     $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+    $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+    if (Test-Path -Path $versionHelper) {
+        . $versionHelper
+        $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LVVersion -RepoRoot $repoRoot
+        $labviewYear = $versionInfo.Year
+    }
+    if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+        $labviewYear = '2021'
+    }
     $viPath = Join-Path $repoRoot 'Tooling\GetPathsToIconEditorFilesInLVInstallationCLI.vi'
     if (-not (Test-Path -Path $viPath)) {
         throw "VI not found: $viPath"

--- a/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Invoke-GetPathsToIconEditorFilesInLVInstallationCLI.ps1
@@ -15,7 +15,11 @@ param(
 
     [string]$ProjectFile = '',
 
-    [string]$SummaryTitle = 'Icon Editor Files in LabVIEW Installation'
+    [string]$SummaryTitle = 'Icon Editor Files in LabVIEW Installation',
+
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -199,6 +203,15 @@ try {
     }
 
     $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+    $worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+    if (Test-Path -Path $worktreeGuard) {
+        . $worktreeGuard
+        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Invoke-GetPathsToIconEditorFilesInLVInstallationCLI'
+        Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Invoke-GetPathsToIconEditorFilesInLVInstallationCLI'
+        if ($resolvedWorktreeRoot) {
+            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+        }
+    }
     $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
     if (Test-Path -Path $versionHelper) {
         . $versionHelper

--- a/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
@@ -189,14 +189,24 @@ if (-not (Test-Path -Path $CsvPath)) {
 }
 
 $repoRootResolved = Resolve-RepoRoot -PathOverride $RepoRoot
-$worktreeGuard = Join-Path $repoRootResolved 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Validate-IconEditorDiagnostics'
-    Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Validate-IconEditorDiagnostics'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$preflightScript = Join-Path $repoRootResolved 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRootResolved `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $LabVIEWVersion `
+        -LabVIEWBitness $Bitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$false `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRootResolved = $preflight.RepoRoot
 }
 $repoRootNormalized = Normalize-Path -Path $repoRootResolved
 if (-not $repoRootNormalized) {

--- a/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
@@ -12,7 +12,8 @@ param(
     [ValidateSet('32', '64')]
     [string]$Bitness,
 
-    [ValidateSet('2021')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$LabVIEWVersion = '2021',
 
     [Parameter(Mandatory)]
@@ -189,6 +190,17 @@ if (-not $repoRootNormalized) {
     throw "Unable to normalize RepoRoot: $repoRootResolved"
 }
 
+$versionHelper = Join-Path $repoRootResolved 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $LabVIEWVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $repoRootResolved
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
+
 $separator = [System.IO.Path]::DirectorySeparatorChar
 if (-not $repoRootNormalized.EndsWith($separator)) {
     $repoRootNormalized += $separator
@@ -202,9 +214,9 @@ if (-not $rows -or $rows.Count -eq 0) {
 $repoRows = $rows | Where-Object { Test-PathUnderRoot -Path $_.'File Path' -Root $repoRootNormalized }
 $iconApiRows = $rows | Where-Object { $_.'File Path' -like "*\vi.lib\LabVIEW Icon API\*" }
 
-$installRoot = Get-LabVIEWInstallRoot -Version $LabVIEWVersion -Bitness $Bitness
+$installRoot = Get-LabVIEWInstallRoot -Version $labviewYear -Bitness $Bitness
 if (-not $installRoot) {
-    throw "LabVIEW $LabVIEWVersion ($Bitness-bit) install not found."
+    throw "LabVIEW $labviewYear ($Bitness-bit) install not found."
 }
 
 $iconApiDir = Join-Path $installRoot 'vi.lib\LabVIEW Icon API'
@@ -221,7 +233,7 @@ $iniHasRepoRoot = Test-LibraryPathContainsRepoRoot -IniPath $iniPath -RepoRoot $
 
 Write-Host "Mode: $Mode"
 Write-Host "Bitness: $Bitness"
-Write-Host "LabVIEW version: $LabVIEWVersion"
+Write-Host "LabVIEW version: $labviewYear"
 Write-Host "Repo root: $repoRootResolved"
 Write-Host "LabVIEW install root: $installRoot"
 Write-Host ("Total rows: {0}" -f $rows.Count)

--- a/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
+++ b/.github/actions/icon-editor-files-in-lv-installation/Validate-IconEditorDiagnostics.ps1
@@ -17,7 +17,11 @@ param(
     [string]$LabVIEWVersion = '2021',
 
     [Parameter(Mandatory)]
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -185,6 +189,15 @@ if (-not (Test-Path -Path $CsvPath)) {
 }
 
 $repoRootResolved = Resolve-RepoRoot -PathOverride $RepoRoot
+$worktreeGuard = Join-Path $repoRootResolved 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Validate-IconEditorDiagnostics'
+    Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Validate-IconEditorDiagnostics'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $repoRootNormalized = Normalize-Path -Path $repoRootResolved
 if (-not $repoRootNormalized) {
     throw "Unable to normalize RepoRoot: $repoRootResolved"

--- a/.github/actions/icon-editor-files-in-lv-installation/action.yml
+++ b/.github/actions/icon-editor-files-in-lv-installation/action.yml
@@ -3,7 +3,7 @@ description: "Runs GetPathsToIconEditorFilesInLVInstallationCLI.vi via g-cli and
 
 inputs:
   lv-ver:
-    description: "LabVIEW version (2021/21.0 only)."
+    description: "LabVIEW version (year or numeric)."
     required: true
   arch:
     description: "Bitness (32 or 64)."

--- a/.github/actions/missing-in-project/Invoke-MissingInProjectCLI.ps1
+++ b/.github/actions/missing-in-project/Invoke-MissingInProjectCLI.ps1
@@ -11,14 +11,24 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Invoke-MissingInProjectCLI'
-    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Invoke-MissingInProjectCLI'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $LVVersion `
+        -LabVIEWBitness $Arch `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$false `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRoot = $preflight.RepoRoot
 }
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $LVVersion
@@ -153,6 +163,19 @@ finally {
 $passed = ($Script:HelperExitCode -eq 0) -and ($Script:MissingFileLines.Count -eq 0) -and (-not $Script:ParsingFailed)
 $passedStr   = $passed.ToString().ToLower()
 $missingCsv  = ($Script:MissingFileLines -join ',')
+
+$artifactRoot = $env:LVIE_ARTIFACT_ROOT
+if (-not [string]::IsNullOrWhiteSpace($artifactRoot) -and (Test-Path $MissingFilePath)) {
+    try {
+        $targetDir = Join-Path $artifactRoot 'missing-in-project'
+        if (-not (Test-Path -Path $targetDir)) {
+            New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
+        }
+        Copy-Item -Path $MissingFilePath -Destination (Join-Path $targetDir 'missing_files.txt') -Force
+    } catch {
+        Write-Warning ("Failed to copy missing_files.txt to artifact root: {0}" -f $_.Exception.Message)
+    }
+}
 
 if ($env:GITHUB_OUTPUT) {
     Add-Content -Path $env:GITHUB_OUTPUT -Value "passed=$passedStr"

--- a/.github/actions/missing-in-project/Invoke-MissingInProjectCLI.ps1
+++ b/.github/actions/missing-in-project/Invoke-MissingInProjectCLI.ps1
@@ -3,12 +3,23 @@
 param(
     [Parameter(Mandatory)][string]$LVVersion,
     [Parameter(Mandatory)][ValidateSet('32','64')][string]$Arch,
-    [Parameter(Mandatory)][string]$ProjectFile
+    [Parameter(Mandatory)][string]$ProjectFile,
+    [string]$WorktreeRoot,
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Invoke-MissingInProjectCLI'
+    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Invoke-MissingInProjectCLI'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $LVVersion
 if (Test-Path -Path $versionHelper) {

--- a/.github/actions/missing-in-project/Invoke-MissingInProjectCLI.ps1
+++ b/.github/actions/missing-in-project/Invoke-MissingInProjectCLI.ps1
@@ -1,12 +1,24 @@
 #Requires -Version 7.0
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)][ValidateSet('2021')][string]$LVVersion,
+    [Parameter(Mandatory)][string]$LVVersion,
     [Parameter(Mandatory)][ValidateSet('32','64')][string]$Arch,
     [Parameter(Mandatory)][string]$ProjectFile
 )
 
 $ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $LVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
 
 # ---------- GLOBAL STATE ----------
 $Script:HelperExitCode   = 0
@@ -24,7 +36,7 @@ if (-not (Test-Path $HelperPath)) {
 # =========================  SETUP  =========================
 function Setup {
     Write-Host "=== Setup ==="
-    Write-Host "LVVersion  : $LVVersion"
+    Write-Host "LVVersion  : $labviewYear"
     Write-Host "Arch       : $Arch-bit"
     Write-Host "ProjectFile: $ProjectFile"
 
@@ -42,7 +54,7 @@ function MainSequence {
     Write-Host "Invoking missing‑file check via helper script …`n"
 
     # call helper & capture any stdout (not strictly needed now)
-    & $HelperPath -LVVersion $LVVersion -Arch $Arch -ProjectFile $ProjectFile
+    & $HelperPath -LVVersion $labviewYear -Arch $Arch -ProjectFile $ProjectFile
     $Script:HelperExitCode = $LASTEXITCODE
 
     if ($Script:HelperExitCode -ne 0) {
@@ -100,7 +112,7 @@ function Cleanup {
 # Close LabVIEW but do not fail the job if it is already closed/missing
 function SafeQuitLabVIEW {
     try {
-        & g-cli --lv-ver $LVVersion --arch $Arch QuitLabVIEW | Out-Null
+        & g-cli --lv-ver $labviewYear --arch $Arch QuitLabVIEW | Out-Null
     }
     catch {
         Write-Warning ("Failed to close LabVIEW: {0}" -f $_.Exception.Message)

--- a/.github/actions/missing-in-project/README.md
+++ b/.github/actions/missing-in-project/README.md
@@ -55,7 +55,7 @@ Results are returned as standard GitHub Action outputs so downstream jobs can d
 # .github/workflows/ci-composite.yml  (excerpt)
 jobs:
   prepare:
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ If you want **any** missing file to abort the pipeline immediately, place the st
 ```yaml
 jobs:
   missing-check:
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/missing-in-project
@@ -141,3 +141,4 @@ type .github/actions/missing-in-project/missing_files.txt
 
 ## License
 This directory inherits the root repository’s license (MIT, unless otherwise noted).
+

--- a/.github/actions/missing-in-project/action.yml
+++ b/.github/actions/missing-in-project/action.yml
@@ -12,7 +12,7 @@ branding:
 
 inputs:
   lv-ver:
-    description: "LabVIEW version (2021/21.0 only)."
+    description: "LabVIEW version (year or numeric)."
     required: true
   arch:
     description: "Bitness (32 or 64)."

--- a/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
+++ b/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
@@ -51,6 +51,8 @@ param (
     [string]$SupportedBitness,
     [string]$RepoRoot,
     [string]$VIPBPath,
+    [string]$WorktreeRoot,
+    [switch]$SkipWorktreeRootCheck,
 
     [Alias('LabVIEWVersion')]
     [ValidateRange(2000, 2100)]
@@ -72,7 +74,7 @@ param (
 
 # 1) Resolve paths
 try {
-    $ResolvedRepoRoot = Resolve-Path -Path $RepoRoot -ErrorAction Stop
+    $ResolvedRepoRoot = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
     $ResolvedVIPBPath = Join-Path -Path $ResolvedRepoRoot -ChildPath $VIPBPath -ErrorAction Stop
 }
 catch {
@@ -83,6 +85,17 @@ catch {
     }
     $errorObject | ConvertTo-Json -Depth 10
     exit 1
+}
+
+# 1a) Worktree guard (optional for local runs)
+$worktreeGuard = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $ResolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'ModifyVIPBDisplayInfo'
+    Write-WorktreeContext -RepoRoot $ResolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'ModifyVIPBDisplayInfo'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
 }
 
 # 2) Create release notes if needed

--- a/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
+++ b/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
@@ -18,10 +18,10 @@
     Relative path to the VIPB file to modify.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW major version (2021 only; 21.0).
+    LabVIEW major version year (e.g., 2021).
 
 .PARAMETER LabVIEWMinorRevision
-    Minor revision number of LabVIEW (0 for 21.0).
+    Minor revision number of LabVIEW (e.g., 0 for 21.0).
 
 .PARAMETER Major
     Major version component for the package.
@@ -52,11 +52,12 @@ param (
     [string]$RepoRoot,
     [string]$VIPBPath,
 
-    [ValidateSet(2021)]
+    [Alias('LabVIEWVersion')]
+    [ValidateRange(2000, 2100)]
     [int]$MinimumSupportedLVVersion,
 
-    [ValidateSet("0")]
-    [string]$LabVIEWMinorRevision = "0",
+    [ValidateRange(0, 99)]
+    [int]$LabVIEWMinorRevision = 0,
 
     [int]$Major,
     [int]$Minor,

--- a/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
+++ b/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
@@ -87,15 +87,25 @@ catch {
     exit 1
 }
 
-# 1a) Worktree guard (optional for local runs)
-$worktreeGuard = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $ResolvedRepoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'ModifyVIPBDisplayInfo'
-    Write-WorktreeContext -RepoRoot $ResolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'ModifyVIPBDisplayInfo'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+# 1a) Worktree preflight (optional for local runs)
+$preflightScript = Join-Path -Path $ResolvedRepoRoot -ChildPath 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $ResolvedRepoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $ResolvedRepoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $MinimumSupportedLVVersion `
+        -LabVIEWBitness $SupportedBitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$false `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs
+    if ($preflight.Reinvoked) {
+        return
     }
+    $ResolvedRepoRoot = $preflight.RepoRoot
 }
 
 # 2) Create release notes if needed

--- a/.github/actions/modify-vipb-display-info/action.yml
+++ b/.github/actions/modify-vipb-display-info/action.yml
@@ -35,7 +35,7 @@ runs:
           -DisplayInformationJSON $displayInformationJson
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'
@@ -47,7 +47,7 @@ inputs:
     description: 'Path to the VIPB file (relative to workspace)'
     required: true
   labview_minor_revision:
-    description: 'LabVIEW minor revision (0 for 21.0)'
+    description: 'LabVIEW minor revision (e.g., 0 for 21.0)'
     required: false
     default: '0'
   major:

--- a/.github/actions/prepare-labview-source/Prepare_LabVIEW_source.ps1
+++ b/.github/actions/prepare-labview-source/Prepare_LabVIEW_source.ps1
@@ -9,7 +9,7 @@
     VI executes so subsequent steps load the changes.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     Target bitness of the LabVIEW environment ("32" or "64").
@@ -30,7 +30,8 @@
 
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet('2021')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$MinimumSupportedLVVersion,
 
     [Parameter(Mandatory = $true)]
@@ -106,6 +107,16 @@ function Get-LabVIEWInstallRoot {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
 $gCliRunner = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\GcliRunner.ps1'
 if (-not (Test-Path -Path $gCliRunner)) {
     throw "g-cli helper not found at $gCliRunner"
@@ -125,8 +136,8 @@ if (-not (Test-Path -Path $viPath)) {
     throw "PrepareIESource.vi not found at $viPath"
 }
 
-if (-not (Get-LabVIEWInstallRoot -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness)) {
-    throw "LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) install not found."
+if (-not (Get-LabVIEWInstallRoot -Version $labviewYear -Bitness $SupportedBitness)) {
+    throw "LabVIEW $labviewYear ($SupportedBitness-bit) install not found."
 }
 
 if (-not (Get-Command g-cli -ErrorAction SilentlyContinue)) {
@@ -136,7 +147,7 @@ if (-not (Get-Command g-cli -ErrorAction SilentlyContinue)) {
 $gCliPath = (Get-Command g-cli -ErrorAction SilentlyContinue).Source
 
 $gCliArgs = @(
-    '--lv-ver', $MinimumSupportedLVVersion,
+    '--lv-ver', $labviewYear,
     '--arch', $SupportedBitness,
     '-v', $viPath
 )
@@ -184,8 +195,8 @@ try {
         $closeFailure = "Close_LabVIEW.ps1 not found at $closeScript"
     } else {
         try {
-            Write-Host "Closing LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)..."
-            & $closeScript -MinimumSupportedLVVersion $MinimumSupportedLVVersion -SupportedBitness $SupportedBitness
+            Write-Host "Closing LabVIEW $labviewYear ($SupportedBitness-bit)..."
+            & $closeScript -MinimumSupportedLVVersion $labviewYear -SupportedBitness $SupportedBitness
             if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
                 $closeFailure = "Close_LabVIEW.ps1 failed with exit code $LASTEXITCODE."
             }

--- a/.github/actions/prepare-labview-source/action.yml
+++ b/.github/actions/prepare-labview-source/action.yml
@@ -22,7 +22,7 @@ runs:
           -RepoRoot "${{ inputs.repo_root }}"
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'

--- a/.github/actions/restore-setup-lv-source/RestoreSetupLVSource.ps1
+++ b/.github/actions/restore-setup-lv-source/RestoreSetupLVSource.ps1
@@ -9,7 +9,7 @@
     steps load the changes.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     Bitness of the LabVIEW environment ("32" or "64").
@@ -30,7 +30,8 @@
 
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet('2021')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]$MinimumSupportedLVVersion,
 
     [Parameter(Mandatory = $true)]
@@ -106,6 +107,16 @@ function Get-LabVIEWInstallRoot {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
 $gCliRunner = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\GcliRunner.ps1'
 if (-not (Test-Path -Path $gCliRunner)) {
     throw "g-cli helper not found at $gCliRunner"
@@ -125,8 +136,8 @@ if (-not (Test-Path -Path $viPath)) {
     throw "RestoreSetupLVSource.vi not found at $viPath"
 }
 
-if (-not (Get-LabVIEWInstallRoot -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness)) {
-    throw "LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) install not found."
+if (-not (Get-LabVIEWInstallRoot -Version $labviewYear -Bitness $SupportedBitness)) {
+    throw "LabVIEW $labviewYear ($SupportedBitness-bit) install not found."
 }
 
 if (-not (Get-Command g-cli -ErrorAction SilentlyContinue)) {
@@ -136,7 +147,7 @@ if (-not (Get-Command g-cli -ErrorAction SilentlyContinue)) {
 $gCliPath = (Get-Command g-cli -ErrorAction SilentlyContinue).Source
 
 $gCliArgs = @(
-    '--lv-ver', $MinimumSupportedLVVersion,
+    '--lv-ver', $labviewYear,
     '--arch', $SupportedBitness,
     '-v', $viPath
 )
@@ -187,8 +198,8 @@ try {
         $closeFailure = "Close_LabVIEW.ps1 not found at $closeScript"
     } else {
         try {
-            Write-Host "Closing LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)..."
-            & $closeScript -MinimumSupportedLVVersion $MinimumSupportedLVVersion -SupportedBitness $SupportedBitness
+            Write-Host "Closing LabVIEW $labviewYear ($SupportedBitness-bit)..."
+            & $closeScript -MinimumSupportedLVVersion $labviewYear -SupportedBitness $SupportedBitness
             if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
                 $closeFailure = "Close_LabVIEW.ps1 failed with exit code $LASTEXITCODE."
             }

--- a/.github/actions/restore-setup-lv-source/action.yml
+++ b/.github/actions/restore-setup-lv-source/action.yml
@@ -22,7 +22,7 @@ runs:
           -RepoRoot "${{ inputs.repo_root }}"
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'

--- a/.github/actions/revert-development-mode/README.md
+++ b/.github/actions/revert-development-mode/README.md
@@ -5,7 +5,7 @@ Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after develop
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
+| `labview_version` | **Yes** | `2021` | LabVIEW version (year or numeric). |
 | `supported_bitness` | **Yes** | `64` | LabVIEW bitness (32 or 64). |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 

--- a/.github/actions/revert-development-mode/RevertDevelopmentMode.ps1
+++ b/.github/actions/revert-development-mode/RevertDevelopmentMode.ps1
@@ -8,7 +8,7 @@
     each run so downstream steps load the changes.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     One or more bitness values ("32", "64") to run (default: both).
@@ -28,8 +28,10 @@
 
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateSet('2021')]
-    [string]$MinimumSupportedLVVersion = '2021',
+    [Alias('LabVIEWVersion')]
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$MinimumSupportedLVVersion = '',
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('32', '64', IgnoreCase = $true)]
@@ -58,6 +60,33 @@ Write-Host "Close_LabVIEW script: $CloseScript"
 
 $ErrorActionPreference = 'Stop'
 
+function Resolve-RepoRoot {
+    param(
+        [string]$PathOverride
+    )
+
+    if ($PathOverride) {
+        if (-not (Test-Path -Path $PathOverride)) {
+            throw "RepoRoot does not exist: $PathOverride"
+        }
+        return (Resolve-Path -Path $PathOverride).Path
+    }
+
+    return (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
+}
+
+$resolvedRepoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path $resolvedRepoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $resolvedRepoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
+
 function Invoke-RestoreLabviewSource {
     param(
         [string]$Bitness
@@ -67,21 +96,21 @@ function Invoke-RestoreLabviewSource {
         throw "Close_LabVIEW.ps1 not found at $CloseScript"
     }
 
-    & $CloseScript -MinimumSupportedLVVersion $MinimumSupportedLVVersion -SupportedBitness $Bitness
+    & $CloseScript -MinimumSupportedLVVersion $labviewYear -SupportedBitness $Bitness
     if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
         throw "Close_LabVIEW.ps1 failed for $Bitness-bit with exit code $LASTEXITCODE."
     }
 
     Write-Host "Restoring LabVIEW sources for $Bitness-bit."
     $scriptArgs = @{
-        MinimumSupportedLVVersion = $MinimumSupportedLVVersion
+        MinimumSupportedLVVersion = $labviewYear
         SupportedBitness          = $Bitness
         ConnectTimeoutMs          = $ConnectTimeoutMs
         ProcessTimeoutMs          = $ProcessTimeoutMs
     }
 
-    if ($RepoRoot) {
-        $scriptArgs.RepoRoot = $RepoRoot
+    if ($resolvedRepoRoot) {
+        $scriptArgs.RepoRoot = $resolvedRepoRoot
     }
 
     & $RestoreScript @scriptArgs

--- a/.github/actions/revert-development-mode/action.yml
+++ b/.github/actions/revert-development-mode/action.yml
@@ -29,7 +29,7 @@ runs:
         & "${{ github.action_path }}/RevertDevelopmentMode.ps1" @scriptArgs
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: 'LabVIEW bitness (32 or 64).'

--- a/.github/actions/run-unit-tests/RunUnitTests.ps1
+++ b/.github/actions/run-unit-tests/RunUnitTests.ps1
@@ -77,20 +77,34 @@ $Script:ReportMissing = $false
 $Script:ParseError = $null
 
 if ([string]::IsNullOrWhiteSpace($ReportPath)) {
-    $ReportPath = Join-Path -Path $PSScriptRoot -ChildPath "UnitTestReport.xml"
+    $reportRoot = if ([string]::IsNullOrWhiteSpace($env:LVIE_ARTIFACT_ROOT)) { $PSScriptRoot } else { Join-Path $env:LVIE_ARTIFACT_ROOT 'unit-tests' }
+    if (-not [string]::IsNullOrWhiteSpace($env:LVIE_ARTIFACT_ROOT) -and -not (Test-Path -Path $reportRoot)) {
+        New-Item -Path $reportRoot -ItemType Directory -Force | Out-Null
+    }
+    $ReportPath = Join-Path -Path $reportRoot -ChildPath "UnitTestReport.xml"
 } else {
     Write-Host "Using report path override: $ReportPath"
 }
 
 $repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'RunUnitTests'
-    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'RunUnitTests'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $MinimumSupportedLVVersion `
+        -LabVIEWBitness $SupportedBitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$false `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRoot = $preflight.RepoRoot
 }
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion

--- a/.github/actions/run-unit-tests/RunUnitTests.ps1
+++ b/.github/actions/run-unit-tests/RunUnitTests.ps1
@@ -57,7 +57,15 @@ param(
     [Parameter(Mandatory = $false, ParameterSetName = 'Run')]
     [Parameter(Mandatory = $false, ParameterSetName = 'ReportOnly')]
     [string]
-    $ReportPath
+    $ReportPath,
+
+    [Parameter(Mandatory = $false, ParameterSetName = 'Run')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'ReportOnly')]
+    [string]$WorktreeRoot,
+
+    [Parameter(Mandatory = $false, ParameterSetName = 'Run')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'ReportOnly')]
+    [switch]$SkipWorktreeRootCheck
 )
 
 # Script-level variables to track exit states and results
@@ -74,7 +82,16 @@ if ([string]::IsNullOrWhiteSpace($ReportPath)) {
     Write-Host "Using report path override: $ReportPath"
 }
 
-$repoRoot = Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'RunUnitTests'
+    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'RunUnitTests'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion
 if (Test-Path -Path $versionHelper) {

--- a/.github/actions/run-unit-tests/RunUnitTests.ps1
+++ b/.github/actions/run-unit-tests/RunUnitTests.ps1
@@ -10,7 +10,7 @@
       - Requires an explicit LabVIEW project path (-ProjectPath).
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     Bitness for LabVIEW (e.g., "64").
@@ -34,7 +34,9 @@
 param(
     [Parameter(Mandatory = $true, ParameterSetName = 'Run')]
     [Parameter(Mandatory = $true, ParameterSetName = 'ReportOnly')]
-    [ValidateSet('2021')]
+    [Alias('LabVIEWVersion')]
+    [AllowNull()]
+    [AllowEmptyString()]
     [string]
     $MinimumSupportedLVVersion,
 
@@ -70,6 +72,18 @@ if ([string]::IsNullOrWhiteSpace($ReportPath)) {
     $ReportPath = Join-Path -Path $PSScriptRoot -ChildPath "UnitTestReport.xml"
 } else {
     Write-Host "Using report path override: $ReportPath"
+}
+
+$repoRoot = Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')
+$versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
 }
 
 # --------------------------------------------------------------------
@@ -216,7 +230,7 @@ function Emit-Results {
 
         if ($env:GITHUB_STEP_SUMMARY) {
             $summary = @()
-            $summary += "### Unit Test Results (LabVIEW $MinimumSupportedLVVersion $SupportedBitness-bit)"
+            $summary += "### Unit Test Results (LabVIEW $labviewYear $SupportedBitness-bit)"
             $summary += ""
             $summary += "- Total: 0"
             $summary += "- Failed: 1"
@@ -303,7 +317,7 @@ function Emit-Results {
         $skippedCount = ($Script:Results | Where-Object { $_.Status -eq "Skipped" }).Count
         $passedResults = $Script:Results | Where-Object { $_.Status -eq "Passed" }
         $summary = @()
-        $summary += "### Unit Test Results (LabVIEW $MinimumSupportedLVVersion $SupportedBitness-bit)"
+        $summary += "### Unit Test Results (LabVIEW $labviewYear $SupportedBitness-bit)"
         $summary += ""
         $summary += "- Total: $($Script:Results.Count)"
         $summary += "- Failed: $($Script:FailedResults.Count)"
@@ -348,7 +362,7 @@ function Emit-Results {
 # ------------------------  MAIN SEQUENCE  ----------------------
 function MainSequence {
     Write-Host "`n=== MainSequence ==="
-    Write-Host "Running unit tests for LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)"
+    Write-Host "Running unit tests for LabVIEW $labviewYear ($SupportedBitness-bit)"
     Write-Host "Project Path: $AbsoluteProjectPath"
     Write-Host "Report will be saved at: $ReportPath"
 
@@ -361,7 +375,7 @@ function MainSequence {
     $previousNativePreference = $PSNativeCommandUseErrorActionPreference
     $PSNativeCommandUseErrorActionPreference = $false
     try {
-        & g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness lunit -- -r "$ReportPath" "$AbsoluteProjectPath"
+        & g-cli --lv-ver $labviewYear --arch $SupportedBitness lunit -- -r "$ReportPath" "$AbsoluteProjectPath"
     }
     finally {
         $PSNativeCommandUseErrorActionPreference = $previousNativePreference

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -22,7 +22,7 @@ runs:
           -ProjectPath "${{ inputs.project_path }}"
 inputs:
   labview_version:
-    description: 'LabVIEW version to run (2021/21.0 only).'
+    description: 'LabVIEW version to run (year or numeric).'
     required: true
   supported_bitness:
     description: '32 or 64'

--- a/.github/actions/set-development-mode/README.md
+++ b/.github/actions/set-development-mode/README.md
@@ -5,7 +5,7 @@ Execute **`Set_Development_Mode.ps1`** to prepare the repository for active deve
 ## Inputs
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
-| `labview_version` | **Yes** | `2021` | LabVIEW 2021 (21.0) only. |
+| `labview_version` | **Yes** | `2021` | LabVIEW version (year or numeric). |
 | `supported_bitness` | **Yes** | `64` | LabVIEW bitness (32 or 64). |
 | `repo_root` | No | `${{ github.workspace }}` | Repository root path (optional). |
 

--- a/.github/actions/set-development-mode/Set_Development_Mode.ps1
+++ b/.github/actions/set-development-mode/Set_Development_Mode.ps1
@@ -8,7 +8,7 @@
 #        each run so downstream steps load the changes.
 #
 #    .PARAMETER MinimumSupportedLVVersion
-#        LabVIEW 2021 (21.0) only.
+#        LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 #
 #    .PARAMETER SupportedBitness
 #        One or more bitness values ("32", "64") to run (default: both).
@@ -29,8 +29,10 @@
 
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateSet('2021')]
-    [string]$MinimumSupportedLVVersion = '2021',
+    [Alias('LabVIEWVersion')]
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$MinimumSupportedLVVersion = '',
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('32', '64', IgnoreCase = $true)]
@@ -61,6 +63,33 @@ Write-Host "Close_LabVIEW script: $CloseScript"
 
 $ErrorActionPreference = 'Stop'
 
+function Resolve-RepoRoot {
+    param(
+        [string]$PathOverride
+    )
+
+    if ($PathOverride) {
+        if (-not (Test-Path -Path $PathOverride)) {
+            throw "RepoRoot does not exist: $PathOverride"
+        }
+        return (Resolve-Path -Path $PathOverride).Path
+    }
+
+    return (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..\..')).Path
+}
+
+$resolvedRepoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path $resolvedRepoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $resolvedRepoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
+
 function Invoke-PrepareLabviewSource {
     param(
         [string]$Bitness
@@ -70,21 +99,21 @@ function Invoke-PrepareLabviewSource {
         throw "Close_LabVIEW.ps1 not found at $CloseScript"
     }
 
-    & $CloseScript -MinimumSupportedLVVersion $MinimumSupportedLVVersion -SupportedBitness $Bitness
+    & $CloseScript -MinimumSupportedLVVersion $labviewYear -SupportedBitness $Bitness
     if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
         throw "Close_LabVIEW.ps1 failed for $Bitness-bit with exit code $LASTEXITCODE."
     }
 
     Write-Host "Preparing LabVIEW sources for $Bitness-bit."
     $scriptArgs = @{
-        MinimumSupportedLVVersion = $MinimumSupportedLVVersion
+        MinimumSupportedLVVersion = $labviewYear
         SupportedBitness          = $Bitness
         ConnectTimeoutMs          = $ConnectTimeoutMs
         ProcessTimeoutMs          = $ProcessTimeoutMs
     }
 
-    if ($RepoRoot) {
-        $scriptArgs.RepoRoot = $RepoRoot
+    if ($resolvedRepoRoot) {
+        $scriptArgs.RepoRoot = $resolvedRepoRoot
     }
 
     & $PrepareScript @scriptArgs

--- a/.github/actions/set-development-mode/action.yml
+++ b/.github/actions/set-development-mode/action.yml
@@ -2,7 +2,7 @@ name: "Set Development Mode"
 description: "Runs Set_Development_Mode.ps1 to configure the repo for development."
 inputs:
   labview_version:
-    description: 'LabVIEW version to target (2021/21.0 only).'
+    description: 'LabVIEW version to target (year or numeric).'
     required: true
   supported_bitness:
     description: 'LabVIEW bitness (32 or 64).'

--- a/.github/actions/unit-tests/unit_tests.ps1
+++ b/.github/actions/unit-tests/unit_tests.ps1
@@ -63,14 +63,25 @@ try {
     Assert-PathExists $RepoRoot "RepoRoot"
     $repoRootResolved = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
     $RepoRoot = $repoRootResolved
-    $worktreeGuard = Join-Path -Path $repoRootResolved -ChildPath 'Tooling\support\WorktreeGuard.ps1'
-    if (Test-Path -Path $worktreeGuard) {
-        . $worktreeGuard
-        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'unit_tests'
-        Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'unit_tests'
-        if ($resolvedWorktreeRoot) {
-            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    $preflightScript = Join-Path -Path $repoRootResolved -ChildPath 'Tooling\Invoke-Preflight.ps1'
+    if (Test-Path -Path $preflightScript) {
+        . $preflightScript
+        $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+        $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRootResolved -Path $PSCommandPath } else { $null }
+        $preflight = Invoke-Preflight `
+            -RepoRoot $repoRootResolved `
+            -WorktreeRoot $WorktreeRoot `
+            -LabVIEWVersion '2021' `
+            -LabVIEWBitness 'both' `
+            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+            -AutoWorktree:$false `
+            -ScriptPath $relativeScript `
+            -ScriptArguments $scriptArgs
+        if ($preflight.Reinvoked) {
+            return
         }
+        $repoRootResolved = $preflight.RepoRoot
+        $RepoRoot = $repoRootResolved
     }
     if (-not (Test-Path "$RepoRoot\resource\plugins")) {
         Write-Host "Plugins folder missing; creating $RepoRoot\resource\plugins" -ForegroundColor Yellow

--- a/.github/actions/unit-tests/unit_tests.ps1
+++ b/.github/actions/unit-tests/unit_tests.ps1
@@ -14,7 +14,12 @@
 #>
 param(
     [Parameter(Mandatory = $true)]
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 # Helper function to check for file or directory existence
@@ -56,6 +61,17 @@ function Execute-Script {
 try {
     # Validate required paths
     Assert-PathExists $RepoRoot "RepoRoot"
+    $repoRootResolved = (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
+    $RepoRoot = $repoRootResolved
+    $worktreeGuard = Join-Path -Path $repoRootResolved -ChildPath 'Tooling\support\WorktreeGuard.ps1'
+    if (Test-Path -Path $worktreeGuard) {
+        . $worktreeGuard
+        $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRootResolved -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'unit_tests'
+        Write-WorktreeContext -RepoRoot $repoRootResolved -WorktreeRoot $resolvedWorktreeRoot -Prefix 'unit_tests'
+        if ($resolvedWorktreeRoot) {
+            $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+        }
+    }
     if (-not (Test-Path "$RepoRoot\resource\plugins")) {
         Write-Host "Plugins folder missing; creating $RepoRoot\resource\plugins" -ForegroundColor Yellow
         New-Item -ItemType Directory -Path "$RepoRoot\resource\plugins" -Force | Out-Null

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1,7 +1,7 @@
 name: CI Pipeline (Composite)
 
 concurrency:
-  group: labview-${{ github.repository }}-self-hosted-windows-lv
+  group: labview-${{ github.repository }}-self-hosted-windows-lv-ie
   cancel-in-progress: false
 
 on:
@@ -34,7 +34,7 @@ on:
 jobs:
   dev-mode-gate:
     name: Verify IE Paths Gate (LV ${{ matrix.bitness }}-bit)
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +99,7 @@ jobs:
   apply-deps-2021-x64:
     name: Apply VIPC (LV x64)
     needs: changes
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
   apply-deps-2021-x86:
     name: Apply VIPC (LV x86)
     needs: [apply-deps-2021-x64, changes]
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -171,7 +171,7 @@ jobs:
   version:
     name: Compute Version
     needs: dev-mode-gate
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     outputs:
       VERSION:       ${{ steps.compute.outputs.VERSION }}
       MAJOR:         ${{ steps.compute.outputs.MAJOR }}
@@ -196,7 +196,7 @@ jobs:
   test-2021:
     name: Run Unit Tests (LV ${{ matrix.bitness }}-bit)
     needs: missing-in-project
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -263,7 +263,7 @@ jobs:
   build-ppl-x86:
     name: Build 32-bit Packed Library
     needs: [build-ppl-x64, version]
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -334,7 +334,7 @@ jobs:
   build-ppl-x64:
     name: Build 64-bit Packed Library
     needs: [test-2021, version]
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -406,7 +406,7 @@ jobs:
     name: Build VI Package
     # Chain after 32-bit PPL build (which depends on 64-bit PPL build).
     needs: [build-ppl-x86, version]
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - uses: actions/checkout@v4
         with:
@@ -628,6 +628,7 @@ jobs:
             git -C "$env:GITHUB_WORKSPACE" worktree remove --force "$env:REPO_ROOT" 2>$null
             git -C "$env:GITHUB_WORKSPACE" worktree prune
           }
+
 
 
 

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1,7 +1,7 @@
 name: CI Pipeline (Composite)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}
+  group: labview-${{ github.repository }}
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1,7 +1,7 @@
 name: CI Pipeline (Composite)
 
 concurrency:
-  group: labview-${{ github.repository }}
+  group: labview-${{ github.repository }}-self-hosted-windows-lv
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -1,7 +1,7 @@
 name: "Toggle Development Mode"
 
 concurrency:
-  group: labview-${{ github.repository }}
+  group: labview-${{ github.repository }}-self-hosted-windows-lv
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -10,7 +10,7 @@ on:
         required: true
         default: "enable"
       labview_version:
-        description: "LabVIEW version to target (2021/21.0 only)."
+        description: "LabVIEW version to target (year or numeric)."
         type: string
         required: true
       bitness:
@@ -35,12 +35,10 @@ on:
           - enable
           - disable
       labview_version:
-        description: "LabVIEW version."
+        description: "LabVIEW version (year or numeric)."
         required: true
         default: "2021"
-        type: choice
-        options:
-          - "2021"
+        type: string
       bitness:
         description: "LabVIEW bitness."
         required: true

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -1,7 +1,7 @@
 name: "Toggle Development Mode"
 
 concurrency:
-  group: labview-${{ github.repository }}-self-hosted-windows-lv
+  group: labview-${{ github.repository }}-self-hosted-windows-lv-ie
   cancel-in-progress: false
 
 on:
@@ -90,7 +90,7 @@ jobs:
           inputs.bitness || '64',
           inputs.labview_version || '2021') }}
 
-    runs-on: [self-hosted-windows-lv]
+    runs-on: [self-hosted-windows-lv-ie]
     env:
       selected_bitness: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bitness || inputs.bitness }}
 
@@ -187,3 +187,4 @@ jobs:
           if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
             exit $LASTEXITCODE
           }
+

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -1,5 +1,9 @@
 name: "Toggle Development Mode"
 
+concurrency:
+  group: labview-${{ github.repository }}
+  cancel-in-progress: false
+
 on:
   # 1) Called by other workflows
   workflow_call:

--- a/.github/workflows/test-missing-in-project-windows.yml
+++ b/.github/workflows/test-missing-in-project-windows.yml
@@ -1,7 +1,7 @@
 name: Test Missing‑In‑Project Action on Windows
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_call' && format('labview-{0}-self-hosted-windows-lv-child-{1}', github.repository, github.run_id) || format('labview-{0}-self-hosted-windows-lv', github.repository) }}
+  group: ${{ github.event_name == 'workflow_call' && format('labview-{0}-self-hosted-windows-lv-ie-child-{1}', github.repository, github.run_id) || format('labview-{0}-self-hosted-windows-lv-ie', github.repository) }}
   cancel-in-progress: false
 
 on:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   missing-in-project-check:
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -150,6 +150,7 @@ jobs:
             git -C "$env:GITHUB_WORKSPACE" worktree remove --force "$env:REPO_ROOT" 2>$null
             git -C "$env:GITHUB_WORKSPACE" worktree prune
           }
+
 
 
 

--- a/.github/workflows/test-missing-in-project-windows.yml
+++ b/.github/workflows/test-missing-in-project-windows.yml
@@ -1,7 +1,7 @@
 name: Test Missing‑In‑Project Action on Windows
 
 concurrency:
-  group: labview-${{ github.repository }}-self-hosted-windows-lv
+  group: ${{ github.event_name == 'workflow_call' && format('labview-{0}-self-hosted-windows-lv-child-{1}', github.repository, github.run_id) || format('labview-{0}-self-hosted-windows-lv', github.repository) }}
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/test-missing-in-project-windows.yml
+++ b/.github/workflows/test-missing-in-project-windows.yml
@@ -1,7 +1,7 @@
 name: Test Missing‑In‑Project Action on Windows
 
 concurrency:
-  group: labview-${{ github.repository }}
+  group: labview-${{ github.repository }}-self-hosted-windows-lv
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/test-missing-in-project-windows.yml
+++ b/.github/workflows/test-missing-in-project-windows.yml
@@ -1,4 +1,9 @@
 name: Test Missing‑In‑Project Action on Windows
+
+concurrency:
+  group: labview-${{ github.repository }}
+  cancel-in-progress: false
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ pwsh -NoProfile -File .\Tooling\New-CIWorktreeForJob.ps1 -Bitness 64
 LabVIEW workflows are serialized on the shared self-hosted runner label to avoid concurrent g-cli/LabVIEW conflicts.
 
 Notes:
-- Workflows share a concurrency group keyed by repository + runner label (e.g., `labview-<repo>-self-hosted-windows-lv`).
+- Workflows share a concurrency group keyed by repository + runner label (e.g., `labview-<repo>-self-hosted-windows-lv-ie`).
 - The reusable missing-in-project workflow uses a unique child concurrency group when invoked via `workflow_call` to avoid parent/child deadlocks.
 - Do not add an identical concurrency group to a child workflow called by another workflow.
 
@@ -204,3 +204,4 @@ Notes:
 - If a run hangs, close LabVIEW and re-run the step:
   - `.github\actions\close-labview\Close_LabVIEW.ps1`
 - Release note generation can log `git describe` errors in shallow or tagless repos; VIP builds may still complete, but fetch tags if you need accurate version strings.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,14 @@ Helper used by CI:
 pwsh -NoProfile -File .\Tooling\New-CIWorktreeForJob.ps1 -Bitness 64
 ```
 
+## CI concurrency (self-hosted LabVIEW runners)
+LabVIEW workflows are serialized on the shared self-hosted runner label to avoid concurrent g-cli/LabVIEW conflicts.
+
+Notes:
+- Workflows share a concurrency group keyed by repository + runner label (e.g., `labview-<repo>-self-hosted-windows-lv`).
+- The reusable missing-in-project workflow uses a unique child concurrency group when invoked via `workflow_call` to avoid parent/child deadlocks.
+- Do not add an identical concurrency group to a child workflow called by another workflow.
+
 ## Local CI Parity (recommended)
 Run the local parity script that mirrors `ci-composite.yml`:
 ```
@@ -73,7 +81,8 @@ pwsh -NoProfile -File .\Tooling\Run-CICompositeLocal.ps1 `
 ```
 
 Notes:
-- Outputs go to `TestResults\ci-local`.
+- Outputs go to `$WORKTREE_ROOT\artifacts\<runid>\ci-local` when guardrails are active (default for local runs).
+- GitHub Actions disables artifact roots by default unless `LVIE_ENABLE_ARTIFACT_ROOT=1` or an explicit `-RunId`/`-ArtifactRoot` is passed.
 - The script always runs both 64-bit and 32-bit steps for LabVIEW 2021 (21.0).
 - The script handles Verify IE Paths, VIPC, missing-in-project, unit tests, PPL builds, and VIP build.
 - If LabVIEW or g-cli is already running, the script waits for them to exit before starting.
@@ -194,3 +203,4 @@ Notes:
 - If `g-cli` cannot connect, increase `-ConnectTimeoutMs` and `-ProcessTimeoutMs`.
 - If a run hangs, close LabVIEW and re-run the step:
   - `.github\actions\close-labview\Close_LabVIEW.ps1`
+- Release note generation can log `git describe` errors in shallow or tagless repos; VIP builds may still complete, but fetch tags if you need accurate version strings.

--- a/Test/Pester/DevMode.Integration.Tests.ps1
+++ b/Test/Pester/DevMode.Integration.Tests.ps1
@@ -1,13 +1,13 @@
 $ErrorActionPreference = 'Stop'
 
-Describe 'Development Mode integration (LabVIEW 2021 (21.0))' {
+Describe 'Development Mode integration' {
     BeforeAll {
         $script:skipAll = $false
         $script:skipReason = ''
         $script:installRoots = @{}
         $script:bitnessesToTest = @()
         $script:missingPathsHelperLoaded = $false
-        $script:labviewVersion = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '2021' } else { $env:LABVIEW_VERSION }
+        $script:labviewVersion = $null
         $script:labviewBitness = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_BITNESS)) { '64' } else { $env:LABVIEW_BITNESS }
         $script:connectTimeoutMs = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_CONNECT_TIMEOUT_MS)) { '120000' } else { $env:LABVIEW_CONNECT_TIMEOUT_MS }
         $script:processTimeoutMs = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_PROCESS_TIMEOUT_MS)) { '300000' } else { $env:LABVIEW_PROCESS_TIMEOUT_MS }
@@ -59,6 +59,36 @@ Describe 'Development Mode integration (LabVIEW 2021 (21.0))' {
             }
 
             return $null
+        }
+
+        function script:Get-BitnessList {
+            param(
+                [string]$BitnessInput
+            )
+
+            if ([string]::IsNullOrWhiteSpace($BitnessInput)) {
+                return @('64')
+            }
+
+            $normalized = $BitnessInput.Trim().ToLowerInvariant()
+            if (@('both', 'all', 'auto') -contains $normalized) {
+                return @('64', '32')
+            }
+
+            $parts = $normalized -split '[,; ]+' | Where-Object { $_ }
+            $bitnesses = foreach ($part in $parts) {
+                switch ($part) {
+                    '32' { '32' }
+                    '64' { '64' }
+                }
+            }
+
+            $bitnesses = $bitnesses | Where-Object { $_ } | Select-Object -Unique
+            if (-not $bitnesses) {
+                return @('64')
+            }
+
+            return @($bitnesses)
         }
 
         function script:Get-LabVIEWPaths {
@@ -119,22 +149,27 @@ Describe 'Development Mode integration (LabVIEW 2021 (21.0))' {
         $script:revertScript = Join-Path $script:actionsRoot 'revert-development-mode\RevertDevelopmentMode.ps1'
         $script:closeScript = Join-Path $script:actionsRoot 'close-labview\Close_LabVIEW.ps1'
         $script:missingPathsHelper = Join-Path $script:repoRoot 'Tooling\support\DevModeMissingPaths.ps1'
+        $script:versionHelper = Join-Path $script:repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 
         if (Test-Path -Path $script:missingPathsHelper) {
             . $script:missingPathsHelper
             $script:missingPathsHelperLoaded = $true
         }
 
+        if (Test-Path -Path $script:versionHelper) {
+            . $script:versionHelper
+            $versionInput = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '' } else { $env:LABVIEW_VERSION }
+            $versionInfo = Get-LabVIEWVersionInfo -VersionInput $versionInput -RepoRoot $script:repoRoot
+            $script:labviewVersion = $versionInfo.Year
+        }
+
+        if ([string]::IsNullOrWhiteSpace($script:labviewVersion)) {
+            $script:labviewVersion = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '2021' } else { $env:LABVIEW_VERSION }
+        }
+
         if (-not $script:runDevModeTests) {
             $script:skipAll = $true
             $script:skipReason = 'Set RUN_DEV_MODE_TESTS=1 to enable dev-mode integration tests.'
-            return
-        }
-
-
-        if ($script:labviewVersion -ne '2021') {
-            $script:skipAll = $true
-            $script:skipReason = 'Only LabVIEW 2021 (21.0) is supported by this test suite.'
             return
         }
 
@@ -144,23 +179,22 @@ Describe 'Development Mode integration (LabVIEW 2021 (21.0))' {
             return
         }
 
-        if ($script:labviewBitness -ne '64') {
+        $bitnessCandidates = Get-BitnessList -BitnessInput $script:labviewBitness
+        foreach ($bitness in $bitnessCandidates) {
+            $root = Get-LabVIEWInstallRoot -Version $script:labviewVersion -Bitness $bitness
+            if ($root) {
+                $script:installRoots[$bitness] = $root
+                $script:bitnessesToTest += $bitness
+            }
+        }
+
+        if (-not $script:bitnessesToTest -or $script:bitnessesToTest.Count -eq 0) {
             $script:skipAll = $true
-            $script:skipReason = 'Only 64-bit LabVIEW is supported by this test suite.'
+            $script:skipReason = "LabVIEW $script:labviewVersion installs not found for requested bitness: $script:labviewBitness."
             return
         }
 
-        $root = Get-LabVIEWInstallRoot -Version $script:labviewVersion -Bitness $script:labviewBitness
-        if ($root) {
-            $script:installRoots[$script:labviewBitness] = $root
-            $script:bitnessesToTest = @($script:labviewBitness)
-        }
-
-        if (-not $script:bitnessesToTest) {
-            $script:skipAll = $true
-            $script:skipReason = "LabVIEW $script:labviewVersion ($script:labviewBitness-bit) install not found."
-            return
-        }
+        $script:bitnessesToTest = $script:bitnessesToTest | Select-Object -Unique
 
         $filteredBitnesses = New-Object System.Collections.Generic.List[string]
         foreach ($bitness in $script:bitnessesToTest) {

--- a/Test/Pester/MissingIEFilesFromLVInstall.Integration.Tests.ps1
+++ b/Test/Pester/MissingIEFilesFromLVInstall.Integration.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'Verify IE Paths integration' {
     BeforeAll {
         $script:skipAll = $false
         $script:skipReason = ''
-        $script:labviewVersion = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '2021' } else { $env:LABVIEW_VERSION }
+        $script:labviewVersion = $null
         $script:labviewBitness = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_BITNESS)) { '64' } else { $env:LABVIEW_BITNESS }
         $script:connectTimeoutMs = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_CONNECT_TIMEOUT_MS)) { '120000' } else { $env:LABVIEW_CONNECT_TIMEOUT_MS }
         $script:processTimeoutMs = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_PROCESS_TIMEOUT_MS)) { '300000' } else { $env:LABVIEW_PROCESS_TIMEOUT_MS }
@@ -112,21 +112,27 @@ Describe 'Verify IE Paths integration' {
         $script:scriptPath = Join-Path $script:repoRoot 'Tooling\Invoke-MissingIEFilesFromLVInstall.ps1'
         $script:revertScript = Join-Path $script:repoRoot '.github\actions\revert-development-mode\RevertDevelopmentMode.ps1'
         $script:missingPathsHelper = Join-Path $script:repoRoot 'Tooling\support\DevModeMissingPaths.ps1'
+        $script:versionHelper = Join-Path $script:repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 
         if (Test-Path -Path $script:missingPathsHelper) {
             . $script:missingPathsHelper
             $script:missingPathsHelperLoaded = $true
         }
 
+        if (Test-Path -Path $script:versionHelper) {
+            . $script:versionHelper
+            $versionInput = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '' } else { $env:LABVIEW_VERSION }
+            $versionInfo = Get-LabVIEWVersionInfo -VersionInput $versionInput -RepoRoot $script:repoRoot
+            $script:labviewVersion = $versionInfo.Year
+        }
+
+        if ([string]::IsNullOrWhiteSpace($script:labviewVersion)) {
+            $script:labviewVersion = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '2021' } else { $env:LABVIEW_VERSION }
+        }
+
         if (-not (Test-Path -Path $script:scriptPath)) {
             $script:skipAll = $true
             $script:skipReason = "Script not found at $script:scriptPath"
-            return
-        }
-
-        if ($script:labviewVersion -ne '2021') {
-            $script:skipAll = $true
-            $script:skipReason = 'Only LabVIEW 2021 (21.0) is supported by this test suite.'
             return
         }
 

--- a/Test/Pester/Run-Pester.ps1
+++ b/Test/Pester/Run-Pester.ps1
@@ -1,6 +1,7 @@
 param(
-    [ValidateSet('2021')]
-    [string]$LabVIEWVersion = '2021',
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$LabVIEWVersion = '',
 
     [ValidateSet('32', '64', 'both', 'all', 'auto')]
     [string]$LabVIEWBitness = '64',
@@ -19,6 +20,19 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Resolve-Path -Path (Join-Path $PSScriptRoot '..\..')
+$versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $repoRoot
+    $LabVIEWVersion = $versionInfo.Year
+    $env:LABVIEW_VERSION_RAW = $versionInfo.Raw
+    $env:LABVIEW_VERSION_YEAR = $versionInfo.Year
+    $env:LABVIEW_MINOR_REVISION = $versionInfo.MinorRevision.ToString()
+    $env:LABVIEW_NUMERIC_VERSION = $versionInfo.NumericVersion
+} elseif ([string]::IsNullOrWhiteSpace($LabVIEWVersion)) {
+    $LabVIEWVersion = '2021'
+}
+
 $env:LABVIEW_VERSION = $LabVIEWVersion
 $env:LABVIEW_BITNESS = $LabVIEWBitness
 $env:LABVIEW_CONNECT_TIMEOUT_MS = $ConnectTimeoutMs.ToString()

--- a/Test/Pester/Run-Pester.ps1
+++ b/Test/Pester/Run-Pester.ps1
@@ -19,20 +19,44 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$WorktreeRoot,
 
-    [switch]$SkipWorktreeRootCheck
+    [switch]$SkipWorktreeRootCheck,
+
+    [switch]$AutoWorktree,
+
+    [string]$RunId,
+
+    [string]$ArtifactRoot,
+
+    [switch]$CleanRoom
 )
 
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = Resolve-Path -Path (Join-Path $PSScriptRoot '..\..')
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Run-Pester'
-    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Run-Pester'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..')).Path
+$artifactRootResolved = $null
+$preflight = $null
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $LabVIEWVersion `
+        -LabVIEWBitness $LabVIEWBitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$AutoWorktree `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs `
+        -RunId $RunId `
+        -ArtifactRoot $ArtifactRoot `
+        -CleanRoom:$CleanRoom
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRoot = $preflight.RepoRoot
+    $artifactRootResolved = $preflight.ArtifactRoot
 }
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 if (Test-Path -Path $versionHelper) {
@@ -65,7 +89,7 @@ $configuration.Run.PassThru = $true
 $configuration.Output.Verbosity = 'Detailed'
 
 if ($CI) {
-    $resultsDir = Join-Path $repoRoot 'TestResults'
+    $resultsDir = if ($artifactRootResolved) { Join-Path $artifactRootResolved 'TestResults' } else { Join-Path $repoRoot 'TestResults' }
     if (-not (Test-Path -Path $resultsDir)) {
         New-Item -Path $resultsDir -ItemType Directory | Out-Null
     }
@@ -75,7 +99,19 @@ if ($CI) {
     $configuration.TestResult.OutputPath = (Join-Path $resultsDir ("pester-devmode-$LabVIEWVersion-$LabVIEWBitness.xml"))
 }
 
-$results = Invoke-Pester -Configuration $configuration
-if ($results.FailedCount -gt 0) {
-    exit 1
+$exitCode = 0
+try {
+    $results = Invoke-Pester -Configuration $configuration
+    if ($results.FailedCount -gt 0) {
+        $exitCode = 1
+    }
+}
+finally {
+    if ($preflight -and $preflight.CleanRoomAfter) {
+        Invoke-PreflightCleanup -RepoRoot $preflight.RepoRoot -Phase 'after'
+    }
+}
+
+if ($exitCode -ne 0) {
+    exit $exitCode
 }

--- a/Test/Pester/Run-Pester.ps1
+++ b/Test/Pester/Run-Pester.ps1
@@ -14,12 +14,26 @@ param(
 
     [switch]$RunDevModeTests,
 
-    [switch]$CI
+    [switch]$CI,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Resolve-Path -Path (Join-Path $PSScriptRoot '..\..')
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Run-Pester'
+    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Run-Pester'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 if (Test-Path -Path $versionHelper) {
     . $versionHelper

--- a/Test/Pester/VerifyIEPaths.DevMode.Integration.Tests.ps1
+++ b/Test/Pester/VerifyIEPaths.DevMode.Integration.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'Verify IE Paths (dev mode) integration' {
     BeforeAll {
         $script:skipAll = $false
         $script:skipReason = ''
-        $script:labviewVersion = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '2021' } else { $env:LABVIEW_VERSION }
+        $script:labviewVersion = $null
         $script:labviewBitness = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_BITNESS)) { '64' } else { $env:LABVIEW_BITNESS }
         $script:connectTimeoutMs = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_CONNECT_TIMEOUT_MS)) { '120000' } else { $env:LABVIEW_CONNECT_TIMEOUT_MS }
         $script:processTimeoutMs = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_PROCESS_TIMEOUT_MS)) { '300000' } else { $env:LABVIEW_PROCESS_TIMEOUT_MS }
@@ -106,16 +106,22 @@ Describe 'Verify IE Paths (dev mode) integration' {
         $script:revertScript = Join-Path $script:repoRoot '.github\actions\revert-development-mode\RevertDevelopmentMode.ps1'
         $script:verifyScript = Join-Path $script:repoRoot 'Tooling\Invoke-MissingIEFilesFromLVInstall.ps1'
         $script:statusHelper = Join-Path $script:repoRoot 'Tooling\support\VerifyIEPathsStatus.ps1'
+        $script:versionHelper = Join-Path $script:repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+
+        if (Test-Path -Path $script:versionHelper) {
+            . $script:versionHelper
+            $versionInput = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '' } else { $env:LABVIEW_VERSION }
+            $versionInfo = Get-LabVIEWVersionInfo -VersionInput $versionInput -RepoRoot $script:repoRoot
+            $script:labviewVersion = $versionInfo.Year
+        }
+
+        if ([string]::IsNullOrWhiteSpace($script:labviewVersion)) {
+            $script:labviewVersion = if ([string]::IsNullOrWhiteSpace($env:LABVIEW_VERSION)) { '2021' } else { $env:LABVIEW_VERSION }
+        }
 
         if (-not $script:runDevModeTests) {
             $script:skipAll = $true
             $script:skipReason = 'Set RUN_DEV_MODE_TESTS=1 to enable this integration test.'
-            return
-        }
-
-        if ($script:labviewVersion -ne '2021') {
-            $script:skipAll = $true
-            $script:skipReason = 'Only LabVIEW 2021 (21.0) is supported by this test suite.'
             return
         }
 

--- a/Tooling/DevModeFinalizeDisable.ps1
+++ b/Tooling/DevModeFinalizeDisable.ps1
@@ -18,6 +18,12 @@
 .PARAMETER RepoRoot
     Optional path to the repository root. If omitted, resolved relative to
     this script's location.
+
+.PARAMETER WorktreeRoot
+    Optional override for the worktree root used by guardrails.
+
+.PARAMETER SkipWorktreeRootCheck
+    Skip enforcing that RepoRoot is under the worktree root.
 #>
 
 param(
@@ -34,7 +40,12 @@ param(
     [string]$LogPath,
 
     [Parameter(Mandatory = $false)]
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -66,6 +77,15 @@ function Write-Log {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'DevModeFinalizeDisable'
+    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'DevModeFinalizeDisable'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion
 if (Test-Path -Path $versionHelper) {

--- a/Tooling/DevModeFinalizeDisable.ps1
+++ b/Tooling/DevModeFinalizeDisable.ps1
@@ -7,7 +7,7 @@
     to leave the system in a disabled state after iteration runs.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     LabVIEW bitness to target ("32" or "64"). Defaults to "64".
@@ -22,8 +22,9 @@
 
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateSet('2021')]
-    [string]$MinimumSupportedLVVersion = '2021',
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$MinimumSupportedLVVersion = '',
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('32', '64', IgnoreCase = $true)]
@@ -65,6 +66,16 @@ function Write-Log {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
 $logPathResolved = $LogPath
 if ([string]::IsNullOrWhiteSpace($logPathResolved)) {
     $logDir = Join-Path -Path $repoRoot -ChildPath 'Tooling\logs'
@@ -83,12 +94,12 @@ if (-not (Test-Path -Path $revertScript)) {
 }
 
 $scriptArgs = @{
-    MinimumSupportedLVVersion = $MinimumSupportedLVVersion
+    MinimumSupportedLVVersion = $labviewYear
     SupportedBitness          = $SupportedBitness
     RepoRoot              = $repoRoot
 }
 
-Write-Log ("start version={0} bitness={1} log={2}" -f $MinimumSupportedLVVersion, $SupportedBitness, $logPathResolved)
+Write-Log ("start version={0} bitness={1} log={2}" -f $labviewYear, $SupportedBitness, $logPathResolved)
 
 try {
     & $revertScript @scriptArgs

--- a/Tooling/DevModeFinalizeDisable.ps1
+++ b/Tooling/DevModeFinalizeDisable.ps1
@@ -24,6 +24,18 @@
 
 .PARAMETER SkipWorktreeRootCheck
     Skip enforcing that RepoRoot is under the worktree root.
+
+.PARAMETER AutoWorktree
+    Auto-create a short-path worktree and re-run from there when needed.
+
+.PARAMETER RunId
+    Optional run identifier used for artifact isolation.
+
+.PARAMETER ArtifactRoot
+    Optional override for the artifact output root.
+
+.PARAMETER CleanRoom
+    If set, purge known output folders before and after the run.
 #>
 
 param(
@@ -45,7 +57,15 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$WorktreeRoot,
 
-    [switch]$SkipWorktreeRootCheck
+    [switch]$SkipWorktreeRootCheck,
+
+    [switch]$AutoWorktree,
+
+    [string]$RunId,
+
+    [string]$ArtifactRoot,
+
+    [switch]$CleanRoom
 )
 
 $ErrorActionPreference = 'Stop'
@@ -77,14 +97,30 @@ function Write-Log {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'DevModeFinalizeDisable'
-    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'DevModeFinalizeDisable'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$artifactRootResolved = $null
+$preflight = $null
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $MinimumSupportedLVVersion `
+        -LabVIEWBitness $SupportedBitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$AutoWorktree `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs `
+        -RunId $RunId `
+        -ArtifactRoot $ArtifactRoot `
+        -CleanRoom:$CleanRoom
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRoot = $preflight.RepoRoot
+    $artifactRootResolved = $preflight.ArtifactRoot
 }
 $versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion
@@ -98,7 +134,7 @@ if ([string]::IsNullOrWhiteSpace($labviewYear)) {
 }
 $logPathResolved = $LogPath
 if ([string]::IsNullOrWhiteSpace($logPathResolved)) {
-    $logDir = Join-Path -Path $repoRoot -ChildPath 'Tooling\logs'
+    $logDir = if ($artifactRootResolved) { Join-Path -Path $artifactRootResolved -ChildPath 'logs' } else { Join-Path -Path $repoRoot -ChildPath 'Tooling\logs' }
     $null = New-Item -Path $logDir -ItemType Directory -Force
     $logPathResolved = Join-Path -Path $logDir -ChildPath ("dev-mode-final-disable-{0}.log" -f (Get-Date -Format 'yyyyMMdd-HHmmss'))
 } else {
@@ -131,4 +167,8 @@ try {
 } catch {
     Write-Log ("error message={0}" -f $($_.Exception.Message))
     throw
+} finally {
+    if ($preflight -and $preflight.CleanRoomAfter) {
+        Invoke-PreflightCleanup -RepoRoot $preflight.RepoRoot -Phase 'after'
+    }
 }

--- a/Tooling/DevModeIterate.ps1
+++ b/Tooling/DevModeIterate.ps1
@@ -42,6 +42,18 @@
 .PARAMETER SkipWorktreeRootCheck
     Skip enforcing that RepoRoot is under the worktree root.
 
+.PARAMETER AutoWorktree
+    Auto-create a short-path worktree and re-run from there when needed.
+
+.PARAMETER RunId
+    Optional run identifier used for artifact isolation.
+
+.PARAMETER ArtifactRoot
+    Optional override for the artifact output root.
+
+.PARAMETER CleanRoom
+    If set, purge known output folders before and after the run.
+
 .EXAMPLE
     .\Tooling\DevModeIterate.ps1 -Iterations 3 -MinimumSupportedLVVersion 2021 -SupportedBitness 64
 
@@ -90,7 +102,15 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$WorktreeRoot,
 
-    [switch]$SkipWorktreeRootCheck
+    [switch]$SkipWorktreeRootCheck,
+
+    [switch]$AutoWorktree,
+
+    [string]$RunId,
+
+    [string]$ArtifactRoot,
+
+    [switch]$CleanRoom
 )
 
 $ErrorActionPreference = 'Stop'
@@ -111,14 +131,30 @@ function Resolve-RepoRoot {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'DevModeIterate'
-    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'DevModeIterate'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$artifactRootResolved = $null
+$preflight = $null
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $MinimumSupportedLVVersion `
+        -LabVIEWBitness $SupportedBitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$AutoWorktree `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs `
+        -RunId $RunId `
+        -ArtifactRoot $ArtifactRoot `
+        -CleanRoom:$CleanRoom
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRoot = $preflight.RepoRoot
+    $artifactRootResolved = $preflight.ArtifactRoot
 }
 $versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion
@@ -132,7 +168,7 @@ if ([string]::IsNullOrWhiteSpace($labviewYear)) {
 }
 $logPathResolved = $LogPath
 if ([string]::IsNullOrWhiteSpace($logPathResolved)) {
-    $logDir = Join-Path -Path $repoRoot -ChildPath 'Tooling\logs'
+    $logDir = if ($artifactRootResolved) { Join-Path -Path $artifactRootResolved -ChildPath 'logs' } else { Join-Path -Path $repoRoot -ChildPath 'Tooling\logs' }
     $null = New-Item -Path $logDir -ItemType Directory -Force
     $logPathResolved = Join-Path -Path $logDir -ChildPath ("dev-mode-iterate-{0}.log" -f (Get-Date -Format 'yyyyMMdd-HHmmss'))
 } else {
@@ -312,5 +348,8 @@ try {
         } catch {
             Write-IterationLog ("transcript_stop_failed message={0}" -f $($_.Exception.Message))
         }
+    }
+    if ($preflight -and $preflight.CleanRoomAfter) {
+        Invoke-PreflightCleanup -RepoRoot $preflight.RepoRoot -Phase 'after'
     }
 }

--- a/Tooling/DevModeIterate.ps1
+++ b/Tooling/DevModeIterate.ps1
@@ -36,6 +36,12 @@
     Optional path to the repository root. If omitted, resolved relative to
     this script's location.
 
+.PARAMETER WorktreeRoot
+    Optional override for the worktree root used by guardrails.
+
+.PARAMETER SkipWorktreeRootCheck
+    Skip enforcing that RepoRoot is under the worktree root.
+
 .EXAMPLE
     .\Tooling\DevModeIterate.ps1 -Iterations 3 -MinimumSupportedLVVersion 2021 -SupportedBitness 64
 
@@ -79,7 +85,12 @@ param(
     [string]$TranscriptPath,
 
     [Parameter(Mandatory = $false)]
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -100,6 +111,15 @@ function Resolve-RepoRoot {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'DevModeIterate'
+    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'DevModeIterate'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion
 if (Test-Path -Path $versionHelper) {

--- a/Tooling/DevModeIterate.ps1
+++ b/Tooling/DevModeIterate.ps1
@@ -8,7 +8,7 @@
     scripts parse g-cli output for dev-mode error codes.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     LabVIEW bitness to target ("32" or "64"). Defaults to "64".
@@ -45,8 +45,9 @@
 
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateSet('2021')]
-    [string]$MinimumSupportedLVVersion = '2021',
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$MinimumSupportedLVVersion = '',
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('32', '64', IgnoreCase = $true)]
@@ -99,6 +100,16 @@ function Resolve-RepoRoot {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path -Path $repoRoot -ChildPath 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
 $logPathResolved = $LogPath
 if ([string]::IsNullOrWhiteSpace($logPathResolved)) {
     $logDir = Join-Path -Path $repoRoot -ChildPath 'Tooling\logs'
@@ -123,7 +134,7 @@ if (-not (Test-Path -Path $revertScript)) {
 }
 
 $scriptArgs = @{
-    MinimumSupportedLVVersion = $MinimumSupportedLVVersion
+    MinimumSupportedLVVersion = $labviewYear
     SupportedBitness          = $SupportedBitness
     RepoRoot              = $repoRoot
 }
@@ -208,7 +219,7 @@ function Invoke-DevModeScript {
 }
 
 Write-IterationLog ("start version={0} bitness={1} iterations={2} sequence={3} log={4}" -f `
-    $MinimumSupportedLVVersion, $SupportedBitness, $Iterations, ($ModeSequence -join ','), $logPathResolved)
+    $labviewYear, $SupportedBitness, $Iterations, ($ModeSequence -join ','), $logPathResolved)
 
 $transcriptActive = $false
 $transcriptPathResolved = $null

--- a/Tooling/Invoke-InWorktree.ps1
+++ b/Tooling/Invoke-InWorktree.ps1
@@ -1,0 +1,98 @@
+#Requires -Version 7.0
+<#[
+.SYNOPSIS
+    Runs a command or script from a short-path worktree.
+
+.DESCRIPTION
+    Creates a worktree under the configured worktree root and invokes the
+    provided command or script from that path. This helps keep build/test
+    artifacts isolated from the main repo path.
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'Command')]
+param(
+    [Parameter(Mandatory = $true, ParameterSetName = 'Command')]
+    [string]$Command,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Script')]
+    [string]$ScriptPath,
+
+    [Parameter(Mandatory = $false, ParameterSetName = 'Script')]
+    [string[]]$ScriptArguments,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeName,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Ref = 'HEAD'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    param([string]$PathOverride)
+
+    if ($PathOverride) {
+        if (-not (Test-Path -Path $PathOverride)) {
+            throw "RepoRoot does not exist: $PathOverride"
+        }
+        return (Resolve-Path -Path $PathOverride).Path
+    }
+
+    return (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+}
+
+$repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$ensureScript = Join-Path $repoRoot 'Tooling\Ensure-WorktreeRoot.ps1'
+if (-not (Test-Path -Path $ensureScript)) {
+    throw "Ensure-WorktreeRoot.ps1 not found at $ensureScript"
+}
+
+$newWorktreeScript = Join-Path $repoRoot 'Tooling\New-CIWorktree.ps1'
+if (-not (Test-Path -Path $newWorktreeScript)) {
+    throw "New-CIWorktree.ps1 not found at $newWorktreeScript"
+}
+
+$resolvedWorktreeRoot = & $ensureScript -WorktreeRoot $WorktreeRoot
+$env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+
+$suffix = if ([string]::IsNullOrWhiteSpace($WorktreeName)) {
+    "ci-guard-{0}" -f (Get-Date -Format 'yyyyMMdd-HHmmss')
+} else {
+    $WorktreeName
+}
+
+$worktreePath = & $newWorktreeScript -Ref $Ref -Name $suffix -WorktreeRoot $resolvedWorktreeRoot
+Write-Host ("Using worktree: {0}" -f $worktreePath)
+
+Push-Location -Path $worktreePath
+try {
+    if ($PSCmdlet.ParameterSetName -eq 'Script') {
+        $scriptFull = if ([System.IO.Path]::IsPathRooted($ScriptPath)) {
+            $ScriptPath
+        } else {
+            Join-Path $worktreePath $ScriptPath
+        }
+
+        if (-not (Test-Path -Path $scriptFull)) {
+            throw "Script not found at $scriptFull"
+        }
+
+        & pwsh -NoProfile -File $scriptFull @ScriptArguments
+    } else {
+        & pwsh -NoProfile -Command $Command
+    }
+
+    if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
+        throw "Command failed with exit code $LASTEXITCODE."
+    }
+}
+finally {
+    Pop-Location
+}

--- a/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
+++ b/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
@@ -18,6 +18,12 @@
     Optional path to the repository root. If omitted, resolved relative to
     this script's location.
 
+.PARAMETER WorktreeRoot
+    Optional override for the worktree root used by guardrails.
+
+.PARAMETER SkipWorktreeRootCheck
+    Skip enforcing that RepoRoot is under the worktree root.
+
 .PARAMETER StatusFileName
     Optional status file name (relative to repo root) or absolute path.
 
@@ -97,7 +103,12 @@ param(
     [switch]$FailOnUnknownStatus,
 
     [Parameter(Mandatory = $false)]
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -227,6 +238,15 @@ function Invoke-VerifyIEPathsStatusCleanup {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Invoke-MissingIEFilesFromLVInstall'
+    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Invoke-MissingIEFilesFromLVInstall'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+}
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion
 if (Test-Path -Path $versionHelper) {

--- a/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
+++ b/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
@@ -9,7 +9,7 @@
     the repo root to report pass/fail details.
 
 .PARAMETER MinimumSupportedLVVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SupportedBitness
     LabVIEW bitness to target ("32" or "64"). Defaults to "64".
@@ -52,8 +52,9 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateSet('2021')]
-    [string]$MinimumSupportedLVVersion = '2021',
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$MinimumSupportedLVVersion = '',
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('32', '64', IgnoreCase = $true)]
@@ -226,6 +227,16 @@ function Invoke-VerifyIEPathsStatusCleanup {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewYear = $MinimumSupportedLVVersion
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $versionInfo = Get-LabVIEWVersionInfo -VersionInput $MinimumSupportedLVVersion -RepoRoot $repoRoot
+    $labviewYear = $versionInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+    $labviewYear = '2021'
+}
 $gCliRunner = Join-Path -Path $PSScriptRoot -ChildPath 'support\GcliRunner.ps1'
 if (-not (Test-Path -Path $gCliRunner)) {
     throw "g-cli helper not found at $gCliRunner"
@@ -243,8 +254,8 @@ if (-not (Test-Path -Path $viPath)) {
     throw "VerifyIEPaths.vi not found at $viPath"
 }
 
-if (-not (Get-LabVIEWInstallRoot -Version $MinimumSupportedLVVersion -Bitness $SupportedBitness)) {
-    throw "LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) install not found."
+if (-not (Get-LabVIEWInstallRoot -Version $labviewYear -Bitness $SupportedBitness)) {
+    throw "LabVIEW $labviewYear ($SupportedBitness-bit) install not found."
 }
 
 if (-not (Get-Command g-cli -ErrorAction SilentlyContinue)) {
@@ -254,7 +265,7 @@ if (-not (Get-Command g-cli -ErrorAction SilentlyContinue)) {
 $gCliPath = (Get-Command g-cli -ErrorAction SilentlyContinue).Source
 
 $gCliArgs = @(
-    '--lv-ver', $MinimumSupportedLVVersion,
+    '--lv-ver', $labviewYear,
     '--arch', $SupportedBitness
 )
 
@@ -325,7 +336,7 @@ try {
 finally {
     Pop-Location
     try {
-        & g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness QuitLabVIEW | Out-Null
+        & g-cli --lv-ver $labviewYear --arch $SupportedBitness QuitLabVIEW | Out-Null
     }
     catch {
         Write-Warning ("Failed to close LabVIEW: {0}" -f $_.Exception.Message)

--- a/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
+++ b/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
@@ -24,6 +24,18 @@
 .PARAMETER SkipWorktreeRootCheck
     Skip enforcing that RepoRoot is under the worktree root.
 
+.PARAMETER AutoWorktree
+    Auto-create a short-path worktree and re-run from there when needed.
+
+.PARAMETER RunId
+    Optional run identifier used for artifact isolation.
+
+.PARAMETER ArtifactRoot
+    Optional override for the artifact output root.
+
+.PARAMETER CleanRoom
+    If set, purge known output folders before and after the run.
+
 .PARAMETER StatusFileName
     Optional status file name (relative to repo root) or absolute path.
 
@@ -108,7 +120,15 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$WorktreeRoot,
 
-    [switch]$SkipWorktreeRootCheck
+    [switch]$SkipWorktreeRootCheck,
+
+    [switch]$AutoWorktree,
+
+    [string]$RunId,
+
+    [string]$ArtifactRoot,
+
+    [switch]$CleanRoom
 )
 
 $ErrorActionPreference = 'Stop'
@@ -238,14 +258,31 @@ function Invoke-VerifyIEPathsStatusCleanup {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Invoke-MissingIEFilesFromLVInstall'
-    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Invoke-MissingIEFilesFromLVInstall'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$artifactRootResolved = $null
+$preflight = $null
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $MinimumSupportedLVVersion `
+        -LabVIEWBitness $SupportedBitness `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$AutoWorktree `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs `
+        -RunId $RunId `
+        -ArtifactRoot $ArtifactRoot `
+        -CleanRoom:$CleanRoom `
+        -RequireGcli
+    if ($preflight.Reinvoked) {
+        return
     }
+    $repoRoot = $preflight.RepoRoot
+    $artifactRootResolved = $preflight.ArtifactRoot
 }
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewYear = $MinimumSupportedLVVersion
@@ -256,6 +293,9 @@ if (Test-Path -Path $versionHelper) {
 }
 if ([string]::IsNullOrWhiteSpace($labviewYear)) {
     $labviewYear = '2021'
+}
+if ([string]::IsNullOrWhiteSpace($StatusFileArchiveDirectory) -and $artifactRootResolved) {
+    $StatusFileArchiveDirectory = Join-Path $artifactRootResolved 'verify-iepaths'
 }
 $gCliRunner = Join-Path -Path $PSScriptRoot -ChildPath 'support\GcliRunner.ps1'
 if (-not (Test-Path -Path $gCliRunner)) {
@@ -361,4 +401,8 @@ finally {
     catch {
         Write-Warning ("Failed to close LabVIEW: {0}" -f $_.Exception.Message)
     }
+}
+
+if ($preflight -and $preflight.CleanRoomAfter) {
+    Invoke-PreflightCleanup -RepoRoot $preflight.RepoRoot -Phase 'after'
 }

--- a/Tooling/Invoke-Preflight.ps1
+++ b/Tooling/Invoke-Preflight.ps1
@@ -1,0 +1,341 @@
+#Requires -Version 7.0
+<#[
+.SYNOPSIS
+    Shared preflight for local entrypoints.
+
+.DESCRIPTION
+    Enforces worktree-root usage, resolves artifact roots, logs run context,
+    and optionally cleans known output folders before/after a run.
+#>
+
+function Convert-BoundParametersToArgs {
+    param(
+        [hashtable]$BoundParameters
+    )
+
+    $args = @()
+    if (-not $BoundParameters) {
+        return $args
+    }
+
+    foreach ($key in $BoundParameters.Keys) {
+        $value = $BoundParameters[$key]
+        if ($value -is [System.Management.Automation.SwitchParameter]) {
+            if ($value.IsPresent) {
+                $args += "-$key"
+            } else {
+                $args += "-$key:`$false"
+            }
+            continue
+        }
+
+        if ($value -is [bool]) {
+            $args += "-$key"
+            $args += $value.ToString().ToLowerInvariant()
+            continue
+        }
+
+        if ($value -is [array]) {
+            foreach ($entry in $value) {
+                $args += "-$key"
+                $args += [string]$entry
+            }
+            continue
+        }
+
+        $args += "-$key"
+        $args += [string]$value
+    }
+
+    return $args
+}
+
+function Resolve-RepoRoot {
+    param(
+        [string]$RepoRoot
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+        throw 'RepoRoot is required.'
+    }
+
+    return (Resolve-Path -Path $RepoRoot -ErrorAction Stop).Path
+}
+
+function Get-RepoRelativePath {
+    param(
+        [string]$RepoRoot,
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot) -or [string]::IsNullOrWhiteSpace($Path)) {
+        return $Path
+    }
+
+    try {
+        $repoFull = [System.IO.Path]::GetFullPath($RepoRoot)
+        $relative = [System.IO.Path]::GetRelativePath($repoFull, $Path)
+        if (-not [string]::IsNullOrWhiteSpace($relative)) {
+            return $relative
+        }
+    } catch {
+        return $Path
+    }
+
+    return $Path
+}
+
+function New-RunId {
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $suffix = [guid]::NewGuid().ToString('N').Substring(0, 8)
+    return "{0}-{1}" -f $timestamp, $suffix
+}
+
+function Resolve-ArtifactRoot {
+    param(
+        [string]$WorktreeRoot,
+        [string]$RunId,
+        [string]$ArtifactRootOverride
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ArtifactRootOverride)) {
+        return [System.IO.Path]::GetFullPath($ArtifactRootOverride)
+    }
+
+    if ([string]::IsNullOrWhiteSpace($RunId)) {
+        $RunId = New-RunId
+    }
+
+    $base = Join-Path -Path $WorktreeRoot -ChildPath 'artifacts'
+    return (Join-Path -Path $base -ChildPath $RunId)
+}
+
+function Get-CleanRoomTargets {
+    param(
+        [string]$RepoRoot
+    )
+
+    $targets = @(
+        (Join-Path $RepoRoot 'TestResults'),
+        (Join-Path $RepoRoot 'builds'),
+        (Join-Path $RepoRoot 'Tooling\logs'),
+        (Join-Path $RepoRoot 'missing_files.txt'),
+        (Join-Path $RepoRoot '.github\actions\missing-in-project\missing_files.txt'),
+        (Join-Path $RepoRoot '.github\actions\run-unit-tests\UnitTestReport.xml'),
+        (Join-Path $RepoRoot 'Icon_Editor_Files_In_LV_Installation_Diagnostics.csv')
+    )
+
+    return $targets
+}
+
+function Invoke-PreflightCleanup {
+    param(
+        [string]$RepoRoot,
+        [string]$Phase = 'before'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+        return
+    }
+
+    Write-Host ("Clean-room ({0}): removing known output folders." -f $Phase)
+
+    foreach ($target in (Get-CleanRoomTargets -RepoRoot $RepoRoot)) {
+        if ([string]::IsNullOrWhiteSpace($target)) { continue }
+        if (Test-Path -Path $target) {
+            try {
+                Remove-Item -Path $target -Recurse -Force -ErrorAction Stop
+            } catch {
+                Write-Warning ("Failed to remove {0}: {1}" -f $target, $_.Exception.Message)
+            }
+        }
+    }
+
+    $pluginDir = Join-Path $RepoRoot 'resource\plugins'
+    if (Test-Path -Path $pluginDir) {
+        try {
+            Get-ChildItem -Path $pluginDir -Filter 'lv_icon*.lvlibp' -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+        } catch {
+            Write-Warning ("Failed to remove lv_icon*.lvlibp under {0}: {1}" -f $pluginDir, $_.Exception.Message)
+        }
+    }
+
+    try {
+        Get-ChildItem -Path $RepoRoot -Filter 'Icon_Editor_Files_In_LV_Installation_Diagnostics*.csv' -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+    } catch {
+        Write-Warning ("Failed to remove diagnostics CSV files: {0}" -f $_.Exception.Message)
+    }
+}
+
+function Write-PreflightContext {
+    param(
+        [string]$RepoRoot,
+        [string]$WorktreeRoot,
+        [string]$ArtifactRoot,
+        [string]$RunId,
+        [string]$LabVIEWVersion,
+        [string]$LabVIEWBitness
+    )
+
+    $contextLine = "LVIE_CONTEXT repo_root={0} worktree_root={1} run_id={2} artifact_root={3} labview_version={4} labview_bitness={5}" -f `
+        $RepoRoot, $WorktreeRoot, $RunId, $ArtifactRoot, $LabVIEWVersion, $LabVIEWBitness
+    Write-Host $contextLine
+
+    if (-not [string]::IsNullOrWhiteSpace($ArtifactRoot)) {
+        try {
+            if (-not (Test-Path -Path $ArtifactRoot)) {
+                New-Item -Path $ArtifactRoot -ItemType Directory -Force | Out-Null
+            }
+            $contextPath = Join-Path $ArtifactRoot 'context.json'
+            $contextObj = [pscustomobject]@{
+                repo_root       = $RepoRoot
+                worktree_root   = $WorktreeRoot
+                run_id          = $RunId
+                artifact_root   = $ArtifactRoot
+                labview_version = $LabVIEWVersion
+                labview_bitness = $LabVIEWBitness
+                timestamp_utc   = (Get-Date).ToUniversalTime().ToString('o')
+            }
+            $contextObj | ConvertTo-Json -Depth 5 | Out-File -FilePath $contextPath -Encoding ascii
+        } catch {
+            Write-Warning ("Failed to write preflight context file: {0}" -f $_.Exception.Message)
+        }
+    }
+}
+
+function Invoke-Preflight {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [string]$WorktreeRoot,
+
+        [string]$LabVIEWVersion,
+
+        [string]$LabVIEWBitness,
+
+        [switch]$SkipWorktreeRootCheck,
+
+        [switch]$AutoWorktree,
+
+        [string]$ScriptPath,
+
+        [string[]]$ScriptArguments,
+
+        [string]$RunId,
+
+        [string]$ArtifactRoot,
+
+        [switch]$CleanRoom,
+
+        [switch]$RequireGcli
+    )
+
+    $resolvedRepoRoot = Resolve-RepoRoot -RepoRoot $RepoRoot
+
+    $worktreeGuard = Join-Path $resolvedRepoRoot 'Tooling\support\WorktreeGuard.ps1'
+    if (-not (Test-Path -Path $worktreeGuard)) {
+        throw "WorktreeGuard.ps1 not found at $worktreeGuard"
+    }
+    . $worktreeGuard
+
+    $resolvedWorktreeRoot = Resolve-WorktreeRoot -WorktreeRoot $WorktreeRoot
+    $repoFull = ConvertTo-NormalizedPath -Path $resolvedRepoRoot
+    $rootFull = ConvertTo-NormalizedPath -Path $resolvedWorktreeRoot
+
+    $skipGuard = Test-WorktreeGuardSkip -Skip:$SkipWorktreeRootCheck
+    $underRoot = $repoFull.StartsWith($rootFull, [System.StringComparison]::OrdinalIgnoreCase)
+
+    if (-not $underRoot -and -not $skipGuard) {
+        if ($AutoWorktree -and $ScriptPath) {
+            $invokeInWorktree = Join-Path $resolvedRepoRoot 'Tooling\Invoke-InWorktree.ps1'
+            if (-not (Test-Path -Path $invokeInWorktree)) {
+                throw "Invoke-InWorktree.ps1 not found at $invokeInWorktree"
+            }
+
+            $relativeScript = Get-RepoRelativePath -RepoRoot $resolvedRepoRoot -Path $ScriptPath
+            Write-Host ("RepoRoot '{0}' is not under worktree root '{1}'. Re-invoking from worktree..." -f $resolvedRepoRoot, $resolvedWorktreeRoot)
+            & $invokeInWorktree -RepoRoot $resolvedRepoRoot -ScriptPath $relativeScript -ScriptArguments $ScriptArguments -WorktreeRoot $resolvedWorktreeRoot
+            return [pscustomobject]@{
+                Reinvoked = $true
+                RepoRoot = $resolvedRepoRoot
+            }
+        }
+
+        throw ("RepoRoot '{0}' is not under worktree root '{1}'. Set LVIE_WORKTREE_ROOT or run from a worktree." -f $repoFull.TrimEnd('\'), $rootFull.TrimEnd('\'))
+    }
+
+    if ($CleanRoom) {
+        Invoke-PreflightCleanup -RepoRoot $resolvedRepoRoot -Phase 'before'
+    }
+
+    $resolvedRunId = if ([string]::IsNullOrWhiteSpace($RunId)) {
+        if (-not [string]::IsNullOrWhiteSpace($env:LVIE_RUN_ID)) { $env:LVIE_RUN_ID } else { New-RunId }
+    } else { $RunId }
+
+    $explicitArtifacts = (-not [string]::IsNullOrWhiteSpace($ArtifactRoot)) -or `
+        (-not [string]::IsNullOrWhiteSpace($RunId)) -or `
+        (-not [string]::IsNullOrWhiteSpace($env:LVIE_ARTIFACT_ROOT)) -or `
+        $CleanRoom
+
+    $enableArtifacts = $explicitArtifacts -or `
+        ($env:GITHUB_ACTIONS -ne 'true') -or `
+        ($env:LVIE_ENABLE_ARTIFACT_ROOT -eq '1')
+
+    $resolvedArtifactRoot = $null
+    if ($enableArtifacts) {
+        $resolvedArtifactRoot = if (-not [string]::IsNullOrWhiteSpace($ArtifactRoot)) {
+            Resolve-ArtifactRoot -WorktreeRoot $resolvedWorktreeRoot -RunId $resolvedRunId -ArtifactRootOverride $ArtifactRoot
+        } elseif (-not [string]::IsNullOrWhiteSpace($env:LVIE_ARTIFACT_ROOT)) {
+            $env:LVIE_ARTIFACT_ROOT
+        } else {
+            Resolve-ArtifactRoot -WorktreeRoot $resolvedWorktreeRoot -RunId $resolvedRunId -ArtifactRootOverride $null
+        }
+        if ($resolvedArtifactRoot) {
+            $resolvedArtifactRoot = [System.IO.Path]::GetFullPath($resolvedArtifactRoot)
+        }
+        if (-not (Test-Path -Path $resolvedArtifactRoot)) {
+            New-Item -Path $resolvedArtifactRoot -ItemType Directory -Force | Out-Null
+        }
+    }
+
+    $env:LVIE_RUN_ID = $resolvedRunId
+    if ($resolvedArtifactRoot) {
+        $env:LVIE_ARTIFACT_ROOT = $resolvedArtifactRoot
+    }
+    $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+
+    if ($RequireGcli -and -not (Get-Command g-cli -ErrorAction SilentlyContinue)) {
+        throw 'g-cli.exe not found in PATH.'
+    }
+
+    $labviewInfo = $null
+    $resolvedLabVIEWVersion = $LabVIEWVersion
+    $versionHelper = Join-Path $resolvedRepoRoot 'Tooling\support\LabVIEWVersion.ps1'
+    if (Test-Path -Path $versionHelper) {
+        try {
+            . $versionHelper
+            $labviewInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $resolvedRepoRoot
+            if ($labviewInfo) {
+                $resolvedLabVIEWVersion = $labviewInfo.Year
+            }
+        } catch {
+            $labviewInfo = $null
+        }
+    }
+
+    Write-PreflightContext -RepoRoot $resolvedRepoRoot -WorktreeRoot $resolvedWorktreeRoot -ArtifactRoot $resolvedArtifactRoot -RunId $resolvedRunId -LabVIEWVersion $resolvedLabVIEWVersion -LabVIEWBitness $LabVIEWBitness
+
+    return [pscustomobject]@{
+        Reinvoked           = $false
+        RepoRoot            = $resolvedRepoRoot
+        WorktreeRoot        = $resolvedWorktreeRoot
+        ArtifactRoot        = $resolvedArtifactRoot
+        RunId               = $resolvedRunId
+        LabVIEWVersion      = $resolvedLabVIEWVersion
+        LabVIEWInfo         = $labviewInfo
+        LabVIEWBitness      = $LabVIEWBitness
+        CleanRoomAfter      = $CleanRoom
+    }
+}

--- a/Tooling/Invoke-Preflight.ps1
+++ b/Tooling/Invoke-Preflight.ps1
@@ -24,7 +24,7 @@ function Convert-BoundParametersToArgs {
             if ($value.IsPresent) {
                 $args += "-$key"
             } else {
-                $args += "-$key:`$false"
+                $args += "-${key}:`$false"
             }
             continue
         }

--- a/Tooling/Pester/DevModeCycle.ps1
+++ b/Tooling/Pester/DevModeCycle.ps1
@@ -3,7 +3,7 @@ param(
     [string]$Ref = 'experimental/447-Sergio-Change-Number-1',
     [string[]]$ModeSequence = @('disable', 'enable'),
     [string[]]$AllowFailureModes = @(),
-    [ValidateSet('2021')]
+    [ValidatePattern('^\d{2,4}(\.\d+)?$')]
     [string]$LabVIEWVersion = '2021',
     [int]$PollSeconds = 2,
     [int]$TimeoutMinutes = 3,

--- a/Tooling/Run-CICompositeLocal-Auto.ps1
+++ b/Tooling/Run-CICompositeLocal-Auto.ps1
@@ -48,6 +48,15 @@
 
 .PARAMETER SkipWorktreeRootCheck
     Skip enforcing that RepoRoot is under the worktree root.
+
+.PARAMETER RunId
+    Optional run identifier used for artifact isolation.
+
+.PARAMETER ArtifactRoot
+    Optional override for the artifact output root.
+
+.PARAMETER CleanRoom
+    If set, purge known output folders before and after the run.
 #>
 
 [CmdletBinding()]
@@ -100,7 +109,15 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$RepoRoot,
 
-    [switch]$SkipWorktreeRootCheck
+    [switch]$SkipWorktreeRootCheck,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RunId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ArtifactRoot,
+
+    [switch]$CleanRoom
 )
 
 $ErrorActionPreference = 'Stop'
@@ -149,9 +166,9 @@ function Write-AutoHistoryEntry {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
 }
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewInfo = $null
@@ -190,32 +207,32 @@ if ($UseWorktree) {
     $runRepoRoot = & $worktreeScript -Ref HEAD -Name $suffix -WorktreeRoot $resolvedWorktreeRoot
     Write-Host ("Using worktree: {0}" -f $runRepoRoot)
 }
-$guardRoot = if ($resolvedWorktreeRoot) { $resolvedWorktreeRoot } else { $WorktreeRoot }
-if (Get-Command Assert-RepoRootUnderWorktreeRoot -ErrorAction SilentlyContinue) {
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $runRepoRoot -WorktreeRoot $guardRoot -Skip:$SkipWorktreeRootCheck -Context 'Run-CICompositeLocal-Auto'
-    Write-WorktreeContext -RepoRoot $runRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Run-CICompositeLocal-Auto'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+$preflight = $null
+$artifactRootResolved = $null
+if (Get-Command Invoke-Preflight -ErrorAction SilentlyContinue) {
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $runRepoRoot `
+        -WorktreeRoot $resolvedWorktreeRoot `
+        -LabVIEWVersion $LabVIEWVersion `
+        -LabVIEWBitness 'both' `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$false `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs `
+        -RunId $RunId `
+        -ArtifactRoot $ArtifactRoot `
+        -CleanRoom:$CleanRoom
+    if ($preflight.Reinvoked) {
+        return
     }
-} else {
-    $worktreeRoot = $env:LVIE_WORKTREE_ROOT
-    if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
-        $worktreeRoot = 'C:\dev'
-    }
-    $worktreeRootFull = [System.IO.Path]::GetFullPath($worktreeRoot)
-    if (-not $worktreeRootFull.EndsWith('\')) {
-        $worktreeRootFull += '\'
-    }
-    $runRepoRootFull = [System.IO.Path]::GetFullPath($runRepoRoot)
-    if (-not $runRepoRootFull.EndsWith('\')) {
-        $runRepoRootFull += '\'
-    }
-    if (-not $runRepoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $runRepoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
-    }
+    $artifactRootResolved = $preflight.ArtifactRoot
+} elseif ($resolvedWorktreeRoot) {
+    $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
 }
 
-$logRoot = Join-Path $repoRoot 'TestResults/agent-logs'
+$logRoot = if ($artifactRootResolved) { Join-Path $artifactRootResolved 'agent-logs' } else { Join-Path $repoRoot 'TestResults/agent-logs' }
 New-Item -Path $logRoot -ItemType Directory -Force | Out-Null
 $historyPath = Join-Path $logRoot 'auto-run-history.csv'
 Ensure-CsvHeader -Path $historyPath -Header 'timestamp,attempt,status,duration_seconds,connect_timeout_ms,process_timeout_ms'
@@ -232,6 +249,7 @@ for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
     $status = 'success'
     $startTime = Get-Date
     try {
+        $attemptRunId = if ($preflight -and $preflight.RunId) { \"{0}-{1}\" -f $preflight.RunId, $attemptLabel } else { $null }
         & $runScript `
             -LabVIEWVersion $LabVIEWVersion `
             -EnsureCleanState:$EnsureCleanState `
@@ -239,7 +257,10 @@ for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
             -ProcessTimeoutMs $attemptProcessTimeout `
             -RepoRoot $runRepoRoot `
             -WorktreeRoot $resolvedWorktreeRoot `
-            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck
+            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+            -RunId $attemptRunId `
+            -ArtifactRoot $ArtifactRoot `
+            -CleanRoom:$CleanRoom
     } catch {
         $status = "error:{0}" -f $_.Exception.Message
     }
@@ -258,4 +279,8 @@ for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
 
     $attemptConnectTimeout = [Math]::Min([int]([Math]::Ceiling($attemptConnectTimeout * $ConnectTimeoutGrowth)), $MaxConnectTimeoutMs)
     $attemptProcessTimeout = [Math]::Min([int]([Math]::Ceiling($attemptProcessTimeout * $ProcessTimeoutGrowth)), $MaxProcessTimeoutMs)
+}
+
+if ($preflight -and $preflight.CleanRoomAfter) {
+    Invoke-PreflightCleanup -RepoRoot $preflight.RepoRoot -Phase 'after'
 }

--- a/Tooling/Run-CICompositeLocal-Auto.ps1
+++ b/Tooling/Run-CICompositeLocal-Auto.ps1
@@ -45,6 +45,9 @@
 
 .PARAMETER RepoRoot
     Optional repository root override.
+
+.PARAMETER SkipWorktreeRootCheck
+    Skip enforcing that RepoRoot is under the worktree root.
 #>
 
 [CmdletBinding()]
@@ -95,7 +98,9 @@ param(
     [string]$WorktreeName,
 
     [Parameter(Mandatory = $false)]
-    [string]$RepoRoot
+    [string]$RepoRoot,
+
+    [switch]$SkipWorktreeRootCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -144,6 +149,10 @@ function Write-AutoHistoryEntry {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+}
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
 $labviewInfo = $null
 if (Test-Path -Path $versionHelper) {
@@ -181,21 +190,29 @@ if ($UseWorktree) {
     $runRepoRoot = & $worktreeScript -Ref HEAD -Name $suffix -WorktreeRoot $resolvedWorktreeRoot
     Write-Host ("Using worktree: {0}" -f $runRepoRoot)
 }
-
-$worktreeRoot = $env:LVIE_WORKTREE_ROOT
-if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
-    $worktreeRoot = 'C:\dev'
-}
-$worktreeRootFull = [System.IO.Path]::GetFullPath($worktreeRoot)
-if (-not $worktreeRootFull.EndsWith('\')) {
-    $worktreeRootFull += '\'
-}
-$runRepoRootFull = [System.IO.Path]::GetFullPath($runRepoRoot)
-if (-not $runRepoRootFull.EndsWith('\')) {
-    $runRepoRootFull += '\'
-}
-if (-not $runRepoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
-    throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $runRepoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
+$guardRoot = if ($resolvedWorktreeRoot) { $resolvedWorktreeRoot } else { $WorktreeRoot }
+if (Get-Command Assert-RepoRootUnderWorktreeRoot -ErrorAction SilentlyContinue) {
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $runRepoRoot -WorktreeRoot $guardRoot -Skip:$SkipWorktreeRootCheck -Context 'Run-CICompositeLocal-Auto'
+    Write-WorktreeContext -RepoRoot $runRepoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Run-CICompositeLocal-Auto'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+} else {
+    $worktreeRoot = $env:LVIE_WORKTREE_ROOT
+    if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
+        $worktreeRoot = 'C:\dev'
+    }
+    $worktreeRootFull = [System.IO.Path]::GetFullPath($worktreeRoot)
+    if (-not $worktreeRootFull.EndsWith('\')) {
+        $worktreeRootFull += '\'
+    }
+    $runRepoRootFull = [System.IO.Path]::GetFullPath($runRepoRoot)
+    if (-not $runRepoRootFull.EndsWith('\')) {
+        $runRepoRootFull += '\'
+    }
+    if (-not $runRepoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $runRepoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
+    }
 }
 
 $logRoot = Join-Path $repoRoot 'TestResults/agent-logs'
@@ -220,7 +237,9 @@ for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
             -EnsureCleanState:$EnsureCleanState `
             -ConnectTimeoutMs $attemptConnectTimeout `
             -ProcessTimeoutMs $attemptProcessTimeout `
-            -RepoRoot $runRepoRoot
+            -RepoRoot $runRepoRoot `
+            -WorktreeRoot $resolvedWorktreeRoot `
+            -SkipWorktreeRootCheck:$SkipWorktreeRootCheck
     } catch {
         $status = "error:{0}" -f $_.Exception.Message
     }

--- a/Tooling/Run-CICompositeLocal-Auto.ps1
+++ b/Tooling/Run-CICompositeLocal-Auto.ps1
@@ -8,7 +8,7 @@
     Uses the existing parity script for all work and logging.
 
 .PARAMETER LabVIEWVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER MaxAttempts
     Maximum number of attempts.
@@ -50,8 +50,9 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateSet('2021')]
-    [string]$LabVIEWVersion = '2021',
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$LabVIEWVersion = '',
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 100)]
@@ -143,6 +144,16 @@ function Write-AutoHistoryEntry {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewInfo = $null
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $labviewInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $repoRoot
+    $LabVIEWVersion = $labviewInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($LabVIEWVersion)) {
+    $LabVIEWVersion = '2021'
+}
 $runScript = Join-Path $repoRoot 'Tooling/Run-CICompositeLocal.ps1'
 if (-not (Test-Path -Path $runScript)) {
     throw "Run-CICompositeLocal.ps1 not found at $runScript"

--- a/Tooling/Run-CICompositeLocal.ps1
+++ b/Tooling/Run-CICompositeLocal.ps1
@@ -62,6 +62,12 @@
 .PARAMETER RepoRoot
     Optional repository root override.
 
+.PARAMETER WorktreeRoot
+    Optional override for the worktree root used by guardrails.
+
+.PARAMETER SkipWorktreeRootCheck
+    Skip enforcing that RepoRoot is under the worktree root.
+
 .PARAMETER Major
     Override major version.
 
@@ -128,6 +134,11 @@ param(
 
     [Parameter(Mandatory = $false)]
     [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorktreeRoot,
+
+    [switch]$SkipWorktreeRootCheck,
 
     [Parameter(Mandatory = $false)]
     [int]$Major,
@@ -489,20 +500,31 @@ if (Test-Path -Path $versionHelper) {
 if ([string]::IsNullOrWhiteSpace($LabVIEWVersion)) {
     $LabVIEWVersion = '2021'
 }
-$worktreeRoot = $env:LVIE_WORKTREE_ROOT
-if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
-    $worktreeRoot = 'C:\dev'
-}
-$worktreeRootFull = [System.IO.Path]::GetFullPath($worktreeRoot)
-if (-not $worktreeRootFull.EndsWith('\')) {
-    $worktreeRootFull += '\'
-}
-$repoRootFull = [System.IO.Path]::GetFullPath($repoRoot)
-if (-not $repoRootFull.EndsWith('\')) {
-    $repoRootFull += '\'
-}
-if (-not $repoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
-    throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $repoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
+$resolvedWorktreeRoot = $null
+$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
+if (Test-Path -Path $worktreeGuard) {
+    . $worktreeGuard
+    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Run-CICompositeLocal'
+    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Run-CICompositeLocal'
+    if ($resolvedWorktreeRoot) {
+        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
+    }
+} else {
+    $worktreeRoot = $env:LVIE_WORKTREE_ROOT
+    if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
+        $worktreeRoot = 'C:\dev'
+    }
+    $worktreeRootFull = [System.IO.Path]::GetFullPath($worktreeRoot)
+    if (-not $worktreeRootFull.EndsWith('\')) {
+        $worktreeRootFull += '\'
+    }
+    $repoRootFull = [System.IO.Path]::GetFullPath($repoRoot)
+    if (-not $repoRootFull.EndsWith('\')) {
+        $repoRootFull += '\'
+    }
+    if (-not $repoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $repoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
+    }
 }
 Push-Location -Path $repoRoot
 $script:RunFailed = $false
@@ -517,7 +539,7 @@ Ensure-CsvHeader -Path $script:RunHistoryPath -Header 'timestamp,status,duration
 Ensure-CsvHeader -Path $script:StepHistoryPath -Header 'timestamp,step,status,duration_seconds'
 $env:LABVIEW_CLOSE_METRICS_PATH = $script:CloseHistoryPath
 $runLog = Join-Path $logRoot "ci-local-$runTimestamp.log"
-$commandLine = "Run-CICompositeLocal.ps1 -LabVIEWVersion $LabVIEWVersion -EnsureCleanState:$EnsureCleanState -SkipVerifyIEPaths:$SkipVerifyIEPaths -SkipVipc:$SkipVipc -SkipMissingInProject:$SkipMissingInProject -SkipUnitTests:$SkipUnitTests -SkipBuildPpl:$SkipBuildPpl -SkipBuildVip:$SkipBuildVip -BumpType $BumpType -ConnectTimeoutMs $ConnectTimeoutMs -ProcessTimeoutMs $ProcessTimeoutMs -StatusFileTimeoutMs $StatusFileTimeoutMs -VipmTimeoutSeconds $VipmTimeoutSeconds -CloseLabVIEWMode $CloseLabVIEWMode"
+$commandLine = "Run-CICompositeLocal.ps1 -LabVIEWVersion $LabVIEWVersion -EnsureCleanState:$EnsureCleanState -SkipVerifyIEPaths:$SkipVerifyIEPaths -SkipVipc:$SkipVipc -SkipMissingInProject:$SkipMissingInProject -SkipUnitTests:$SkipUnitTests -SkipBuildPpl:$SkipBuildPpl -SkipBuildVip:$SkipBuildVip -BumpType $BumpType -ConnectTimeoutMs $ConnectTimeoutMs -ProcessTimeoutMs $ProcessTimeoutMs -StatusFileTimeoutMs $StatusFileTimeoutMs -VipmTimeoutSeconds $VipmTimeoutSeconds -CloseLabVIEWMode $CloseLabVIEWMode -WorktreeRoot $WorktreeRoot -SkipWorktreeRootCheck:$SkipWorktreeRootCheck"
 $script:TranscriptStarted = $false
 try {
     Start-Transcript -Path $runLog -Append | Out-Null

--- a/Tooling/Run-CICompositeLocal.ps1
+++ b/Tooling/Run-CICompositeLocal.ps1
@@ -5,17 +5,17 @@
 
 .DESCRIPTION
     Executes the key LabVIEW steps from ci-composite.yml locally:
-    - Verify IE Paths gate (2021 32/64)
-    - Apply VIPC dependencies (2021 32/64)
-    - Missing-in-project checks (2021 32/64)
-    - Unit tests (2021 32/64)
-    - Build PPLs (2021 32/64) + rename
-    - Build VIP (2021 64)
+    - Verify IE Paths gate (version 32/64)
+    - Apply VIPC dependencies (version 32/64)
+    - Missing-in-project checks (version 32/64)
+    - Unit tests (version 32/64)
+    - Build PPLs (version 32/64) + rename
+    - Build VIP (version 64)
 
     GitHub-only gates (issue-status, labels, artifact upload) are not included.
 
 .PARAMETER LabVIEWVersion
-    LabVIEW 2021 (21.0) only.
+    LabVIEW version year (e.g., 2021) or numeric version (e.g., 21.0).
 
 .PARAMETER SkipVerifyIEPaths
     Skip the Verify IE Paths gate.
@@ -81,8 +81,9 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [ValidateSet('2021')]
-    [string]$LabVIEWVersion = '2021',
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$LabVIEWVersion = '',
 
     [switch]$SkipVerifyIEPaths,
     [switch]$EnsureCleanState,
@@ -478,6 +479,16 @@ function Write-GCliBuildLogTail {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
+$labviewInfo = $null
+if (Test-Path -Path $versionHelper) {
+    . $versionHelper
+    $labviewInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $repoRoot
+    $LabVIEWVersion = $labviewInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($LabVIEWVersion)) {
+    $LabVIEWVersion = '2021'
+}
 $worktreeRoot = $env:LVIE_WORKTREE_ROOT
 if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
     $worktreeRoot = 'C:\dev'
@@ -523,11 +534,11 @@ try {
 
     Wait-ForIdle -RunHistoryPath $script:RunHistoryPath
 
-    $bitnessList = @('64', '32')
+$bitnessList = @('64', '32')
     foreach ($bitness in $bitnessList) {
         Assert-LabVIEWInstalled -Version $LabVIEWVersion -Bitness $bitness
     }
-    $vipLabVIEWMinorRevision = "0"
+    $vipLabVIEWMinorRevision = if ($labviewInfo) { [int]$labviewInfo.MinorRevision } else { 0 }
 
     $versionInfo = Get-LocalVersionInfo -RepoRoot $repoRoot -BumpType $BumpType
     if ($PSBoundParameters.ContainsKey('Major')) { $versionInfo.Major = $Major }

--- a/Tooling/Run-CICompositeLocal.ps1
+++ b/Tooling/Run-CICompositeLocal.ps1
@@ -68,6 +68,18 @@
 .PARAMETER SkipWorktreeRootCheck
     Skip enforcing that RepoRoot is under the worktree root.
 
+.PARAMETER AutoWorktree
+    Auto-create a short-path worktree and re-run from there when needed.
+
+.PARAMETER RunId
+    Optional run identifier used for artifact isolation.
+
+.PARAMETER ArtifactRoot
+    Optional override for the artifact output root.
+
+.PARAMETER CleanRoom
+    If set, purge known output folders before and after the run.
+
 .PARAMETER Major
     Override major version.
 
@@ -139,6 +151,16 @@ param(
     [string]$WorktreeRoot,
 
     [switch]$SkipWorktreeRootCheck,
+
+    [switch]$AutoWorktree,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RunId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ArtifactRoot,
+
+    [switch]$CleanRoom,
 
     [Parameter(Mandatory = $false)]
     [int]$Major,
@@ -442,10 +464,16 @@ function Get-DisplayInformationJson {
 function Copy-LatestVipToBuilds {
     param(
         [string]$RepoRoot,
-        [datetime]$Since
+        [datetime]$Since,
+        [string]$ArtifactRoot
     )
 
-    $buildsDir = Join-Path $RepoRoot 'builds'
+    $artifactRootResolved = if ([string]::IsNullOrWhiteSpace($ArtifactRoot)) { $env:LVIE_ARTIFACT_ROOT } else { $ArtifactRoot }
+    $buildsDir = if ([string]::IsNullOrWhiteSpace($artifactRootResolved)) {
+        Join-Path $RepoRoot 'builds'
+    } else {
+        Join-Path $artifactRootResolved 'builds'
+    }
     $vipDir = Join-Path $buildsDir 'VI Package'
     New-Item -Path $vipDir -ItemType Directory -Force | Out-Null
 
@@ -475,10 +503,16 @@ function Copy-LatestVipToBuilds {
 function Write-GCliBuildLogTail {
     param(
         [string]$RepoRoot,
-        [int]$TailLines = 120
+        [int]$TailLines = 120,
+        [string]$ArtifactRoot
     )
 
-    $logFile = Join-Path $RepoRoot 'builds/logs/gcli-build.log'
+    $artifactRootResolved = if ([string]::IsNullOrWhiteSpace($ArtifactRoot)) { $env:LVIE_ARTIFACT_ROOT } else { $ArtifactRoot }
+    $logFile = if ([string]::IsNullOrWhiteSpace($artifactRootResolved)) {
+        Join-Path $RepoRoot 'builds/logs/gcli-build.log'
+    } else {
+        Join-Path $artifactRootResolved 'builds/logs/gcli-build.log'
+    }
     if (-not (Test-Path -Path $logFile)) {
         Write-Host ("g-cli build log not found at {0}" -f $logFile)
         return
@@ -490,47 +524,51 @@ function Write-GCliBuildLogTail {
 }
 
 $repoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+$artifactRootResolved = $null
+$preflight = $null
+$preflightScript = Join-Path $repoRoot 'Tooling\Invoke-Preflight.ps1'
+if (Test-Path -Path $preflightScript) {
+    . $preflightScript
+    $scriptArgs = Convert-BoundParametersToArgs -BoundParameters $PSBoundParameters
+    $relativeScript = if ($PSCommandPath) { Get-RepoRelativePath -RepoRoot $repoRoot -Path $PSCommandPath } else { $null }
+    $preflight = Invoke-Preflight `
+        -RepoRoot $repoRoot `
+        -WorktreeRoot $WorktreeRoot `
+        -LabVIEWVersion $LabVIEWVersion `
+        -LabVIEWBitness 'both' `
+        -SkipWorktreeRootCheck:$SkipWorktreeRootCheck `
+        -AutoWorktree:$AutoWorktree `
+        -ScriptPath $relativeScript `
+        -ScriptArguments $scriptArgs `
+        -RunId $RunId `
+        -ArtifactRoot $ArtifactRoot `
+        -CleanRoom:$CleanRoom `
+        -RequireGcli
+    if ($preflight.Reinvoked) {
+        return
+    }
+    $repoRoot = $preflight.RepoRoot
+    $artifactRootResolved = $preflight.ArtifactRoot
+}
+
 $versionHelper = Join-Path $repoRoot 'Tooling\support\LabVIEWVersion.ps1'
-$labviewInfo = $null
-if (Test-Path -Path $versionHelper) {
+$labviewInfo = if ($preflight -and $preflight.LabVIEWInfo) { $preflight.LabVIEWInfo } else { $null }
+if (-not $labviewInfo -and (Test-Path -Path $versionHelper)) {
     . $versionHelper
     $labviewInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $repoRoot
+    $LabVIEWVersion = $labviewInfo.Year
+}
+if ([string]::IsNullOrWhiteSpace($LabVIEWVersion) -and $labviewInfo) {
     $LabVIEWVersion = $labviewInfo.Year
 }
 if ([string]::IsNullOrWhiteSpace($LabVIEWVersion)) {
     $LabVIEWVersion = '2021'
 }
-$resolvedWorktreeRoot = $null
-$worktreeGuard = Join-Path $repoRoot 'Tooling\support\WorktreeGuard.ps1'
-if (Test-Path -Path $worktreeGuard) {
-    . $worktreeGuard
-    $resolvedWorktreeRoot = Assert-RepoRootUnderWorktreeRoot -RepoRoot $repoRoot -WorktreeRoot $WorktreeRoot -Skip:$SkipWorktreeRootCheck -Context 'Run-CICompositeLocal'
-    Write-WorktreeContext -RepoRoot $repoRoot -WorktreeRoot $resolvedWorktreeRoot -Prefix 'Run-CICompositeLocal'
-    if ($resolvedWorktreeRoot) {
-        $env:LVIE_WORKTREE_ROOT = $resolvedWorktreeRoot
-    }
-} else {
-    $worktreeRoot = $env:LVIE_WORKTREE_ROOT
-    if ([string]::IsNullOrWhiteSpace($worktreeRoot)) {
-        $worktreeRoot = 'C:\dev'
-    }
-    $worktreeRootFull = [System.IO.Path]::GetFullPath($worktreeRoot)
-    if (-not $worktreeRootFull.EndsWith('\')) {
-        $worktreeRootFull += '\'
-    }
-    $repoRootFull = [System.IO.Path]::GetFullPath($repoRoot)
-    if (-not $repoRootFull.EndsWith('\')) {
-        $repoRootFull += '\'
-    }
-    if (-not $repoRootFull.StartsWith($worktreeRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw ("RepoRoot '{0}' is not under worktree root '{1}'. Consider using a short path or set LVIE_WORKTREE_ROOT." -f $repoRootFull.TrimEnd('\'), $worktreeRootFull.TrimEnd('\'))
-    }
-}
 Push-Location -Path $repoRoot
 $script:RunFailed = $false
 $runStart = Get-Date
 $runTimestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
-$logRoot = Join-Path $repoRoot 'TestResults/agent-logs'
+$logRoot = if ($artifactRootResolved) { Join-Path $artifactRootResolved 'agent-logs' } else { Join-Path $repoRoot 'TestResults/agent-logs' }
 New-Item -Path $logRoot -ItemType Directory -Force | Out-Null
 $script:RunHistoryPath = Join-Path $logRoot 'run-history.csv'
 $script:StepHistoryPath = Join-Path $logRoot 'step-history.csv'
@@ -539,7 +577,7 @@ Ensure-CsvHeader -Path $script:RunHistoryPath -Header 'timestamp,status,duration
 Ensure-CsvHeader -Path $script:StepHistoryPath -Header 'timestamp,step,status,duration_seconds'
 $env:LABVIEW_CLOSE_METRICS_PATH = $script:CloseHistoryPath
 $runLog = Join-Path $logRoot "ci-local-$runTimestamp.log"
-$commandLine = "Run-CICompositeLocal.ps1 -LabVIEWVersion $LabVIEWVersion -EnsureCleanState:$EnsureCleanState -SkipVerifyIEPaths:$SkipVerifyIEPaths -SkipVipc:$SkipVipc -SkipMissingInProject:$SkipMissingInProject -SkipUnitTests:$SkipUnitTests -SkipBuildPpl:$SkipBuildPpl -SkipBuildVip:$SkipBuildVip -BumpType $BumpType -ConnectTimeoutMs $ConnectTimeoutMs -ProcessTimeoutMs $ProcessTimeoutMs -StatusFileTimeoutMs $StatusFileTimeoutMs -VipmTimeoutSeconds $VipmTimeoutSeconds -CloseLabVIEWMode $CloseLabVIEWMode -WorktreeRoot $WorktreeRoot -SkipWorktreeRootCheck:$SkipWorktreeRootCheck"
+$commandLine = "Run-CICompositeLocal.ps1 -LabVIEWVersion $LabVIEWVersion -EnsureCleanState:$EnsureCleanState -SkipVerifyIEPaths:$SkipVerifyIEPaths -SkipVipc:$SkipVipc -SkipMissingInProject:$SkipMissingInProject -SkipUnitTests:$SkipUnitTests -SkipBuildPpl:$SkipBuildPpl -SkipBuildVip:$SkipBuildVip -BumpType $BumpType -ConnectTimeoutMs $ConnectTimeoutMs -ProcessTimeoutMs $ProcessTimeoutMs -StatusFileTimeoutMs $StatusFileTimeoutMs -VipmTimeoutSeconds $VipmTimeoutSeconds -CloseLabVIEWMode $CloseLabVIEWMode -WorktreeRoot $WorktreeRoot -SkipWorktreeRootCheck:$SkipWorktreeRootCheck -AutoWorktree:$AutoWorktree -RunId $RunId -ArtifactRoot $ArtifactRoot -CleanRoom:$CleanRoom"
 $script:TranscriptStarted = $false
 try {
     Start-Transcript -Path $runLog -Append | Out-Null
@@ -569,7 +607,7 @@ $bitnessList = @('64', '32')
     if ($PSBoundParameters.ContainsKey('Build')) { $versionInfo.Build = $Build }
     if ($PSBoundParameters.ContainsKey('Commit')) { $versionInfo.Commit = $Commit }
 
-    $artifactsRoot = Join-Path $repoRoot 'TestResults/ci-local'
+    $artifactsRoot = if ($artifactRootResolved) { Join-Path $artifactRootResolved 'ci-local' } else { Join-Path $repoRoot 'TestResults/ci-local' }
     New-Item -Path $artifactsRoot -ItemType Directory -Force | Out-Null
 
     if (-not $SkipVerifyIEPaths) {
@@ -788,13 +826,13 @@ $bitnessList = @('64', '32')
             }
         }
         catch {
-            Write-GCliBuildLogTail -RepoRoot $repoRoot
+            Write-GCliBuildLogTail -RepoRoot $repoRoot -ArtifactRoot $artifactRootResolved
             throw
         }
 
-        $vipOutput = Copy-LatestVipToBuilds -RepoRoot $repoRoot -Since $vipBuildStart
+        $vipOutput = Copy-LatestVipToBuilds -RepoRoot $repoRoot -Since $vipBuildStart -ArtifactRoot $artifactRootResolved
         if (-not $vipOutput) {
-            Write-GCliBuildLogTail -RepoRoot $repoRoot
+            Write-GCliBuildLogTail -RepoRoot $repoRoot -ArtifactRoot $artifactRootResolved
             throw "VIP build did not produce a .vip after $($vipBuildStart.ToString('yyyy-MM-dd HH:mm:ss'))."
         }
 
@@ -816,6 +854,9 @@ finally {
         catch {
             # ignore transcript failures
         }
+    }
+    if ($preflight -and $preflight.CleanRoomAfter) {
+        Invoke-PreflightCleanup -RepoRoot $preflight.RepoRoot -Phase 'after'
     }
     if ($env:LABVIEW_CLOSE_METRICS_PATH) {
         Remove-Item Env:LABVIEW_CLOSE_METRICS_PATH -ErrorAction SilentlyContinue

--- a/Tooling/support/LabVIEWVersion.ps1
+++ b/Tooling/support/LabVIEWVersion.ps1
@@ -1,0 +1,66 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Resolve LabVIEW version details from an input string or .lvversion.
+
+.DESCRIPTION
+    Accepts a LabVIEW version input (year like "2021" or numeric like "21.0")
+    and returns the corresponding year, numeric version, and minor revision.
+    When VersionInput is empty, the function reads .lvversion from RepoRoot.
+#>
+
+function Get-LabVIEWVersionInfo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$VersionInput,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RepoRoot
+    )
+
+    $raw = $VersionInput
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+            throw "RepoRoot is required when VersionInput is not provided."
+        }
+
+        $versionPath = Join-Path -Path $RepoRoot -ChildPath '.lvversion'
+        if (-not (Test-Path -Path $versionPath)) {
+            throw ".lvversion not found at $versionPath"
+        }
+
+        $raw = (Get-Content -Raw -Path $versionPath).Trim()
+    }
+
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw "LabVIEW version input is empty."
+    }
+
+    if (-not ($raw -match '^(?<major>\d{2,4})(?:\.(?<minor>\d+))?$')) {
+        throw "LabVIEW version '$raw' is invalid. Expected formats like '21.0' or '2021'."
+    }
+
+    $majorRaw = [int]$Matches['major']
+    $minor = if ($Matches['minor']) { [int]$Matches['minor'] } else { 0 }
+
+    if ($majorRaw -ge 2000) {
+        $year = $majorRaw
+        $numericMajor = $majorRaw - 2000
+    } else {
+        $numericMajor = $majorRaw
+        $year = 2000 + $majorRaw
+    }
+
+    if ($numericMajor -lt 0) {
+        throw "LabVIEW version '$raw' produced an invalid numeric major."
+    }
+
+    [pscustomobject]@{
+        Raw            = $raw
+        Year           = $year.ToString()
+        MinorRevision  = $minor
+        NumericMajor   = $numericMajor
+        NumericVersion = "$numericMajor.$minor"
+    }
+}

--- a/Tooling/support/WorktreeGuard.ps1
+++ b/Tooling/support/WorktreeGuard.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 7.0
+<#[
+.SYNOPSIS
+    Shared guardrails for enforcing short-path worktree usage.
+
+.DESCRIPTION
+    Resolves the configured worktree root and validates that RepoRoot
+    is under it. Allows explicit opt-out for advanced scenarios.
+#>
+
+[CmdletBinding()]
+param()
+
+function Test-WorktreeGuardSkip {
+    param(
+        [switch]$Skip
+    )
+
+    if ($Skip) {
+        return $true
+    }
+
+    $envValue = $env:LVIE_SKIP_WORKTREE_ROOT_CHECK
+    if ([string]::IsNullOrWhiteSpace($envValue)) {
+        return $false
+    }
+
+    $normalized = $envValue.Trim().ToLowerInvariant()
+    return ($normalized -notin @('0', 'false', 'no'))
+}
+
+function Resolve-WorktreeRoot {
+    param(
+        [string]$WorktreeRoot
+    )
+
+    $ensureScript = Join-Path $PSScriptRoot '..\Ensure-WorktreeRoot.ps1'
+    if (-not (Test-Path -Path $ensureScript)) {
+        throw "Ensure-WorktreeRoot.ps1 not found at $ensureScript"
+    }
+
+    $resolved = & $ensureScript -WorktreeRoot $WorktreeRoot
+    if ([string]::IsNullOrWhiteSpace($resolved)) {
+        throw 'Worktree root could not be resolved.'
+    }
+
+    return $resolved
+}
+
+function ConvertTo-NormalizedPath {
+    param(
+        [string]$Path
+    )
+
+    $full = [System.IO.Path]::GetFullPath($Path)
+    if (-not $full.EndsWith('\')) {
+        $full += '\'
+    }
+
+    return $full
+}
+
+function Assert-RepoRootUnderWorktreeRoot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [string]$WorktreeRoot,
+
+        [switch]$Skip,
+
+        [string]$Context
+    )
+
+    if (Test-WorktreeGuardSkip -Skip:$Skip) {
+        return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($RepoRoot)) {
+        throw 'RepoRoot is required to validate worktree root.'
+    }
+
+    $resolvedWorktreeRoot = Resolve-WorktreeRoot -WorktreeRoot $WorktreeRoot
+    $repoFull = ConvertTo-NormalizedPath -Path $RepoRoot
+    $rootFull = ConvertTo-NormalizedPath -Path $resolvedWorktreeRoot
+
+    if (-not $repoFull.StartsWith($rootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $contextLabel = if ([string]::IsNullOrWhiteSpace($Context)) { 'script' } else { $Context }
+        $message = "RepoRoot '{0}' is not under worktree root '{1}' for {2}." -f $repoFull.TrimEnd('\'), $rootFull.TrimEnd('\'), $contextLabel
+        $message += " Use Tooling\\New-CIWorktree.ps1 to create a short-path worktree or set LVIE_WORKTREE_ROOT."
+        $message += " To bypass, pass -SkipWorktreeRootCheck or set LVIE_SKIP_WORKTREE_ROOT_CHECK=1."
+        throw $message
+    }
+
+    return $resolvedWorktreeRoot
+}
+
+function Write-WorktreeContext {
+    param(
+        [string]$RepoRoot,
+        [string]$WorktreeRoot,
+        [string]$Prefix = 'Worktree'
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RepoRoot)) {
+        Write-Host ("{0} repo_root={1}" -f $Prefix, $RepoRoot)
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($WorktreeRoot)) {
+        Write-Host ("{0} worktree_root={1}" -f $Prefix, $WorktreeRoot)
+    }
+}

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -137,7 +137,7 @@ The `build-ppl` job uses a matrix to produce both bitnesses rather than distinct
    Go to **Settings → Actions → Runners** in your GitHub repository (or organization) and follow the steps to register a runner on your machine that has LabVIEW installed.
 
 3. **Label the Runner** (optional):
-   - Use labels such as `self-hosted-windows-lv` for the default jobs. The default CI matrix currently runs only on this Windows label.
+   - Use labels such as `self-hosted-windows-lv-ie` for the default jobs. The default CI matrix currently runs only on this Windows label.
    - `self-hosted-linux-lv` is included for potential future expansion but isn't used by the default jobs yet.
    - Adjust the workflow’s `runs-on` lines to match your runner labels. This helps ensure the correct environment is used for building the Icon Editor.
 
@@ -204,3 +204,4 @@ This runs Verify IE Paths, applies VIPC dependencies, runs missing-in-project ch
 - **Branding**: To highlight the **organization** or **repository** behind a particular build, simply pass `-CompanyName` and `-AuthorName` (or similar parameters) into the `Build.ps1` script. This metadata flows into the final **Display Information** of the Icon Editor’s VI Package.
 
 By adopting these workflows—**Development Mode Toggle** and **Build VI Package**—you can maintain a **streamlined, consistent** CI/CD process for the Icon Editor while customizing the VI Package with your own **unique** or **fork-specific** branding.
+

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -94,7 +94,7 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 
 ### 3.1 How the Action Is Triggered
 The `build-vi-package` directory defines a **composite action**. It does not listen for events on its own; instead, the CI workflow in [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) invokes it.
-That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. The `issue-status` and `changes` jobs run on GitHub-hosted `ubuntu-latest`. Subsequent jobs that require LabVIEW—`apply-deps`, `version`, `test`, `build-ppl`, and `build-vi-package`—execute on a self-hosted Windows runner (`self-hosted-windows-lv`). Only Windows-specific jobs (e.g., `test`, `build-ppl`, `build-vi-package`) require the self-hosted runner. Linux support is considered a future or custom expansion: you would need to extend the matrix and provide a corresponding runner label (for example, `self-hosted-linux-lv`). Pushes are limited to `main`, `develop`, `release-alpha/*`, `release-beta/*`, `release-rc/*`, `feature/*`, `hotfix/*`, and `issue-*` branches, and pull requests must target one of those branches. However, `build-vi-package` executes only if the `issue-status` job allows the pipeline to continue: the source branch name must contain `issue-<number>` (for example, `issue-123` or `feature/issue-123`) and the linked issue's Status must be **In Progress**. For pull requests, the `issue-status` gate evaluates the PR’s head branch before running the `version` and `build-ppl` jobs, which depend on this gate.
+That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. The `issue-status` and `changes` jobs run on GitHub-hosted `ubuntu-latest`. Subsequent jobs that require LabVIEW—`apply-deps`, `version`, `test`, `build-ppl`, and `build-vi-package`—execute on a self-hosted Windows runner (`self-hosted-windows-lv-ie`). Only Windows-specific jobs (e.g., `test`, `build-ppl`, `build-vi-package`) require the self-hosted runner. Linux support is considered a future or custom expansion: you would need to extend the matrix and provide a corresponding runner label (for example, `self-hosted-linux-lv`). Pushes are limited to `main`, `develop`, `release-alpha/*`, `release-beta/*`, `release-rc/*`, `feature/*`, `hotfix/*`, and `issue-*` branches, and pull requests must target one of those branches. However, `build-vi-package` executes only if the `issue-status` job allows the pipeline to continue: the source branch name must contain `issue-<number>` (for example, `issue-123` or `feature/issue-123`) and the linked issue's Status must be **In Progress**. For pull requests, the `issue-status` gate evaluates the PR’s head branch before running the `version` and `build-ppl` jobs, which depend on this gate.
 
 ### 3.2 Configurable Inputs / Parameters
 `ci-composite.yml` calls this action and provides all required inputs automatically. When invoking
@@ -126,7 +126,7 @@ components remain unchanged and only the build number increases.
 - **Fork Setup**:
   1. **Copy** the workflow file (`.github/workflows/ci-composite.yml`) into your fork.
   2. **Update** any references to the official repo name (`ni/labview-icon-editor`) if your fork is named differently.
- 3. **Self-Hosted Runner**: Confirm your runner uses the `self-hosted-windows-lv` label (or `self-hosted-linux-lv` for Linux jobs) or update `runs-on` to match your runner’s labels.
+ 3. **Self-Hosted Runner**: Confirm your runner uses the `self-hosted-windows-lv-ie` label (or `self-hosted-linux-lv` for Linux jobs) or update `runs-on` to match your runner’s labels.
   4. **Write Permissions**: In fork settings → Actions → General, ensure “Workflow Permissions” = “Read and write.”
 
 ### 3.4 Artifact Publication
@@ -208,7 +208,7 @@ components remain unchanged and only the build number increases.
    - Ensure your self-hosted runner OS is patched and has any new LabVIEW versions if your project updates.
 
 ### 6.2 Runner Management
-- **Labels**: The workflow uses `runs-on: self-hosted-windows-lv` (and `self-hosted-linux-lv` where applicable). Confirm your runner has the required label.
+- **Labels**: The workflow uses `runs-on: self-hosted-windows-lv-ie` (and `self-hosted-linux-lv` where applicable). Confirm your runner has the required label.
 - **Resource Monitoring**: If the build is large or slow, upgrade the machine specs or add more runners to handle parallel tasks.
 
 ### 6.3 Adding New Features
@@ -320,5 +320,6 @@ components remain unchanged and only the build number increases.
 ## 11. **Conclusion**
 
 By properly setting up environment variables, referencing your LabVIEW environment on a self-hosted runner, and using label-based version increments plus a commit-based build number, this GitHub Action automates your `.vip` build and artifact upload process. Maintainers can extend the pipeline with tagging or release steps if desired. Follow the troubleshooting steps if anything goes awry, and enjoy streamlined LabVIEW CI/CD!
+
 
 

--- a/docs/ci/actions/development-mode-toggle.md
+++ b/docs/ci/actions/development-mode-toggle.md
@@ -23,7 +23,7 @@ You do **not** need to copy/paste the entire workflow snippet here, as it’s al
    - Go to the "Actions" tab on your (or your fork's) GitHub repository.
    - Select the **"Toggle Development Mode"** workflow.
    - Click "Run workflow" and choose either `enable` or `disable` from the dropdown.
-   - LabVIEW version is fixed to **2021** (`labview_version`).
+   - LabVIEW version is provided via `labview_version` (year or numeric), defaulting to **2021** if omitted.
    - Choose a bitness (`bitness`, default `64`).
    - This will execute the PowerShell scripts ([`Set_Development_Mode.ps1`](../../../.github/actions/set-development-mode/Set_Development_Mode.ps1) or [`RevertDevelopmentMode.ps1`](../../../.github/actions/revert-development-mode/RevertDevelopmentMode.ps1)) on the **target self-hosted runner** (your personal machine or a shared machine).
 
@@ -139,17 +139,21 @@ When development mode fails, the VI error source string prints a **comma-separat
 **To change** how "dev mode" behaves, **edit those scripts** directly. 
 
 ### Integration Tests
-You can run the integration tests locally on a runner that has LabVIEW 2021 (21.0) 64-bit installed:
+You can run the integration tests locally on a runner that has LabVIEW 2021 (21.0) 32-bit or 64-bit installed:
 
 ```powershell
+pwsh -NoProfile -File .\Test\Pester\Run-Pester.ps1 -LabVIEWVersion 2021 -LabVIEWBitness 32 -ConnectTimeoutMs 180000 -ProcessTimeoutMs 300000
 pwsh -NoProfile -File .\Test\Pester\Run-Pester.ps1 -LabVIEWVersion 2021 -LabVIEWBitness 64 -ConnectTimeoutMs 180000 -ProcessTimeoutMs 300000
 ```
 
 To include the dev-mode integration tests (enable/disable dev mode and VerifyIEPaths checks):
 
 ```powershell
+pwsh -NoProfile -File .\Test\Pester\Run-Pester.ps1 -RunDevModeTests -LabVIEWVersion 2021 -LabVIEWBitness 32 -ConnectTimeoutMs 180000 -ProcessTimeoutMs 300000
 pwsh -NoProfile -File .\Test\Pester\Run-Pester.ps1 -RunDevModeTests -LabVIEWVersion 2021 -LabVIEWBitness 64 -ConnectTimeoutMs 180000 -ProcessTimeoutMs 300000
 ```
+
+To test both bitnesses in one run, use `-LabVIEWBitness both`.
 
 ### Pull Requests with Script Updates
 Collaborators are free to:

--- a/docs/ci/actions/development-mode-toggle.md
+++ b/docs/ci/actions/development-mode-toggle.md
@@ -54,7 +54,7 @@ If you have another workflow file (e.g., `my-other-workflow.yml`) in the same re
 
     jobs:
       call-dev-mode:
-        runs-on: [self-hosted-windows-lv]
+        runs-on: [self-hosted-windows-lv-ie]
         steps:
           - name: Invoke Dev Mode Toggle (enable)
             uses: ./.github/workflows/development-mode-toggle.yml
@@ -77,7 +77,7 @@ If you store “Development mode toggle” in a separate public repo, you can re
 
     jobs:
       remote-dev-mode:
-        runs-on: [self-hosted-windows-lv]
+        runs-on: [self-hosted-windows-lv-ie]
         steps:
           - name: Use remote Dev Mode Toggle
             uses: <owner>/<repo>/.github/workflows/development-mode-toggle.yml@main
@@ -101,7 +101,7 @@ If a collaborator forked your original repo, they might keep the workflow in the
 
     jobs:
       forked-workflow-call:
-        runs-on: [self-hosted-windows-lv]
+        runs-on: [self-hosted-windows-lv-ie]
         steps:
           - name: Call Dev Mode Toggle from My Fork
             uses: <your-fork>/<repo>/.github/workflows/development-mode-toggle.yml@my-feature-branch
@@ -168,3 +168,4 @@ Collaborators are free to:
 - GitHub Docs: https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow
 
 ---
+

--- a/docs/ci/actions/injecting-repo-org-to-vi-package.md
+++ b/docs/ci/actions/injecting-repo-org-to-vi-package.md
@@ -49,7 +49,7 @@ An abbreviated **GitHub Actions** example below mirrors the [`ci-composite.yml`]
 ```yaml
 jobs:
   version:
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,7 +62,7 @@ jobs:
       PATCH: ${{ steps.compute-version.outputs.PATCH }}
       BUILD: ${{ steps.compute-version.outputs.BUILD }}
   build-ppl:
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     needs: version
     strategy:
       matrix:
@@ -81,7 +81,7 @@ jobs:
           commit: ${{ github.sha }}
 
   build-vi-package:
-    runs-on: self-hosted-windows-lv
+    runs-on: self-hosted-windows-lv-ie
     needs: [build-ppl, version]
     steps:
       - uses: actions/checkout@v4
@@ -176,3 +176,4 @@ This legacy script produces a `.vip` file that, when inspected in VIPM or LabVIE
 - Each fork or organization can **uniquely** brand its builds.
 - CI/CD with **GitHub Actions** automatically **populates** build metadata, removing manual steps.  
 - You have a **clear**, **traceable** record of each build’s origin—particularly useful in multi-team or open-source projects.
+

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -116,7 +116,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - Follow GitHub’s CLI instructions.
 
 4. **Labels** (optional)
-   - The workflow uses the `self-hosted-windows-lv` label. Its `runs-on` expression also references `self-hosted-linux-lv` for potential Linux jobs, though the default matrix runs only on Windows. Label your runner accordingly, and prepare a Linux runner with `self-hosted-linux-lv` if you expand the matrix.
+   - The workflow uses the `self-hosted-windows-lv-ie` label. Its `runs-on` expression also references `self-hosted-linux-lv` for potential Linux jobs, though the default matrix runs only on Windows. Label your runner accordingly, and prepare a Linux runner with `self-hosted-linux-lv` if you expand the matrix.
 
 5. **Runner diagnostics cleanup (recommended)**
    - Some runner failures can occur before checkout if old diagnostics logs accumulate under the runner's `_diag\pages` folder.
@@ -204,5 +204,6 @@ Notes:
 - **Troubleshoot**: If manual environment edits are needed, consult `ManualSetup.md` or the original documentation for advanced configuration steps.  
 
 **Happy Building!** By integrating these workflows, you’ll maintain a **robust, automated CI/CD** pipeline for the LabVIEW Icon Editor—complete with **semantic versioning**, **build artifact uploads**, and **metadata branding** (company/repo).
+
 
 

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -110,7 +110,7 @@ For **detailed runner configuration**, see **`runner-setup-guide.md`**. Below is
 2. **Add a Self-Hosted Runner**  
    - Go to **Settings → Actions → Runners**. Follow GitHub’s steps to register a Windows runner on your machine with LabVIEW installed.  
 3. **Label Your Runner**  
-   - For example, use `self-hosted-windows-lv` (or `self-hosted-linux-lv` for Linux). Ensure your workflow’s `runs-on` references these labels.
+   - For example, use `self-hosted-windows-lv-ie` (or `self-hosted-linux-lv` for Linux). Ensure your workflow’s `runs-on` references these labels.
 
 ---
 
@@ -144,7 +144,7 @@ You’ll typically name the workflow file **`development-mode-toggle.yml`**. Its
    - Choose `enable` or `disable` to run the corresponding PowerShell script (`Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`).  
    - LabVIEW version is fixed to **2021** (`labview_version`).  
    - Choose a bitness (`bitness`, default `64`).  
-   - The workflow runs on your self-hosted runner (e.g., labeled `self-hosted-windows-lv`).  
+   - The workflow runs on your self-hosted runner (e.g., labeled `self-hosted-windows-lv-ie`).  
 
 2. **Important Note for Testing**  
    - With dev mode **enabled**, LabVIEW references local code, so installing the `.vip` may fail or cause conflicts.  
@@ -167,7 +167,7 @@ on:
 
 jobs:
   call-dev-mode:
-  runs-on: self-hosted-windows-lv
+  runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Invoke Dev Mode Toggle (enable)
         uses: ./.github/workflows/development-mode-toggle.yml
@@ -185,7 +185,7 @@ on:
 
 jobs:
   remote-dev-mode:
-  runs-on: self-hosted-windows-lv
+  runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Use remote Dev Mode Toggle
         uses: <owner>/<repo>/.github/workflows/development-mode-toggle.yml@main
@@ -203,7 +203,7 @@ on:
 
 jobs:
   forked-workflow-call:
-  runs-on: self-hosted-windows-lv
+  runs-on: self-hosted-windows-lv-ie
     steps:
       - name: Call Dev Mode Toggle from My Fork
         uses: <your-fork>/<repo>/.github/workflows/development-mode-toggle.yml@my-feature-branch
@@ -323,4 +323,5 @@ In order to **enforce** the Gitflow approach “hands-off”:
 - **Gitflow Diagram**: [Atlassian Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) or any other standard resource to visualize the overall branching approach (extended with alpha/beta/rc branches).
 
 ---
+
 

--- a/docs/powershell-dependency-scripts.md
+++ b/docs/powershell-dependency-scripts.md
@@ -62,8 +62,8 @@ Configures the repository for development by invoking `Prepare_LabVIEW_source.ps
 Undoes development mode by invoking `RestoreSetupLVSource.ps1` for both bitnesses. Helpful when leaving development or before distributing a build. Accepts `-ConnectTimeoutMs` and `-ProcessTimeoutMs` to pass through to g-cli.
 
 ## RunUnitTests.ps1
-Runs unit tests through g-cli and outputs a table of results. Requires an explicit `.lvproj` path via `-ProjectPath`. Used in CI workflows.
+Runs unit tests through g-cli and outputs a table of results. Requires an explicit `.lvproj` path via `-ProjectPath`. Ensure the LUnit dependency is installed for the selected bitness (apply `runner_dependencies.vipc` for both 32-bit and 64-bit). Used in CI workflows.
 
 ## Run-CICompositeLocal.ps1
-Runs a local CI parity sequence based on `ci-composite.yml`. This script validates Verify IE Paths, applies VIPC dependencies, runs missing-in-project checks and unit tests for LabVIEW 2021 (21.0), 32- and 64-bit, builds packed libraries, and produces the VI package using LabVIEW 2021 (21.0) 64-bit. The script always runs both 64-bit and 32-bit steps for LabVIEW 2021 (21.0), and most steps can be skipped via switches. Outputs are stored under `TestResults/ci-local`. Use `-ConnectTimeoutMs`, `-ProcessTimeoutMs`, and `-StatusFileTimeoutMs` to tune g-cli and status-file timing for your machine.
+Runs a local CI parity sequence based on `ci-composite.yml`. This script validates Verify IE Paths, applies VIPC dependencies, runs missing-in-project checks and unit tests for the LabVIEW version declared in `.lvversion` (defaulting to 2021/21.0), 32- and 64-bit, builds packed libraries, and produces the VI package using the 64-bit install of that version. The script always runs both 64-bit and 32-bit steps for the selected LabVIEW version, and most steps can be skipped via switches. Outputs are stored under `TestResults/ci-local`. Use `-ConnectTimeoutMs`, `-ProcessTimeoutMs`, and `-StatusFileTimeoutMs` to tune g-cli and status-file timing for your machine.
 

--- a/docs/powershell-dependency-scripts.md
+++ b/docs/powershell-dependency-scripts.md
@@ -4,6 +4,8 @@ This document lists the PowerShell scripts used to build, test, and distribute t
 
 Local entrypoints enforce short-path worktree usage by default. If a script fails because the repo is not under the worktree root, use `Tooling\New-CIWorktree.ps1` or `Tooling\Invoke-InWorktree.ps1`. Set `LVIE_SKIP_WORKTREE_ROOT_CHECK=1` or pass `-SkipWorktreeRootCheck` only when you intentionally want to bypass the guard.
 
+Per-run artifacts are written under `$WORKTREE_ROOT\artifacts\<runid>` when guardrails are active. Use `-RunId` or `-ArtifactRoot` to override, and `-CleanRoom` to purge known output folders before and after a run. Artifact roots are disabled by default inside GitHub Actions unless `LVIE_ENABLE_ARTIFACT_ROOT=1` (or an explicit `-ArtifactRoot`/`-RunId` is provided).
+
 ## Table of Contents
 
 - [AddTokenToLabVIEW.ps1](#addtokentolabviewps1)
@@ -23,6 +25,7 @@ Local entrypoints enforce short-path worktree usage by default. If a script fail
 - [Run-CICompositeLocal.ps1](#run-cicompositelocalps1)
 - [Invoke-InWorktree.ps1](#invoke-inworktreeps1)
 - [WorktreeGuard.ps1](#worktreeguardps1)
+- [Invoke-Preflight.ps1](#invoke-preflightps1)
 
 ---
 
@@ -76,4 +79,7 @@ Creates a short-path worktree and runs a command or script from that path. Use t
 
 ## WorktreeGuard.ps1
 Shared helper used by local entrypoints to enforce that `RepoRoot` is under the configured worktree root. Supports `-SkipWorktreeRootCheck` and `LVIE_SKIP_WORKTREE_ROOT_CHECK=1` for explicit bypass scenarios.
+
+## Invoke-Preflight.ps1
+Shared preflight used by local entrypoints. Enforces worktree root usage, creates per-run artifact roots, logs run context, and supports `-AutoWorktree` and `-CleanRoom` options.
 

--- a/docs/powershell-dependency-scripts.md
+++ b/docs/powershell-dependency-scripts.md
@@ -2,6 +2,8 @@
 
 This document lists the PowerShell scripts used to build, test, and distribute the LabVIEW Icon Editor. Each script is a dependency in the tooling chain and can be called directly or by other scripts.
 
+Local entrypoints enforce short-path worktree usage by default. If a script fails because the repo is not under the worktree root, use `Tooling\New-CIWorktree.ps1` or `Tooling\Invoke-InWorktree.ps1`. Set `LVIE_SKIP_WORKTREE_ROOT_CHECK=1` or pass `-SkipWorktreeRootCheck` only when you intentionally want to bypass the guard.
+
 ## Table of Contents
 
 - [AddTokenToLabVIEW.ps1](#addtokentolabviewps1)
@@ -19,6 +21,8 @@ This document lists the PowerShell scripts used to build, test, and distribute t
 - [RevertDevelopmentMode.ps1](#revertdevelopmentmodeps1)
 - [RunUnitTests.ps1](#rununittestsps1)
 - [Run-CICompositeLocal.ps1](#run-cicompositelocalps1)
+- [Invoke-InWorktree.ps1](#invoke-inworktreeps1)
+- [WorktreeGuard.ps1](#worktreeguardps1)
 
 ---
 
@@ -66,4 +70,10 @@ Runs unit tests through g-cli and outputs a table of results. Requires an explic
 
 ## Run-CICompositeLocal.ps1
 Runs a local CI parity sequence based on `ci-composite.yml`. This script validates Verify IE Paths, applies VIPC dependencies, runs missing-in-project checks and unit tests for the LabVIEW version declared in `.lvversion` (defaulting to 2021/21.0), 32- and 64-bit, builds packed libraries, and produces the VI package using the 64-bit install of that version. The script always runs both 64-bit and 32-bit steps for the selected LabVIEW version, and most steps can be skipped via switches. Outputs are stored under `TestResults/ci-local`. Use `-ConnectTimeoutMs`, `-ProcessTimeoutMs`, and `-StatusFileTimeoutMs` to tune g-cli and status-file timing for your machine.
+
+## Invoke-InWorktree.ps1
+Creates a short-path worktree and runs a command or script from that path. Use this when you want to keep artifacts isolated without manually creating worktrees. Accepts either `-Command` or `-ScriptPath`/`-ScriptArguments` and will reuse the configured worktree root.
+
+## WorktreeGuard.ps1
+Shared helper used by local entrypoints to enforce that `RepoRoot` is under the configured worktree root. Supports `-SkipWorktreeRootCheck` and `LVIE_SKIP_WORKTREE_ROOT_CHECK=1` for explicit bypass scenarios.
 


### PR DESCRIPTION
## Summary
- Add centralized preflight guardrails (mandatory worktree enforcement, auto-reinvoke option, run-id + artifact roots, clean-room mode, log contract)
- Route key outputs to per-run artifact roots when enabled
- Wire guardrails into local entrypoints and action scripts
- Document guardrail and artifact-root behavior
- Fix preflight switch arg formatting (avoid PowerShell variable parsing error)
- Serialize LabVIEW workflows with a shared concurrency group to avoid same-host overlap
- Scope LabVIEW concurrency to the self-hosted runner label (`self-hosted-windows-lv-ie`)
- Avoid `workflow_call` concurrency deadlock in missing-in-project reusable workflow
- Document concurrency + artifact output behavior in AGENTS.md
- Update workflows/docs to use the new runner label (`self-hosted-windows-lv-ie`)

## Testing
- `pwsh -NoProfile -File .\Tooling\Run-CICompositeLocal.ps1 -LabVIEWVersion 2021 -EnsureCleanState -AutoWorktree`
  - Worktree: `C:\dev\labview-icon-editor-ci-guard-20260201-133304`
  - Artifact root: `C:\dev\artifacts\20260201-133306-e88417b1`
  - Result: success (VerifyIEPaths, VIPC, Missing-in-Project, Unit Tests 64/32, PPL 64/32, VIP build)
  - VIP: `C:\dev\artifacts\20260201-133306-e88417b1\builds\VI Package\ni_icon_editor-0.1.1.1287.vip`
  - Note: release notes step logged `fatal: --unshallow ...` / `fatal: No names found`, but run completed.
