### PR TITLE
ci: add runner-cli docker workflow

### DIFF
--- a/.github/workflows/runner-cli-docker.yml
+++ b/.github/workflows/runner-cli-docker.yml
@@ -1,0 +1,60 @@
+name: Runner CLI Docker (Linux)
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - release/*
+      - feature/*
+      - hotfix/*
+    paths:
+      - 'Tooling/runner-cli/**'
+      - 'Tooling/pylavi/**'
+      - 'Tooling/Run-ViValidate.ps1'
+      - 'Tooling/Get-PylaviOffenders.ps1'
+      - 'Tooling/Fetch-PylaviOffenders.ps1'
+      - 'Tooling/docker/runner-cli/**'
+      - '.github/workflows/runner-cli-docker.yml'
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'Tooling/runner-cli/**'
+      - 'Tooling/pylavi/**'
+      - 'Tooling/Run-ViValidate.ps1'
+      - 'Tooling/Get-PylaviOffenders.ps1'
+      - 'Tooling/Fetch-PylaviOffenders.ps1'
+      - 'Tooling/docker/runner-cli/**'
+      - '.github/workflows/runner-cli-docker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build runner-cli docker image
+        shell: bash
+        run: |
+          docker build -t lvie-runner-cli:ci -f Tooling/docker/runner-cli/Dockerfile Tooling/docker/runner-cli
+
+      - name: Run runner-cli + pylavi checks
+        shell: bash
+        run: |
+          docker run --rm -v "$PWD:/repo" -w /repo lvie-runner-cli:ci bash -lc "
+            set -euo pipefail
+            dotnet test Tooling/runner-cli/RunnerCli.Tests/RunnerCli.Tests.csproj -c Release
+            dotnet run --project Tooling/runner-cli/RunnerCli/RunnerCli.csproj --configuration Release -- version-gate --repo-root /repo --json
+            dotnet run --project Tooling/runner-cli/RunnerCli/RunnerCli.csproj --configuration Release -- pylavi scan --repo-root /repo --config Tooling/pylavi/vi-validate.yml --report-only --offenders-path /tmp/pylavi-offenders.json --log-path /tmp/vi_validate.log
+            test -s /tmp/pylavi-offenders.json
+            test -s /tmp/vi_validate.log
+            dotnet run --project Tooling/runner-cli/RunnerCli/RunnerCli.csproj --configuration Release -- pylavi summarize --path /tmp/pylavi-offenders.json --json --output-path /tmp/pylavi-summary.json
+            test -s /tmp/pylavi-summary.json
+          "

--- a/Tooling/docker/runner-cli/Dockerfile
+++ b/Tooling/docker/runner-cli/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        git \
+    && python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir pylavi \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo

--- a/Tooling/docker/runner-cli/README.md
+++ b/Tooling/docker/runner-cli/README.md
@@ -1,0 +1,18 @@
+# Runner CLI Linux Docker
+
+This image is intended for **runner-cli/pylavi/tooling** checks on Linux. It does **not** include LabVIEW or g-cli.
+
+## Build
+```bash
+docker build -t lvie-runner-cli:ci -f Tooling/docker/runner-cli/Dockerfile Tooling/docker/runner-cli
+```
+
+## Run (example)
+```bash
+docker run --rm -v "$PWD:/repo" -w /repo lvie-runner-cli:ci bash -lc "
+  dotnet test Tooling/runner-cli/RunnerCli.Tests/RunnerCli.Tests.csproj -c Release &&
+  dotnet run --project Tooling/runner-cli/RunnerCli/RunnerCli.csproj --configuration Release -- version-gate --repo-root /repo --json &&
+  dotnet run --project Tooling/runner-cli/RunnerCli/RunnerCli.csproj --configuration Release -- pylavi scan --repo-root /repo --config Tooling/pylavi/vi-validate.yml --report-only --offenders-path /tmp/pylavi-offenders.json --log-path /tmp/vi_validate.log &&
+  dotnet run --project Tooling/runner-cli/RunnerCli/RunnerCli.csproj --configuration Release -- pylavi summarize --path /tmp/pylavi-offenders.json --json --output-path /tmp/pylavi-summary.json
+"
+```

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -104,6 +104,15 @@ Below are the **key GitHub Actions** provided in this repository:
    - By default, “Company Name” and “Author Name” in the generated `.vip` come from `github.repository_owner` and `github.event.repository.name`. Update the “Generate display information JSON” step in [`ci-composite.yml`](../.github/workflows/ci-composite.yml) if you need custom values.
    - Uploads the `.vip` artifact to GitHub’s build artifacts.
 
+3. **Runner CLI (Reusable Build)**
+   - [`runner-cli-reusable.yml`](../.github/workflows/runner-cli-reusable.yml) publishes a self-contained `runner-cli` binary for a target RID.
+   - `ci-composite.yml` calls this reusable workflow and downloads the artifact to run `runner-cli version-gate` without rebuilding on every job.
+   - `runner-audit.yml` uses the published `runner-cli` artifact when available; falls back to PowerShell scripts otherwise.
+
+4. **Runner CLI Docker (Linux)**
+   - [`runner-cli-docker.yml`](../.github/workflows/runner-cli-docker.yml) builds a Linux Docker image with .NET + pylavi.
+   - Runs runner-cli tests plus a pylavi scan/summarize loop on Ubuntu to validate tooling without LabVIEW.
+
 #### Jobs in CI workflow
 
 The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks the build into several jobs:


### PR DESCRIPTION
Adds a Linux-only Docker workflow for runner-cli/pylavi/tooling checks and updates docs.\n\n- New Dockerfile + README under Tooling/docker/runner-cli\n- New workflow runner-cli-docker.yml\n- docs/ci-workflows.md updated