### PR TITLE
Runner-cli pylavi delta gate + CI runner-cli enforcement

### DIFF
--- a/.github/actions/missing-in-project/action.yml
+++ b/.github/actions/missing-in-project/action.yml
@@ -147,15 +147,33 @@ runs:
         $projectFile = '${{ steps.resolve.outputs.projFile }}'
         $lvInput = '${{ inputs.lv-ver }}'
 
+        function Test-Enabled {
+          param([string]$Value)
+          if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+          $normalized = $Value.Trim().ToLowerInvariant()
+          return ($normalized -eq '1' -or $normalized -eq 'true' -or $normalized -eq 'yes')
+        }
+        $requireRunnerCli = Test-Enabled $env:LVIE_REQUIRE_RUNNER_CLI
+        $runnerCliPath = $env:LVIE_RUNNER_CLI_PATH
+        if ([string]::IsNullOrWhiteSpace($runnerCliPath)) {
+          $cliName = if ($IsWindows) { 'runner-cli.exe' } else { 'runner-cli' }
+          $candidate = Join-Path $env:RUNNER_TEMP 'runner-cli' $cliName
+          if (Test-Path $candidate) {
+            $runnerCliPath = $candidate
+          }
+        }
         $runnerCliProject = Join-Path $repoRoot 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
