### PR TITLE
docs: revalidate A-006 evidence for runner-cli v5.1

### DIFF
--- a/docs/runner-cli-requirements-v5-acceptance.md
+++ b/docs/runner-cli-requirements-v5-acceptance.md
@@ -37,7 +37,7 @@ Acceptance coverage summary:
 | A-010 | Pass | `06fc47d1893893af74c6192b3fbda1cd4727f7d7` | `local` | Validated from `TestResults/agent-logs/extended-go-no-go-20260207-140227`; exit-code matrix verified (`pass=0`, `warn=0`, `strict-warn=3`, `fail=2`). |
 | A-013 | Pass | `e70e010783c4a33e8730da610be8ecbe3af08e78` | `21786875251` | Hosted Linux + hosted Windows Core checks completed in `CI Pipeline (Composite)` with successful `Conformance Check (Full, Strict)` and no malformed `actions-runner_work` path occurrences in logs. |
 | A-005 | Pass | `153dcb68047e9e311516589bb35480d25392ab61` | `local` | Revalidated on 2026-02-07 via `pwsh -NoProfile -File .\\Tooling\\Test-RunnerCliRequirementsA005.ps1`; A-005 target RC IDs passed atomicity/single-obligation lint. |
-| A-006 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (`spec_version=v5.1` assertion added). |
+| A-006 | Pass | `457c3cc07156accfce5cfd82699d0c8e96fd1cfd` | `local` | Revalidated on 2026-02-07 via `dotnet test Tooling/runner-cli/RunnerCli.Tests/RunnerCli.Tests.csproj --filter \"FullyQualifiedName~Manifest_emits_required_json_fields\"`; confirms `spec_document_id=LVIE-RC-REQ-v5` and `spec_version=v5.1`. |
 | A-007 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (manifest compatibility semantics updated via RC-MAN-004 and RC-JSN-004). |
 | A-009 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (RC-CONF and RC-ENV split-responsibility wording update). |
 | A-011 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (RC-GOV-006 major-version governance criterion). |


### PR DESCRIPTION
## Summary
Revalidates acceptance scenario A-006 after the v5.1 remediation by replacing its pending revalidation entry with a pass entry tied to the v5.1 manifest assertion.

## Changes
- Updated `docs/runner-cli-requirements-v5-acceptance.md` evidence row for `A-006` to:
  - `Status=Pass`
  - commit `457c3cc07156accfce5cfd82699d0c8e96fd1cfd`
  - local targeted test evidence command

## Validation
- `dotnet test Tooling/runner-cli/RunnerCli.Tests/RunnerCli.Tests.csproj --filter "FullyQualifiedName~Manifest_emits_required_json_fields"` (pass)
