### PR TITLE
Automation: open sync PRs from upstream mirror

### DIFF
--- a/.github/workflows/sync-upstream-develop-pr.yml
+++ b/.github/workflows/sync-upstream-develop-pr.yml
@@ -1,0 +1,53 @@
+name: Sync Upstream Develop PR
+
+on:
+  push:
+    branches:
+      - sync/upstream-develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update sync PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = 'sync/upstream-develop';
+            const base = 'develop';
+
+            const prs = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${head}`,
+              base
+            });
+
+            if (prs.data.length > 0) {
+              core.info(`Sync PR already open: ${prs.data[0].html_url}`);
+              return;
+            }
+
+            const compare = await github.rest.repos.compareCommits({ owner, repo, base, head });
+            if ((compare.data.total_commits || 0) === 0) {
+              core.info('No commits to sync; skipping PR creation.');
+              return;
+            }
+
+            const title = 'Sync upstream develop into fork';
+            const body = [
+              'This PR keeps fork develop aligned by merging the upstream mirror branch (sync/upstream-develop) into fork develop.',
+              '',
+              'Use this PR as the promotion lane after upstream-parity tests pass.'
+            ].join('\n');
+
+            const pr = await github.rest.pulls.create({ owner, repo, head, base, title, body });
+            core.info(`Created PR: ${pr.data.html_url}`);


### PR DESCRIPTION
Adds a workflow that opens/updates a PR from sync/upstream-develop into develop when upstream mirror changes land.

This enables the two-lane workflow: upstream parity in sync branch, promotion into develop via PR.