### PR TITLE
docs: revalidate A-011 evidence for runner-cli v5.1

### DIFF
--- a/docs/runner-cli-requirements-v5-acceptance.md
+++ b/docs/runner-cli-requirements-v5-acceptance.md
@@ -40,7 +40,7 @@ Acceptance coverage summary:
 | A-006 | Pass | `457c3cc07156accfce5cfd82699d0c8e96fd1cfd` | `local` | Revalidated on 2026-02-07 via `dotnet test Tooling/runner-cli/RunnerCli.Tests/RunnerCli.Tests.csproj --filter \"FullyQualifiedName~Manifest_emits_required_json_fields\"`; confirms `spec_document_id=LVIE-RC-REQ-v5` and `spec_version=v5.1`. |
 | A-007 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (manifest compatibility semantics updated via RC-MAN-004 and RC-JSN-004). |
 | A-009 | Pass | `eb2fe4b59281e1de4902c90f0888f75c07b15906` | `21788889016` | Revalidated on 2026-02-07 using CI `Build & Test Runner CLI` (env-default conformance tests for `RC_PROFILE`/`RC_STRICT_MODE`) plus local requirements inspection confirming canonical env names in `RC-ENV-010`/`RC-ENV-011`. |
-| A-011 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (RC-GOV-006 major-version governance criterion). |
+| A-011 | Pass | `9cb257a8fdc739b4ec985b4e55d22a0d490150d2` | `local` | Revalidated on 2026-02-07 via targeted requirements inspection for `RC-GOV-001/002/003/004/006`; confirms change classification, migration-note requirement, deprecation lifecycle phases, and version-boundary metadata criteria. |
 | A-012 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (traceability coverage expanded to v5.1 RC IDs). |
 | A-014 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (target RC list revised for updated compatibility/scope clauses). |
 | A-015 | Pending-Revalidation | `N/A` | `N/A` | Required due v5.1 ISO remediation (new conformance-gating semantics scenario). |


### PR DESCRIPTION
## Summary
Revalidates acceptance scenario A-011 after the v5.1 remediation by replacing its pending revalidation entry with a pass entry.

## Constraint handling
A GitHub Action and local `g-cli`/`LabVIEW` automation were active during this update, so this revalidation used a fast static governance check (no long-running local runtime flow).

## Changes
- Updated `docs/runner-cli-requirements-v5-acceptance.md` evidence row for `A-011` to:
  - `Status=Pass`
  - commit `9cb257a8fdc739b4ec985b4e55d22a0d490150d2`
  - local targeted governance inspection evidence

## Validation
Executed targeted local check against `docs/runner-cli-requirements.md`:
- verified exact presence/wording for `RC-GOV-001`, `RC-GOV-002`, `RC-GOV-003`, `RC-GOV-004`, `RC-GOV-006`
- confirms change classification, migration-note requirement, deprecation lifecycle phases, and version-boundary metadata criteria