-        $canUseRunnerCli = (Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject)
+        $useRunnerCliBinary = (-not [string]::IsNullOrWhiteSpace($runnerCliPath)) -and (Test-Path $runnerCliPath)
+        $canUseRunnerCli = $useRunnerCliBinary -or ((Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject))
+        if (-not $canUseRunnerCli -and $requireRunnerCli) {
+          throw "runner-cli is required but unavailable. Set LVIE_RUNNER_CLI_PATH or enable dotnet build for Tooling/runner-cli."
+        }
         if ($canUseRunnerCli) {
+          if ($useRunnerCliBinary -and -not $IsWindows) {
+            chmod +x $runnerCliPath
+          }
           Write-Host "Using runner-cli missing-in-project (incremental migration)."
           $args = @(
-            'run',
-            '--project', $runnerCliProject,
-            '--configuration', 'Release',
-            '--',
             'missing-in-project',
             '--repo-root', $repoRoot,
             '--arch', '${{ inputs.arch }}',
@@ -165,7 +183,17 @@ runs:
             $args += '--labview'
             $args += $lvInput
           }
-          & dotnet @args
+          if ($useRunnerCliBinary) {
+            & $runnerCliPath @args
+          } else {
+            $dotnetArgs = @(
+              'run',
+              '--project', $runnerCliProject,
+              '--configuration', 'Release',
+              '--'
+            ) + $args
+            & dotnet @dotnetArgs
+          }
           $exitCode = $LASTEXITCODE
           if ($exitCode -ne 0 -and $exitCode -ne $null) {
             exit $exitCode

--- a/.github/actions/pylavi-validate/README.md
+++ b/.github/actions/pylavi-validate/README.md
@@ -1,6 +1,6 @@
 # pylavi-validate
 
-Composite action that runs `vi_validate` (pylavi) against the repo using the LabVIEW version synced from `.lvversion` (or an explicit input that must match). Any configured `absolute_roots` are redacted in CI output and the uploaded log artifact. The step summary includes top-offender tables when available.
+Composite action that runs `vi_validate` (pylavi) against the repo using the LabVIEW version synced from `.lvversion` (or an explicit input that must match). Prefers `runner-cli` when available (set `LVIE_REQUIRE_RUNNER_CLI=1` to disable fallbacks). Any configured `absolute_roots` are redacted in CI output and the uploaded log artifact. The step summary includes top-offender tables when available, including optional baseline/delta details.
 
 ## Inputs
 - `config_path` (default: `Tooling/pylavi/vi-validate.yml`)
@@ -13,6 +13,16 @@ Composite action that runs `vi_validate` (pylavi) against the repo using the Lab
 - `offenders_name` (default: `pylavi-validate-offenders`)
 - `upload_log` (default: `true`)
 - `log_name` (default: `pylavi-validate-log`)
+- `baseline_path` (optional; baseline offenders report path for delta checks)
+- `baseline_required` (default: `false`; fail if baseline is missing)
+- `fail_on_delta` (default: `false`; fail if new offenders appear vs baseline)
+
+## Environment
+- `LVIE_RUNNER_CLI_PATH` (optional; prefer this runner-cli binary)
+- `LVIE_REQUIRE_RUNNER_CLI=1` to fail if runner-cli is unavailable (disables PowerShell fallback)
+- `LVIE_PYLAVI_BASELINE_PATH` (optional; baseline path when `baseline_path` input is empty)
+- `LVIE_PYLAVI_BASELINE_REQUIRED=1` (optional; same as `baseline_required`)
+- `LVIE_PYLAVI_FAIL_ON_DELTA=1` (optional; same as `fail_on_delta`)
 
 ## Example (report-only)
 ```yaml

--- a/.github/actions/pylavi-validate/action.yml
+++ b/.github/actions/pylavi-validate/action.yml
@@ -41,6 +41,18 @@ inputs:
     description: Artifact name for the vi_validate log.
     required: false
     default: pylavi-validate-log
+  baseline_path:
+    description: Optional baseline offenders report path (relative to repo root) for delta checks.
+    required: false
+    default: ''
+  baseline_required:
+    description: Fail if baseline_path is set but missing.
+    required: false
+    default: 'false'
+  fail_on_delta:
+    description: Fail if new offenders are detected compared to the baseline.
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -82,21 +94,49 @@ runs:
           $label = 'pylavi'
         }
         $absoluteRootsRaw = '${{ inputs.absolute_roots }}'
+        function Test-Enabled {
+          param([string]$Value)
+          if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+          $normalized = $Value.Trim().ToLowerInvariant()
+          return ($normalized -eq '1' -or $normalized -eq 'true' -or $normalized -eq 'yes')
+        }
+        $baselineInput = '${{ inputs.baseline_path }}'
+        if ([string]::IsNullOrWhiteSpace($baselineInput)) {
+          $baselineInput = $env:LVIE_PYLAVI_BASELINE_PATH
+        }
+        $baselineRequired = (Test-Enabled '${{ inputs.baseline_required }}') -or (Test-Enabled $env:LVIE_PYLAVI_BASELINE_REQUIRED)
+        $failOnDelta = (Test-Enabled '${{ inputs.fail_on_delta }}') -or (Test-Enabled $env:LVIE_PYLAVI_FAIL_ON_DELTA)
+        if ($baselineRequired -and [string]::IsNullOrWhiteSpace($baselineInput)) {
+          throw "baseline_required is true but baseline_path is empty. Set inputs.baseline_path or LVIE_PYLAVI_BASELINE_PATH."
+        }
+        $requireRunnerCli = Test-Enabled $env:LVIE_REQUIRE_RUNNER_CLI
+        $needsRunnerCli = $requireRunnerCli -or (-not [string]::IsNullOrWhiteSpace($baselineInput)) -or $baselineRequired -or $failOnDelta
         $viCommand = Get-Command vi_validate -ErrorAction SilentlyContinue
         if (-not $viCommand) {
           throw 'vi_validate not found in PATH. Install pylavi (python -m pip install pylavi).'
         }
         $commandLine = "{0} --config `"{1}`" --eq {2}" -f $viCommand.Source, $config, $labviewNumeric
         Write-Host ("vi_validate command ({0}): {1}" -f $label, $commandLine)
+        $runnerCliPath = $env:LVIE_RUNNER_CLI_PATH
+        if ([string]::IsNullOrWhiteSpace($runnerCliPath)) {
+          $cliName = if ($IsWindows) { 'runner-cli.exe' } else { 'runner-cli' }
+          $candidate = Join-Path $env:RUNNER_TEMP 'runner-cli' $cliName
+          if (Test-Path $candidate) {
+            $runnerCliPath = $candidate
+          }
+        }
         $runnerCliProject = Join-Path $env:GITHUB_WORKSPACE 'Tooling/runner-cli/RunnerCli/RunnerCli.csproj'
-        $canUseRunnerCli = (Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject)
+        $useRunnerCliBinary = (-not [string]::IsNullOrWhiteSpace($runnerCliPath)) -and (Test-Path $runnerCliPath)
+        $canUseRunnerCli = $useRunnerCliBinary -or ((Get-Command dotnet -ErrorAction SilentlyContinue) -and (Test-Path $runnerCliProject))
+        if (-not $canUseRunnerCli -and $needsRunnerCli) {
+          throw "runner-cli is required but unavailable. Set LVIE_RUNNER_CLI_PATH or enable dotnet build for Tooling/runner-cli."
+        }
         if ($canUseRunnerCli) {
+          if ($useRunnerCliBinary -and -not $IsWindows) {
+            chmod +x $runnerCliPath
+          }
           Write-Host "Using runner-cli pylavi scan (incremental migration)."
           $scanArgs = @(
-            'run',
-            '--project', $runnerCliProject,
-            '--configuration', 'Release',
-            '--',
             'pylavi', 'scan',
             '--repo-root', $env:GITHUB_WORKSPACE,
             '--config', $config,
@@ -115,22 +155,48 @@ runs:
           if ('${{ inputs.report_only }}' -eq 'true') {
             $scanArgs += '--report-only'
           }
-          & dotnet @scanArgs
+          if ($useRunnerCliBinary) {
+            & $runnerCliPath @scanArgs
+          } else {
+            $dotnetArgs = @(
+              'run',
+              '--project', $runnerCliProject,
+              '--configuration', 'Release',
+              '--'
+            ) + $scanArgs
+            & dotnet @dotnetArgs
+          }
           $scanExit = $LASTEXITCODE
 
           if (Test-Path -Path $offendersPath) {
             $summaryArgs = @(
-              'run',
-              '--project', $runnerCliProject,
-              '--configuration', 'Release',
-              '--',
               'pylavi', 'summarize',
               '--path', $offendersPath,
               '--label', $label,
               '--write-summary',
               '--top', '10'
             )
-            & dotnet @summaryArgs | Out-Host
+            if (-not [string]::IsNullOrWhiteSpace($baselineInput)) {
+              $summaryArgs += '--baseline'
+              $summaryArgs += $baselineInput
+            }
+            if ($baselineRequired) {
+              $summaryArgs += '--baseline-required'
+            }
+            if ($failOnDelta) {
+              $summaryArgs += '--fail-on-delta'
+            }
+            if ($useRunnerCliBinary) {
+              & $runnerCliPath @summaryArgs | Out-Host
+            } else {
+              $dotnetSummaryArgs = @(
+                'run',
+                '--project', $runnerCliProject,
+                '--configuration', 'Release',
+                '--'
+              ) + $summaryArgs
+              & dotnet @dotnetSummaryArgs | Out-Host
+            }
           }
 
           if ('${{ inputs.report_only }}' -eq 'true' -and $scanExit -ne 0) {

--- a/.github/workflows/build-runner-cli.yml
+++ b/.github/workflows/build-runner-cli.yml
@@ -93,6 +93,82 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
+  smoke-pr:
+    name: Smoke Runner CLI (PR linux-x64)
+    needs: build-and-test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Publish runner-cli (linux-x64)
+        shell: pwsh
+        run: |
+          $outputDir = Join-Path $env:RUNNER_TEMP 'runner-cli-pr'
+          dotnet publish "Tooling/runner-cli/RunnerCli/RunnerCli.csproj" `
+            --configuration Release `
+            --runtime linux-x64 `
+            --self-contained true `
+            -p:PublishSingleFile=true `
+            -p:PublishTrimmed=true `
+            --output $outputDir
+
+      - name: Smoke test runner-cli (linux-x64)
+        shell: pwsh
+        run: |
+          $cli = Join-Path $env:RUNNER_TEMP 'runner-cli-pr' 'runner-cli'
+          if (-not (Test-Path $cli)) {
+            Write-Error "runner-cli not found at $cli"
+            Get-ChildItem -Path $env:RUNNER_TEMP -Recurse -File | Select-Object -First 50 | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+          chmod +x $cli
+          & $cli --help
+          if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
+            throw "runner-cli --help failed with exit code $LASTEXITCODE"
+          }
+          & $cli version-gate --repo-root $env:GITHUB_WORKSPACE --json
+          if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
+            throw "runner-cli version-gate failed with exit code $LASTEXITCODE"
+          }
+
+          $fixture = Join-Path $env:GITHUB_WORKSPACE 'Tooling' 'pylavi' 'fixtures' 'pylavi-offenders.sample.json'
+          if (-not (Test-Path $fixture)) {
+            throw "Pylavi fixture not found at $fixture"
+          }
+
+          $summaryPath = Join-Path $env:RUNNER_TEMP 'pylavi-summary.json'
+          $output = & $cli pylavi summarize --path $fixture --json --output-path $summaryPath | Out-String
+          if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $null) {
+            throw "runner-cli pylavi summarize failed with exit code $LASTEXITCODE"
+          }
+
+          $report = $output | ConvertFrom-Json
+          if (-not $report.label) { throw "pylavi summarize JSON missing label" }
+          if ($report.total_fails -lt 1) { throw "pylavi summarize JSON missing total_fails" }
+          if (-not $report.top_offenders -or $report.top_offenders.Count -lt 1) { throw "pylavi summarize JSON missing top_offenders" }
+          if (-not $report.top_absolute_offenders -or $report.top_absolute_offenders.Count -lt 1) { throw "pylavi summarize JSON missing top_absolute_offenders" }
+
+          if (-not (Test-Path $summaryPath)) {
+            throw "pylavi summarize output file not found at $summaryPath"
+          }
+          $summary = Get-Content $summaryPath -Raw | ConvertFrom-Json
+          if (-not $summary.label) { throw "pylavi summarize output missing label" }
+          if (-not $summary.file -or ($summary.file -notlike "*pylavi-offenders.sample.json")) {
+            throw "pylavi summarize output missing file path"
+          }
+          if (-not $summary.has_findings) { throw "pylavi summarize output missing has_findings" }
+
+      - name: Shutdown dotnet build servers
+        if: always()
+        run: dotnet build-server shutdown
+
   smoke:
     name: Smoke Runner CLI (${{ matrix.rid }} on ${{ matrix.os }})
     needs: publish

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -11,6 +11,10 @@ env:
   LVIE_FORCE_NO_LABVIEW_DEVMODE: 1
   LVIE_RUNNER_ACL_AUTOFIX: 1
   LVIE_RUNNER_ACL_WARN_ONLY: 1
+  LVIE_REQUIRE_RUNNER_CLI: ${{ vars.LVIE_REQUIRE_RUNNER_CLI || '0' }}
+  LVIE_PYLAVI_BASELINE_PATH: ${{ vars.LVIE_PYLAVI_BASELINE_PATH || '' }}
+  LVIE_PYLAVI_BASELINE_REQUIRED: ${{ vars.LVIE_PYLAVI_BASELINE_REQUIRED || '0' }}
+  LVIE_PYLAVI_FAIL_ON_DELTA: ${{ vars.LVIE_PYLAVI_FAIL_ON_DELTA || '0' }}
 
 concurrency:
   group: labview-${{ github.repository }}-${{ vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}
@@ -124,6 +128,17 @@ jobs:
       rid: linux-x64
       artifact_name: runner-cli-linux-x64
 
+  runner-cli-build-win:
+    name: Build runner-cli (win-x64)
+    needs: run-metadata
+    uses: ./.github/workflows/runner-cli-reusable.yml
+    permissions:
+      actions: read
+      contents: read
+    with:
+      rid: win-x64
+      artifact_name: runner-cli-win-x64
+
   version-gate:
     name: LabVIEW Version Gate
     needs: [run-metadata, runner-cli-build]
@@ -182,6 +197,9 @@ jobs:
             }
             $info = $json | ConvertFrom-Json
             } else {
+              if ($env:LVIE_REQUIRE_RUNNER_CLI -eq '1') {
+                throw "LVIE_REQUIRE_RUNNER_CLI=1 but runner-cli was not available."
+              }
               Write-Warning "runner-cli unavailable; falling back to Assert-LabVIEWVersion.ps1."
               $info = & "$repoRoot/Tooling/Assert-LabVIEWVersion.ps1" -RepoRoot $repoRoot -Context 'ci-version-gate' -WriteSummary
             }
@@ -250,12 +268,30 @@ jobs:
 
   pylavi-validate:
     name: Validate LabVIEW Files (pylavi, report-only)
-    needs: [run-metadata, version-gate]
+    needs: [run-metadata, version-gate, runner-cli-build-win]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Download runner-cli artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.runner-cli-build-win.outputs.artifact_name }}
+          path: ${{ runner.temp }}/runner-cli
+      - name: Export runner-cli path
+        shell: pwsh
+        run: |
+          $cliPath = Join-Path $env:RUNNER_TEMP 'runner-cli' 'runner-cli.exe'
+          if (Test-Path $cliPath) {
+            "LVIE_RUNNER_CLI_PATH=$cliPath" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding ascii
+            Write-Host ("Using runner-cli at {0}" -f $cliPath)
+          } else {
+            Write-Warning ("runner-cli artifact missing at {0}" -f $cliPath)
+            if ($env:LVIE_REQUIRE_RUNNER_CLI -eq '1') {
+              throw "LVIE_REQUIRE_RUNNER_CLI=1 but runner-cli was not found."
+            }
+          }
       - name: Run vi_validate (strict, report-only)
         uses: ./.github/actions/pylavi-validate
         with:

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -894,7 +894,8 @@ jobs:
         id: vip-status
         shell: pwsh
         run: |
-          $statusPath = Join-Path $env:REPO_ROOT 'builds/status/vip-build.json'
+          $statusRoot = if (-not [string]::IsNullOrWhiteSpace($env:LVIE_ARTIFACT_ROOT)) { $env:LVIE_ARTIFACT_ROOT } else { $env:REPO_ROOT }
+          $statusPath = Join-Path $statusRoot 'builds/status/vip-build.json'
           $exists = Test-Path -Path $statusPath
           "exists=$($exists.ToString().ToLowerInvariant())" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
       - name: Upload VIP build status
@@ -902,7 +903,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vip-build-status
-          path: ${{ env.REPO_ROOT }}/builds/status/vip-build.json
+          path: ${{ env.LVIE_ARTIFACT_ROOT || env.REPO_ROOT }}/builds/status/vip-build.json
           if-no-files-found: warn
       - name: Prepare release notes artifact
         id: release-notes

--- a/.github/workflows/development-mode-toggle.yml
+++ b/.github/workflows/development-mode-toggle.yml
@@ -5,6 +5,7 @@ permissions:
 
 env:
   LVIE_FORCE_NO_LABVIEW_DEVMODE: 1
+  LVIE_REQUIRE_RUNNER_CLI: ${{ vars.LVIE_REQUIRE_RUNNER_CLI || '0' }}
 
 concurrency:
   group: labview-${{ github.repository }}-${{ vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}
@@ -171,6 +172,9 @@ jobs:
             }
             $lvInfo = $json | ConvertFrom-Json
           } else {
+            if ($env:LVIE_REQUIRE_RUNNER_CLI -eq '1') {
+              throw "LVIE_REQUIRE_RUNNER_CLI=1 but runner-cli was not available."
+            }
             Write-Warning "runner-cli unavailable; falling back to Assert-LabVIEWVersion.ps1."
             $assertScript = Join-Path $repoRoot 'Tooling\Assert-LabVIEWVersion.ps1'
             if (-not (Test-Path -Path $assertScript)) {

--- a/.github/workflows/runner-audit.yml
+++ b/.github/workflows/runner-audit.yml
@@ -6,6 +6,7 @@ permissions:
 env:
   LVIE_EXPECTED_RUNNER_LABEL: ${{ vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}
   LVIE_CANONICAL_RUNNER_LABEL: self-hosted-windows-lv
+  LVIE_REQUIRE_RUNNER_CLI: ${{ vars.LVIE_REQUIRE_RUNNER_CLI || '0' }}
 
 on:
   workflow_dispatch:
@@ -95,6 +96,9 @@ jobs:
             }
             $lvInfo = $json | ConvertFrom-Json
           } else {
+            if ($env:LVIE_REQUIRE_RUNNER_CLI -eq '1') {
+              throw "LVIE_REQUIRE_RUNNER_CLI=1 but runner-cli was not available."
+            }
             Write-Warning "runner-cli not available; falling back to Assert-LabVIEWVersion.ps1."
             $assertScript = Join-Path $repoRoot 'Tooling\Assert-LabVIEWVersion.ps1'
             if (-not (Test-Path -Path $assertScript)) {
@@ -118,6 +122,9 @@ jobs:
             Write-Host 'Validating contract with runner-cli …'
             & $cli validate-contract --contract-path $env:LVIE_RUNNER_CONTRACT_PATH
           } else {
+            if ($env:LVIE_REQUIRE_RUNNER_CLI -eq '1') {
+              throw "LVIE_REQUIRE_RUNNER_CLI=1 but runner-cli was not available."
+            }
             Write-Host 'runner-cli not found; using PowerShell fallback.'
             pwsh -NoProfile -File "$env:GITHUB_WORKSPACE\\Tooling\\Validate-RunnerContract.ps1"
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ This repository uses LabVIEW, g-cli, and PowerShell tooling. Follow the steps be
 - Local runs write a redacted offenders report to `TestResults\agent-logs\pylavi-offenders.latest.json`. Use `Tooling\Get-PylaviOffenders.ps1` to summarize it.
 - If the local report is missing, fetch the latest CI artifact instead: `pwsh -NoProfile -File .\Tooling\Fetch-PylaviOffenders.ps1 -Branch develop` or `pwsh -NoProfile -File .\Tooling\Get-PylaviOffenders.ps1 -FetchLatest`. Requires `GH_TOKEN`/`GITHUB_TOKEN` with `actions:read`.
 - Deterministic: `Tooling\Get-PylaviOffenders.ps1 -Sha <commit>` to read `pylavi-offenders.<sha>.json`, or `-RunId <id> -FetchLatest` to pin a specific workflow run.
+- Baseline/delta gating (runner-cli): set `LVIE_PYLAVI_BASELINE_PATH` to a redacted offenders report and optionally `LVIE_PYLAVI_FAIL_ON_DELTA=1` to fail on new offenders. Use `LVIE_PYLAVI_BASELINE_REQUIRED=1` to require the baseline file.
+- Runner-cli-only toggle: set `LVIE_REQUIRE_RUNNER_CLI=1` to enforce runner-cli usage (no PowerShell fallback).
 - Config files:
   - `Tooling/pylavi/vi-validate.yml` (strict scope; version injected at runtime).
   - `Tooling/pylavi/vi-validate-legacy.yml` (legacy scope; typically absolute-path checks only).

--- a/Tooling/Assert-RunnerLabel.ps1
+++ b/Tooling/Assert-RunnerLabel.ps1
@@ -198,6 +198,26 @@ function Get-ContractLabelSet {
     }
 }
 
+function Write-RunnerLabelSummary {
+    param([string]$ContractPath)
+
+    if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        return
+    }
+    if ($env:LVIE_RUNNER_LABEL_SUMMARY_WRITTEN -eq '1') {
+        return
+    }
+
+    $contractNote = if ([string]::IsNullOrWhiteSpace($ContractPath)) {
+        "Runner label check used local runner contract. Refresh labels with `Tooling\\Setup-Runner.ps1` on the runner host if labels are stale."
+    } else {
+        "Runner label check used local runner contract ($ContractPath). Refresh labels with `Tooling\\Setup-Runner.ps1` on the runner host if labels are stale."
+    }
+
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $contractNote
+    $env:LVIE_RUNNER_LABEL_SUMMARY_WRITTEN = '1'
+}
+
 function Test-LabelSet {
     param(
         [string[]]$ExpectedLabels,
@@ -232,6 +252,7 @@ function Test-LabelSet {
 $contractFallback = Get-ContractLabelSet
 if ($contractFallback -and -not $contractFallback.HasLabels) {
     Write-Warning ("Runner label check: runner contract at {0} has no labels. Run Tooling\Setup-Runner.ps1 to refresh it." -f $contractFallback.Source)
+    Write-RunnerLabelSummary -ContractPath $contractFallback.Source
     if ($strictLabelCheck) {
         throw "Runner label check: strict mode enabled and contract is missing labels."
     }
@@ -243,6 +264,7 @@ if ([string]::IsNullOrWhiteSpace($Token)) {
     if ($fallback -and $fallback.Labels -and $fallback.Labels.Count -gt 0) {
         Write-Warning ("Runner label check: GitHub token not available; validating against runner contract at {0}." -f $fallback.Source)
         Test-LabelSet -ExpectedLabels $expected -ActualLabels $fallback.Labels -SourceLabel 'contract fallback'
+        Write-RunnerLabelSummary -ContractPath $fallback.Source
         return
     }
 
@@ -297,6 +319,7 @@ try {
     if ($contractFallback -and $contractFallback.Labels -and $contractFallback.Labels.Count -gt 0) {
         Write-Warning ("Runner label check: API lookup failed ({0}). Falling back to runner contract at {1}." -f $message, $contractFallback.Source)
         Test-LabelSet -ExpectedLabels $expected -ActualLabels $contractFallback.Labels -SourceLabel 'contract fallback'
+        Write-RunnerLabelSummary -ContractPath $contractFallback.Source
         return
     }
     if ($requireLabelEnabled -and $strictLabelCheck) { throw }
@@ -309,6 +332,7 @@ if (-not $runnerInfo) {
     if ($contractFallback -and $contractFallback.Labels -and $contractFallback.Labels.Count -gt 0) {
         Write-Warning ("{0} Using contract fallback at {1}." -f $message, $contractFallback.Source)
         Test-LabelSet -ExpectedLabels $expected -ActualLabels $contractFallback.Labels -SourceLabel 'contract fallback'
+        Write-RunnerLabelSummary -ContractPath $contractFallback.Source
         return
     }
     if ($requireLabelEnabled -and $strictLabelCheck) { throw $message }

--- a/Tooling/README.md
+++ b/Tooling/README.md
@@ -35,6 +35,7 @@ Common entrypoints:
   Example: `runner-cli pylavi scan --config Tooling/pylavi/vi-validate.yml --report-only`  
   Example: `runner-cli pylavi summarize --repo-root .`  
   Example: `runner-cli pylavi fetch --repo <owner/name> --branch develop`
+  Example (baseline delta): `runner-cli pylavi summarize --path TestResults/agent-logs/pylavi-offenders.latest.json --baseline Tooling/pylavi/pylavi-offenders.baseline.json --fail-on-delta`
 
 Related config:
 - `pylavi/vi-validate.yml`  

--- a/Tooling/runner-cli/RunnerCli.Tests/PylaviJsonContextTests.cs
+++ b/Tooling/runner-cli/RunnerCli.Tests/PylaviJsonContextTests.cs
@@ -97,6 +97,47 @@ public class PylaviJsonContextTests
     }
 
     [Fact]
+    public void PylaviSummarizeOutput_serializes_baseline_and_delta_fields()
+    {
+        var output = new PylaviSummarizeOutput
+        {
+            Label = "strict",
+            GeneratedUtc = "2026-02-06T12:00:00Z",
+            TotalFails = 4,
+            ConfiguredRootCount = 2,
+            HasFindings = true,
+            File = "TestResults/agent-logs/pylavi-offenders.latest.json",
+            BaselineFile = "Tooling/pylavi/pylavi-offenders.baseline.json",
+            BaselineTotalFails = 3,
+            BaselineConfiguredRootCount = 1,
+            BaselineHasFindings = true,
+            HasDelta = true,
+            DeltaTotalFails = 1,
+            DeltaOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "delta.vi", Count = 1 }
+            },
+            DeltaAbsoluteOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "C:\\Users\\DevUser\\Projects\\delta.vi", Count = 1 }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(output, RunnerCliJsonContext.Default.PylaviSummarizeOutput);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("Tooling/pylavi/pylavi-offenders.baseline.json", root.GetProperty("baseline_file").GetString());
+        Assert.Equal(3, root.GetProperty("baseline_total_fails").GetInt32());
+        Assert.Equal(1, root.GetProperty("baseline_configured_root_count").GetInt32());
+        Assert.True(root.GetProperty("baseline_has_findings").GetBoolean());
+        Assert.True(root.GetProperty("has_delta").GetBoolean());
+        Assert.Equal(1, root.GetProperty("delta_total_fails").GetInt32());
+        Assert.Equal("delta.vi", root.GetProperty("delta_offenders")[0].GetProperty("item").GetString());
+        Assert.Equal("C:\\Users\\DevUser\\Projects\\delta.vi", root.GetProperty("delta_absolute_offenders")[0].GetProperty("item").GetString());
+    }
+
+    [Fact]
     public void PylaviOffendersReport_deserializes_case_insensitive_json()
     {
         var json = """

--- a/Tooling/runner-cli/RunnerCli.Tests/RunnerCliCliTests.cs
+++ b/Tooling/runner-cli/RunnerCli.Tests/RunnerCliCliTests.cs
@@ -65,6 +65,114 @@ public class RunnerCliCliTests
     }
 
     [Fact]
+    public void PylaviSummarize_with_baseline_emits_delta_fields()
+    {
+        var repoRoot = FindRepoRoot();
+        var tempDir = Directory.CreateTempSubdirectory("lvie-cli-delta");
+        var reportPath = Path.Combine(tempDir.FullName, "pylavi-report.json");
+        var baselinePath = Path.Combine(tempDir.FullName, "pylavi-baseline.json");
+        var outputPath = Path.Combine(tempDir.FullName, "pylavi-summary.json");
+
+        var baseline = new PylaviOffendersReport
+        {
+            Label = "pylavi",
+            GeneratedUtc = "2026-02-06T12:00:00Z",
+            TotalFails = 1,
+            ConfiguredRoots = "<redacted>",
+            ConfiguredRootCount = 1,
+            TopOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "foo.vi", Count = 1 }
+            },
+            TopAbsoluteOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "C:\\Users\\DevUser\\Projects\\bar.vi", Count = 1 }
+            }
+        };
+
+        var report = new PylaviOffendersReport
+        {
+            Label = "pylavi",
+            GeneratedUtc = "2026-02-06T12:00:00Z",
+            TotalFails = 2,
+            ConfiguredRoots = "<redacted>",
+            ConfiguredRootCount = 2,
+            TopOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "foo.vi", Count = 1 },
+                new() { Item = "delta.vi", Count = 1 }
+            },
+            TopAbsoluteOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "C:\\Users\\DevUser\\Projects\\bar.vi", Count = 1 },
+                new() { Item = "C:\\Users\\DevUser\\Projects\\delta.vi", Count = 1 }
+            }
+        };
+
+        File.WriteAllText(baselinePath, JsonSerializer.Serialize(baseline, RunnerCliJsonContext.Default.PylaviOffendersReport));
+        File.WriteAllText(reportPath, JsonSerializer.Serialize(report, RunnerCliJsonContext.Default.PylaviOffendersReport));
+
+        var args = $"pylavi summarize --path \"{reportPath}\" --baseline \"{baselinePath}\" --json --output-path \"{outputPath}\"";
+        var (exitCode, _, stderr) = RunCli(repoRoot, args);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(string.IsNullOrWhiteSpace(stderr), $"stderr: {stderr}");
+        Assert.True(File.Exists(outputPath), "output path not written");
+
+        using var summaryDoc = JsonDocument.Parse(File.ReadAllText(outputPath));
+        var summaryRoot = summaryDoc.RootElement;
+        Assert.True(summaryRoot.GetProperty("has_delta").GetBoolean());
+        Assert.Equal(1, summaryRoot.GetProperty("delta_total_fails").GetInt32());
+        Assert.Equal("delta.vi", summaryRoot.GetProperty("delta_offenders")[0].GetProperty("item").GetString());
+        Assert.Equal("C:\\Users\\DevUser\\Projects\\delta.vi", summaryRoot.GetProperty("delta_absolute_offenders")[0].GetProperty("item").GetString());
+    }
+
+    [Fact]
+    public void PylaviSummarize_fail_on_delta_returns_exit_code_6()
+    {
+        var repoRoot = FindRepoRoot();
+        var tempDir = Directory.CreateTempSubdirectory("lvie-cli-delta-fail");
+        var reportPath = Path.Combine(tempDir.FullName, "pylavi-report.json");
+        var baselinePath = Path.Combine(tempDir.FullName, "pylavi-baseline.json");
+
+        var baseline = new PylaviOffendersReport
+        {
+            Label = "pylavi",
+            GeneratedUtc = "2026-02-06T12:00:00Z",
+            TotalFails = 1,
+            ConfiguredRoots = "<redacted>",
+            ConfiguredRootCount = 1,
+            TopOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "foo.vi", Count = 1 }
+            }
+        };
+
+        var report = new PylaviOffendersReport
+        {
+            Label = "pylavi",
+            GeneratedUtc = "2026-02-06T12:00:00Z",
+            TotalFails = 2,
+            ConfiguredRoots = "<redacted>",
+            ConfiguredRootCount = 1,
+            TopOffenders = new List<PylaviOffenderEntry>
+            {
+                new() { Item = "foo.vi", Count = 1 },
+                new() { Item = "delta.vi", Count = 1 }
+            }
+        };
+
+        File.WriteAllText(baselinePath, JsonSerializer.Serialize(baseline, RunnerCliJsonContext.Default.PylaviOffendersReport));
+        File.WriteAllText(reportPath, JsonSerializer.Serialize(report, RunnerCliJsonContext.Default.PylaviOffendersReport));
+
+        var args = $"pylavi summarize --path \"{reportPath}\" --baseline \"{baselinePath}\" --fail-on-delta";
+        var (exitCode, _, stderr) = RunCli(repoRoot, args);
+
+        Assert.Equal(6, exitCode);
+        Assert.Contains("new entries", stderr, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void PylaviSummarize_validate_exists_returns_exit_code_2()
     {
         var repoRoot = FindRepoRoot();

--- a/Tooling/runner-cli/RunnerCli/Program.cs
+++ b/Tooling/runner-cli/RunnerCli/Program.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Text;
 using System.Text.Json;
 using RunnerCli;
 
@@ -324,6 +325,17 @@ var failOnThresholdOption = new Option<int>(
     name: "--fail-on-threshold",
     getDefaultValue: () => -1,
     description: "Exit non-zero if total FAILs exceed this threshold.");
+var baselinePathOption = new Option<string?>(
+    name: "--baseline",
+    description: "Optional baseline offenders report to compute deltas.");
+var baselineRequiredOption = new Option<bool>(
+    name: "--baseline-required",
+    getDefaultValue: () => false,
+    description: "Exit non-zero if the baseline file is missing.");
+var failOnDeltaOption = new Option<bool>(
+    name: "--fail-on-delta",
+    getDefaultValue: () => false,
+    description: "Exit non-zero if new offenders are detected compared to the baseline.");
 
 pylaviSummarizeCmd.AddOption(reportPathOption);
 pylaviSummarizeCmd.AddOption(summarizeLabelOption);
@@ -337,6 +349,9 @@ pylaviSummarizeCmd.AddOption(validateExistsOption);
 pylaviSummarizeCmd.AddOption(failOnEmptyOption);
 pylaviSummarizeCmd.AddOption(failOnFindingsOption);
 pylaviSummarizeCmd.AddOption(failOnThresholdOption);
+pylaviSummarizeCmd.AddOption(baselinePathOption);
+pylaviSummarizeCmd.AddOption(baselineRequiredOption);
+pylaviSummarizeCmd.AddOption(failOnDeltaOption);
 
 pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
 {
@@ -355,6 +370,9 @@ pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
         var failOnEmpty = context.ParseResult.GetValueForOption(failOnEmptyOption);
         var failOnFindings = context.ParseResult.GetValueForOption(failOnFindingsOption);
         var failOnThreshold = context.ParseResult.GetValueForOption(failOnThresholdOption);
+        var baselineInput = context.ParseResult.GetValueForOption(baselinePathOption);
+        var baselineRequired = context.ParseResult.GetValueForOption(baselineRequiredOption);
+        var failOnDelta = context.ParseResult.GetValueForOption(failOnDeltaOption);
 
         var resolvedRoot = RepoLocator.Resolve(repoRoot, Environment.CurrentDirectory);
         var resolvedPath = PylaviOffendersService.ResolveReportPath(resolvedRoot, path, label, sha);
@@ -369,14 +387,14 @@ pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
                 {
                     var shaHint = PylaviOffendersService.ResolveSha(sha, resolvedPath, null);
                     var labelValueHint = string.IsNullOrWhiteSpace(label) ? "pylavi" : label;
-                PylaviOffendersService.WriteMachineLines(resolvedPath, labelValueHint, shaHint, false, 0, 2);
+                    PylaviOffendersService.WriteMachineLines(resolvedPath, labelValueHint, shaHint, false, 0, 2);
+                }
+                Environment.ExitCode = 2;
+                context.ExitCode = 2;
+                return;
             }
-            Environment.ExitCode = 2;
-            context.ExitCode = 2;
-            return;
+            throw new FileNotFoundException(message, resolvedPath);
         }
-        throw new FileNotFoundException(message, resolvedPath);
-    }
 
         if (validateExists)
         {
@@ -399,9 +417,63 @@ pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
         var shaValue = PylaviOffendersService.ResolveSha(sha, resolvedPath, report);
         var hasFindings = report.TotalFails > 0 || report.TopOffenders.Count > 0;
 
+        var baselinePath = string.IsNullOrWhiteSpace(baselineInput)
+            ? null
+            : (Path.IsPathRooted(baselineInput) ? baselineInput : Path.Combine(resolvedRoot, baselineInput));
+        var baselineMissing = false;
+        PylaviOffendersReport? baselineReport = null;
+        if (!string.IsNullOrWhiteSpace(baselinePath))
+        {
+            if (!File.Exists(baselinePath))
+            {
+                baselineMissing = true;
+                Console.WriteLine($"WARNING: Baseline report not found at {baselinePath}.");
+            }
+            else
+            {
+                baselineReport = PylaviOffendersService.LoadReport(baselinePath);
+            }
+        }
+
+        var deltaTotalFails = (int?)null;
+        var deltaOffenders = (List<PylaviOffenderEntry>?)null;
+        var deltaAbsolute = (List<PylaviOffenderEntry>?)null;
+        var hasDelta = (bool?)null;
+        if (baselineReport is not null)
+        {
+            deltaTotalFails = report.TotalFails - baselineReport.TotalFails;
+            var baselineOffenders = new HashSet<string>(
+                baselineReport.TopOffenders.Select(entry => entry.Item),
+                StringComparer.OrdinalIgnoreCase);
+            var baselineAbsolute = new HashSet<string>(
+                baselineReport.TopAbsoluteOffenders.Select(entry => entry.Item),
+                StringComparer.OrdinalIgnoreCase);
+
+            deltaOffenders = report.TopOffenders
+                .Where(entry => !baselineOffenders.Contains(entry.Item))
+                .ToList();
+            deltaAbsolute = report.TopAbsoluteOffenders
+                .Where(entry => !baselineAbsolute.Contains(entry.Item))
+                .ToList();
+
+            hasDelta = (deltaTotalFails > 0)
+                || (deltaOffenders.Count > 0)
+                || (deltaAbsolute.Count > 0);
+        }
+
         var exitCode = 0;
         string? exitMessage = null;
-        if (failOnEmpty && !hasFindings)
+        if (baselineRequired && string.IsNullOrWhiteSpace(baselinePath))
+        {
+            exitCode = 7;
+            exitMessage = "Baseline is required but no baseline path was provided.";
+        }
+        else if (baselineRequired && baselineMissing)
+        {
+            exitCode = 7;
+            exitMessage = $"Baseline report not found at {baselinePath}.";
+        }
+        else if (failOnEmpty && !hasFindings)
         {
             exitCode = 3;
             exitMessage = "Pylavi offenders report contains no entries.";
@@ -416,6 +488,11 @@ pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
             exitCode = 4;
             exitMessage = "Pylavi offenders report contains offender entries.";
         }
+        else if (failOnDelta && hasDelta == true)
+        {
+            exitCode = 6;
+            exitMessage = "Pylavi offenders report contains new entries compared to the baseline.";
+        }
 
         if (!string.IsNullOrWhiteSpace(outputPath))
         {
@@ -429,7 +506,15 @@ pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
                 File = resolvedPath,
                 TopOffenders = report.TopOffenders.Take(top).ToList(),
                 TopAbsoluteOffenders = report.TopAbsoluteOffenders.Take(top).ToList(),
-                SourceSha = string.IsNullOrWhiteSpace(shaValue) ? null : shaValue
+                SourceSha = string.IsNullOrWhiteSpace(shaValue) ? null : shaValue,
+                BaselineFile = baselinePath,
+                BaselineTotalFails = baselineReport?.TotalFails,
+                BaselineConfiguredRootCount = baselineReport?.ConfiguredRootCount,
+                BaselineHasFindings = baselineReport is null ? null : (baselineReport.TotalFails > 0 || baselineReport.TopOffenders.Count > 0),
+                HasDelta = hasDelta,
+                DeltaTotalFails = deltaTotalFails,
+                DeltaOffenders = deltaOffenders,
+                DeltaAbsoluteOffenders = deltaAbsolute
             };
 
             var summaryDir = Path.GetDirectoryName(outputPath);
@@ -466,6 +551,34 @@ pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
                 Console.WriteLine($"Source SHA: {shaValue}");
             }
             Console.WriteLine($"Configured roots: <redacted> (count: {report.ConfiguredRootCount})");
+            if (baselineReport is not null)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Baseline file: {baselinePath}");
+                Console.WriteLine($"Baseline FAILs: {baselineReport.TotalFails}");
+                Console.WriteLine($"Baseline configured roots: <redacted> (count: {baselineReport.ConfiguredRootCount})");
+                if (hasDelta == true)
+                {
+                    Console.WriteLine($"Delta FAILs: {deltaTotalFails}");
+                    if (deltaOffenders is { Count: > 0 })
+                    {
+                        Console.WriteLine($"New offenders: {deltaOffenders.Count}");
+                    }
+                    if (deltaAbsolute is { Count: > 0 })
+                    {
+                        Console.WriteLine($"New absolute-path offenders: {deltaAbsolute.Count}");
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Delta FAILs: 0");
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(baselinePath))
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Baseline file: {baselinePath} (missing)");
+            }
 
             if (report.TopOffenders.Count > 0)
             {
@@ -490,6 +603,29 @@ pylaviSummarizeCmd.SetHandler((InvocationContext context) =>
 
         var summaryPath = writeSummary ? Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY") : null;
         PylaviOffendersService.WriteSummary(labelValue, report, top, shaValue, summaryPath);
+        if (!string.IsNullOrWhiteSpace(summaryPath) && (baselineReport is not null || !string.IsNullOrWhiteSpace(baselinePath)))
+        {
+            var summaryLines = new List<string>
+            {
+                "### Pylavi Delta",
+                ""
+            };
+            if (baselineReport is null)
+            {
+                summaryLines.Add($"- Baseline: {PylaviOffendersService.EscapeMarkdown(baselinePath ?? string.Empty)} (missing)");
+            }
+            else
+            {
+                summaryLines.Add($"- Baseline: {PylaviOffendersService.EscapeMarkdown(baselinePath ?? string.Empty)}");
+                summaryLines.Add($"- Baseline FAILs: {baselineReport.TotalFails}");
+                summaryLines.Add($"- Baseline configured roots: <redacted> (count: {baselineReport.ConfiguredRootCount})");
+                summaryLines.Add($"- Delta FAILs: {deltaTotalFails}");
+                summaryLines.Add($"- New offenders: {deltaOffenders?.Count ?? 0}");
+                summaryLines.Add($"- New absolute-path offenders: {deltaAbsolute?.Count ?? 0}");
+            }
+            summaryLines.Add("");
+            File.AppendAllLines(summaryPath, summaryLines, Encoding.UTF8);
+        }
 
         PylaviOffendersService.WriteMachineLines(resolvedPath, labelValue, shaValue, hasFindings, report.TotalFails, exitCode);
 

--- a/Tooling/runner-cli/RunnerCli/PylaviModels.cs
+++ b/Tooling/runner-cli/RunnerCli/PylaviModels.cs
@@ -95,4 +95,36 @@ public sealed class PylaviSummarizeOutput
     [JsonPropertyName("source_sha")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SourceSha { get; set; }
+
+    [JsonPropertyName("baseline_file")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BaselineFile { get; set; }
+
+    [JsonPropertyName("baseline_total_fails")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? BaselineTotalFails { get; set; }
+
+    [JsonPropertyName("baseline_configured_root_count")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? BaselineConfiguredRootCount { get; set; }
+
+    [JsonPropertyName("baseline_has_findings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? BaselineHasFindings { get; set; }
+
+    [JsonPropertyName("has_delta")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? HasDelta { get; set; }
+
+    [JsonPropertyName("delta_total_fails")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DeltaTotalFails { get; set; }
+
+    [JsonPropertyName("delta_offenders")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<PylaviOffenderEntry>? DeltaOffenders { get; set; }
+
+    [JsonPropertyName("delta_absolute_offenders")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<PylaviOffenderEntry>? DeltaAbsoluteOffenders { get; set; }
 }

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -98,7 +98,7 @@ Below are the **key GitHub Actions** provided in this repository:
 
 3. **Runner CLI (Reusable Build)**
    - [`runner-cli-reusable.yml`](../.github/workflows/runner-cli-reusable.yml) publishes a self-contained `runner-cli` binary for a target RID.
-   - `ci-composite.yml` calls this reusable workflow and downloads the artifact to run `runner-cli version-gate` without rebuilding on every job.
+   - `ci-composite.yml` calls this reusable workflow and downloads the artifact to run `runner-cli version-gate` on Linux and `runner-cli pylavi` on Windows without rebuilding on every job.
    - `runner-audit.yml` uses the published `runner-cli` artifact when available; falls back to PowerShell scripts otherwise.
 
 4. **Runner CLI Docker (Linux)**
@@ -109,7 +109,7 @@ Below are the **key GitHub Actions** provided in this repository:
 
 The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks the build into several jobs:
 
-- **pylavi-validate** – report-only LabVIEW file validation using `vi_validate` (strict + legacy profiles) with `.lvversion`-synced version gating.
+- **pylavi-validate** – report-only LabVIEW file validation using `vi_validate` (strict + legacy profiles) with `.lvversion`-synced version gating and optional baseline/delta reporting.
 - **changes** – checks out the repository and detects `.vipc` file changes to determine if dependencies need to be applied.
 - **apply-deps** – installs VIPC dependencies for multiple LabVIEW versions and bitnesses **only when** the `changes` job reports `.vipc` modifications (`if: needs.changes.outputs.vipc == 'true'`).
 - **version** – computes the semantic version and build number using commit count and PR labels.

--- a/docs/ci/actions/README.md
+++ b/docs/ci/actions/README.md
@@ -16,7 +16,7 @@ This repository defines several reusable [composite actions](https://docs.github
 | [missing-in-project](../../../.github/actions/missing-in-project) | Checks a project for missing files using `MissingInProjectCLI.vi`. |
 | [modify-vipb-display-info](../../../.github/actions/modify-vipb-display-info) | Updates display information in a VIPB file. |
 | [prepare-labview-source](../../../.github/actions/prepare-labview-source) | Prepares LabVIEW sources for builds. |
-| [pylavi-validate](../../../.github/actions/pylavi-validate) | Runs pylavi `vi_validate` with `.lvversion`-synced LabVIEW version (report-only or strict). |
+| [pylavi-validate](../../../.github/actions/pylavi-validate) | Runs pylavi `vi_validate` with `.lvversion`-synced LabVIEW version (report-only or strict), with optional baseline/delta gating. |
 | [rename-file](../../../.github/actions/rename-file) | Renames a file on disk. |
 | [restore-setup-lv-source](../../../.github/actions/restore-setup-lv-source) | Reverts prepared sources back to their packaged state. |
 | [revert-development-mode](../../../.github/actions/revert-development-mode) | Restores the repository after development mode. |
@@ -26,4 +26,4 @@ This repository defines several reusable [composite actions](https://docs.github
 Each action directory includes a `README.md` and `action.yml` with full usage details.
 
 > [!NOTE]
-> Several actions now prefer `runner-cli` subcommands when available (for example, `pylavi-validate`, `missing-in-project`, and `.lvversion` version-gate usage in workflows). They fall back to PowerShell scripts if `runner-cli` is unavailable, so behavior remains backward-compatible during the migration.
+> Several actions now prefer `runner-cli` subcommands when available (for example, `pylavi-validate`, `missing-in-project`, and `.lvversion` version-gate usage in workflows). They fall back to PowerShell scripts if `runner-cli` is unavailable, so behavior remains backward-compatible during the migration. Set `LVIE_REQUIRE_RUNNER_CLI=1` to make runner-cli mandatory.


### PR DESCRIPTION
## Summary
- Add runner-cli pylavi baseline/delta gating (`--baseline`, `--baseline-required`, `--fail-on-delta`) with JSON output fields for automation.
- Enforce runner-cli-only option (`LVIE_REQUIRE_RUNNER_CLI=1`) across pylavi, missing-in-project, version-gate, dev-mode toggle, and runner-audit.
- Use win-x64 runner-cli artifact in `ci-composite` for pylavi validation.
- Fix VIP status upload to use `LVIE_ARTIFACT_ROOT` when set.
- Update docs/AGENTS for delta gate + runner-cli-only behavior.
- Expand runner-cli tests for baseline/delta output and exit codes.
- Add one-time summary hint to refresh runner labels via `Tooling\Setup-Runner.ps1` when falling back to contract.

## Testing
- `dotnet test Tooling/runner-cli/RunnerCli.Tests/RunnerCli.Tests.csproj -c Release`

## Notes
- Enable delta gate via:
  - `LVIE_PYLAVI_BASELINE_PATH=Tooling/pylavi/pylavi-offenders.baseline.json`
  - `LVIE_PYLAVI_FAIL_ON_DELTA=1`
  - `LVIE_PYLAVI_BASELINE_REQUIRED=1` (optional)
- Enforce runner-cli-only with `LVIE_REQUIRE_RUNNER_CLI=1`.