### PR TITLE
ci(container): build lv_icon_editor build spec in Docker parity workflow

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -31,7 +31,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
       - release/*
       - feature/*
       - hotfix/*

--- a/.github/workflows/labview-container-parity.yml
+++ b/.github/workflows/labview-container-parity.yml
@@ -7,6 +7,11 @@ on:
         description: LabVIEW container release tag (for example, 2026q1)
         required: false
         default: "2026q1"
+      run_build_spec:
+        description: Run ExecuteBuildSpec parity for Editor Packed Library
+        required: false
+        type: boolean
+        default: false
   pull_request:
     paths:
       - ".github/workflows/labview-container-parity.yml"
@@ -24,6 +29,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Resolve build-spec mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.run_build_spec }}" == "true" ]]; then
+            echo "RUN_BUILD_SPEC=true" >> "$GITHUB_ENV"
+          else
+            echo "RUN_BUILD_SPEC=false" >> "$GITHUB_ENV"
+          fi
+
       - name: Pull LabVIEW Linux image
         shell: bash
         run: |
@@ -33,18 +48,57 @@ jobs:
           echo "Using image: ${IMAGE}"
           docker pull "${IMAGE}"
           echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+          echo "LV_RELEASE=${LV_RELEASE}" >> "$GITHUB_ENV"
 
       - name: Run LabVIEWCLI parity script (Linux)
         shell: bash
         run: |
           set -euo pipefail
+          LV_YEAR="${LV_RELEASE:0:4}"
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -e WORKSPACE_ROOT=/workspace \
             -e TARGET_DIR=/workspace/Test/Templates \
+            -e "LV_YEAR=${LV_YEAR}" \
             -e "CONTAINER_PARITY_EXCLUDE_FILES=Polymorphic Template.vi" \
+            -e "CONTAINER_PARITY_BUILD_SPEC=${RUN_BUILD_SPEC}" \
+            -e "CONTAINER_PARITY_BUILD_SPEC_NAME=Editor Packed Library" \
+            -e "CONTAINER_PARITY_TARGET_NAME=My Computer" \
+            -e "CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH=resource/plugins/lv_icon.lvlibp" \
+            -e "CONTAINER_PARITY_LABVIEW_VERSION=${LV_YEAR}" \
             "$IMAGE" \
-            bash -lc "chmod +x /workspace/Tooling/container-parity/runlabview-linux.sh && /workspace/Tooling/container-parity/runlabview-linux.sh"
+            bash -lc "chmod +x /workspace/Tooling/container-parity/runlabview-linux.sh /workspace/Tooling/container-parity/devmode-linux.sh && /workspace/Tooling/container-parity/runlabview-linux.sh"
+
+      - name: Verify built specification output (Linux container)
+        if: ${{ env.RUN_BUILD_SPEC == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_path="${GITHUB_WORKSPACE}/resource/plugins/lv_icon.lvlibp"
+          if [[ ! -f "$output_path" ]]; then
+            echo "Expected build output was not found: $output_path" >&2
+            exit 1
+          fi
+          bytes="$(wc -c < "$output_path" | xargs)"
+          echo "Built specification artifact: $output_path ($bytes bytes)"
+
+      - name: Upload built specification artifact (Linux container)
+        if: ${{ env.RUN_BUILD_SPEC == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: labview-container-editor-packed-library-linux
+          path: resource/plugins/lv_icon.lvlibp
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload LabVIEWCLI logs (Linux container)
+        if: ${{ env.RUN_BUILD_SPEC == 'true' || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: labview-container-logs-linux
+          path: TestResults/container-parity/linux/logs
+          if-no-files-found: warn
+          retention-days: 14
 
   parity-windows:
     name: Parity (Windows Container)
@@ -53,6 +107,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Resolve build-spec mode
+        shell: pwsh
+        run: |
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ github.event.inputs.run_build_spec }}' -eq 'true') {
+            'RUN_BUILD_SPEC=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          } else {
+            'RUN_BUILD_SPEC=false' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
 
       - name: Pull LabVIEW Windows image
         shell: pwsh
@@ -66,19 +129,22 @@ jobs:
           Write-Host "Using image: $image"
           docker pull $image
           "IMAGE=$image" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "LV_RELEASE=$lvRelease" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Run LabVIEWCLI parity script (Windows)
         shell: pwsh
         run: |
+          $lvYear = if ($env:LV_RELEASE -match '^(?<year>\d{4})') { $Matches['year'] } else { '2026' }
           docker run --rm `
             -v "${env:GITHUB_WORKSPACE}:C:\workspace" `
             -e WORKSPACE_ROOT=C:\workspace `
             -e TARGET_DIR=C:\workspace\Test\Templates `
             -e "CONTAINER_PARITY_EXCLUDE_FILES=Polymorphic Template.vi" `
-            -e "CONTAINER_PARITY_BUILD_SPEC=true" `
+            -e "CONTAINER_PARITY_BUILD_SPEC=${env:RUN_BUILD_SPEC}" `
             -e "CONTAINER_PARITY_BUILD_SPEC_NAME=Editor Packed Library" `
-            -e "CONTAINER_PARITY_BUILD_TARGET_NAME=My Computer" `
+            -e "CONTAINER_PARITY_TARGET_NAME=My Computer" `
             -e "CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH=resource\plugins\lv_icon.lvlibp" `
+            -e "CONTAINER_PARITY_LABVIEW_VERSION=$lvYear" `
             $env:IMAGE `
             powershell -NoProfile -ExecutionPolicy Bypass -File C:\workspace\Tooling\container-parity\runlabview-windows.ps1 -WorkspaceRoot C:\workspace
 
@@ -87,6 +153,7 @@ jobs:
           }
 
       - name: Verify built specification output (Windows container)
+        if: ${{ env.RUN_BUILD_SPEC == 'true' }}
         shell: pwsh
         run: |
           $outputPath = Join-Path $env:GITHUB_WORKSPACE 'resource\plugins\lv_icon.lvlibp'
@@ -97,9 +164,19 @@ jobs:
           Write-Host ("Built specification artifact: {0} ({1} bytes)" -f $item.FullName, $item.Length)
 
       - name: Upload built specification artifact (Windows container)
+        if: ${{ env.RUN_BUILD_SPEC == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: labview-container-editor-packed-library-windows
           path: resource/plugins/lv_icon.lvlibp
           if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload LabVIEWCLI logs (Windows container)
+        if: ${{ env.RUN_BUILD_SPEC == 'true' || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: labview-container-logs-windows
+          path: TestResults/container-parity/windows/logs
+          if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/labview-container-parity.yml
+++ b/.github/workflows/labview-container-parity.yml
@@ -11,7 +11,7 @@ on:
         description: Run ExecuteBuildSpec parity for Editor Packed Library
         required: false
         type: boolean
-        default: false
+        default: true
   pull_request:
     paths:
       - ".github/workflows/labview-container-parity.yml"
@@ -33,10 +33,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.run_build_spec }}" == "true" ]]; then
-            echo "RUN_BUILD_SPEC=true" >> "$GITHUB_ENV"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ github.event.inputs.run_build_spec }}" == "false" ]]; then
+              echo "RUN_BUILD_SPEC=false" >> "$GITHUB_ENV"
+            else
+              echo "RUN_BUILD_SPEC=true" >> "$GITHUB_ENV"
+            fi
           else
-            echo "RUN_BUILD_SPEC=false" >> "$GITHUB_ENV"
+            echo "RUN_BUILD_SPEC=true" >> "$GITHUB_ENV"
           fi
 
       - name: Pull LabVIEW Linux image
@@ -111,10 +115,14 @@ jobs:
       - name: Resolve build-spec mode
         shell: pwsh
         run: |
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ github.event.inputs.run_build_spec }}' -eq 'true') {
-            'RUN_BUILD_SPEC=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            if ('${{ github.event.inputs.run_build_spec }}' -eq 'false') {
+              'RUN_BUILD_SPEC=false' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            } else {
+              'RUN_BUILD_SPEC=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            }
           } else {
-            'RUN_BUILD_SPEC=false' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            'RUN_BUILD_SPEC=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           }
 
       - name: Pull LabVIEW Windows image

--- a/.github/workflows/labview-container-parity.yml
+++ b/.github/workflows/labview-container-parity.yml
@@ -15,12 +15,6 @@ on:
   push:
     branches:
       - develop
-    paths:
-      - ".github/workflows/labview-container-parity.yml"
-      - "Tooling/container-parity/**"
-      - "Test/Templates/**"
-      - "lv_icon_editor.lvproj"
-      - ".lvversion"
   pull_request:
     paths:
       - ".github/workflows/labview-container-parity.yml"

--- a/.github/workflows/labview-container-parity.yml
+++ b/.github/workflows/labview-container-parity.yml
@@ -12,6 +12,15 @@ on:
         required: false
         type: boolean
         default: true
+  push:
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/labview-container-parity.yml"
+      - "Tooling/container-parity/**"
+      - "Test/Templates/**"
+      - "lv_icon_editor.lvproj"
+      - ".lvversion"
   pull_request:
     paths:
       - ".github/workflows/labview-container-parity.yml"
@@ -106,6 +115,7 @@ jobs:
 
   parity-windows:
     name: Parity (Windows Container)
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'develop') }}
     runs-on: windows-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/labview-container-parity.yml
+++ b/.github/workflows/labview-container-parity.yml
@@ -75,9 +75,31 @@ jobs:
             -e WORKSPACE_ROOT=C:\workspace `
             -e TARGET_DIR=C:\workspace\Test\Templates `
             -e "CONTAINER_PARITY_EXCLUDE_FILES=Polymorphic Template.vi" `
+            -e "CONTAINER_PARITY_BUILD_SPEC=true" `
+            -e "CONTAINER_PARITY_BUILD_SPEC_NAME=Editor Packed Library" `
+            -e "CONTAINER_PARITY_BUILD_TARGET_NAME=My Computer" `
+            -e "CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH=resource\plugins\lv_icon.lvlibp" `
             $env:IMAGE `
             powershell -NoProfile -ExecutionPolicy Bypass -File C:\workspace\Tooling\container-parity\runlabview-windows.ps1 -WorkspaceRoot C:\workspace
 
           if ($LASTEXITCODE -ne 0) {
             throw "Windows container parity run failed with exit code $LASTEXITCODE."
           }
+
+      - name: Verify built specification output (Windows container)
+        shell: pwsh
+        run: |
+          $outputPath = Join-Path $env:GITHUB_WORKSPACE 'resource\plugins\lv_icon.lvlibp'
+          if (-not (Test-Path -LiteralPath $outputPath -PathType Leaf)) {
+            throw "Expected build output was not found: $outputPath"
+          }
+          $item = Get-Item -LiteralPath $outputPath
+          Write-Host ("Built specification artifact: {0} ({1} bytes)" -f $item.FullName, $item.Length)
+
+      - name: Upload built specification artifact (Windows container)
+        uses: actions/upload-artifact@v4
+        with:
+          name: labview-container-editor-packed-library-windows
+          path: resource/plugins/lv_icon.lvlibp
+          if-no-files-found: error
+          retention-days: 14

--- a/Tooling/Revert-DevelopmentMode-NoLabVIEW.ps1
+++ b/Tooling/Revert-DevelopmentMode-NoLabVIEW.ps1
@@ -24,6 +24,9 @@
 
 .PARAMETER SkipProcessCheck
     Skip checking for running LabVIEW or g-cli processes.
+
+.PARAMETER SkipRepoVersionCheck
+    When LabVIEWVersion is provided, skip strict .lvversion equality validation.
 #>
 
 [CmdletBinding()]
@@ -44,7 +47,10 @@ param(
     [string]$ContractPath,
 
     [Parameter(Mandatory = $false)]
-    [switch]$SkipProcessCheck
+    [switch]$SkipProcessCheck,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipRepoVersionCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -525,7 +531,8 @@ function Invoke-RevertDevModeNoLabVIEWMain {
         [string[]]$SupportedBitness,
         [string]$RepoRoot,
         [string]$ContractPath,
-        [switch]$SkipProcessCheck
+        [switch]$SkipProcessCheck,
+        [switch]$SkipRepoVersionCheck
     )
 
     $resolvedRepoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
@@ -534,7 +541,12 @@ function Invoke-RevertDevModeNoLabVIEWMain {
     $labviewYear = $LabVIEWVersion
     if (Test-Path -Path $versionHelper) {
         . $versionHelper
-        $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $resolvedRepoRoot
+        $useBypass = $SkipRepoVersionCheck -and -not [string]::IsNullOrWhiteSpace($LabVIEWVersion)
+        if ($useBypass) {
+            $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion
+        } else {
+            $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $resolvedRepoRoot
+        }
         $labviewYear = $versionInfo.Year
     }
     if (-not (Test-Path -Path $contractHelper)) {
@@ -573,7 +585,8 @@ if ($MyInvocation.InvocationName -ne '.') {
         -SupportedBitness $SupportedBitness `
         -RepoRoot $RepoRoot `
         -ContractPath $ContractPath `
-        -SkipProcessCheck:$SkipProcessCheck
+        -SkipProcessCheck:$SkipProcessCheck `
+        -SkipRepoVersionCheck:$SkipRepoVersionCheck
 }
 
 

--- a/Tooling/Set-DevelopmentMode-NoLabVIEW.ps1
+++ b/Tooling/Set-DevelopmentMode-NoLabVIEW.ps1
@@ -24,6 +24,9 @@
 
 .PARAMETER SkipProcessCheck
     Skip checking for running LabVIEW or g-cli processes.
+
+.PARAMETER SkipRepoVersionCheck
+    When LabVIEWVersion is provided, skip strict .lvversion equality validation.
 #>
 
 [CmdletBinding()]
@@ -44,7 +47,10 @@ param(
     [string]$ContractPath,
 
     [Parameter(Mandatory = $false)]
-    [switch]$SkipProcessCheck
+    [switch]$SkipProcessCheck,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipRepoVersionCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -469,7 +475,8 @@ function Invoke-DevModeNoLabVIEWMain {
         [string[]]$SupportedBitness,
         [string]$RepoRoot,
         [string]$ContractPath,
-        [switch]$SkipProcessCheck
+        [switch]$SkipProcessCheck,
+        [switch]$SkipRepoVersionCheck
     )
 
     $resolvedRepoRoot = Resolve-RepoRoot -PathOverride $RepoRoot
@@ -478,7 +485,12 @@ function Invoke-DevModeNoLabVIEWMain {
     $labviewYear = $LabVIEWVersion
     if (Test-Path -Path $versionHelper) {
         . $versionHelper
-        $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $resolvedRepoRoot
+        $useBypass = $SkipRepoVersionCheck -and -not [string]::IsNullOrWhiteSpace($LabVIEWVersion)
+        if ($useBypass) {
+            $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion
+        } else {
+            $versionInfo = Get-LabVIEWVersionInfo -VersionInput $LabVIEWVersion -RepoRoot $resolvedRepoRoot
+        }
         $labviewYear = $versionInfo.Year
     }
     if (-not (Test-Path -Path $contractHelper)) {
@@ -517,7 +529,8 @@ if ($MyInvocation.InvocationName -ne '.') {
         -SupportedBitness $SupportedBitness `
         -RepoRoot $RepoRoot `
         -ContractPath $ContractPath `
-        -SkipProcessCheck:$SkipProcessCheck
+        -SkipProcessCheck:$SkipProcessCheck `
+        -SkipRepoVersionCheck:$SkipRepoVersionCheck
 }
 
 

--- a/Tooling/container-parity/devmode-linux.sh
+++ b/Tooling/container-parity/devmode-linux.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+LABVIEW_ROOT="${2:-${LABVIEW_ROOT:-}}"
+WORKSPACE_ROOT="${3:-${WORKSPACE_ROOT:-/workspace}}"
+
+if [[ -z "$MODE" ]]; then
+  echo "Usage: $0 <enable|revert> [labview_root] [workspace_root]" >&2
+  exit 2
+fi
+
+if [[ -z "$LABVIEW_ROOT" ]]; then
+  echo "ERROR: LabVIEW root is required." >&2
+  exit 2
+fi
+
+ICON_API_DIR="$LABVIEW_ROOT/vi.lib/LabVIEW Icon API"
+ICON_API_ZIP="$LABVIEW_ROOT/vi.lib/LabVIEW Icon API.zip"
+PLUGIN_DIR="$LABVIEW_ROOT/resource/plugins"
+LVLIBP_PATH="$PLUGIN_DIR/lv_icon.lvlibp"
+SHIP_PATH="$PLUGIN_DIR/lv_icon.ship"
+
+resolve_ini_path() {
+  if [[ -n "${LVIE_LABVIEW_INI_PATH:-}" ]]; then
+    printf '%s' "$LVIE_LABVIEW_INI_PATH"
+    return
+  fi
+
+  if [[ -f "$LABVIEW_ROOT/LabVIEW.ini" ]]; then
+    printf '%s' "$LABVIEW_ROOT/LabVIEW.ini"
+    return
+  fi
+
+  if [[ -f "$LABVIEW_ROOT/labviewprofull.ini" ]]; then
+    printf '%s' "$LABVIEW_ROOT/labviewprofull.ini"
+    return
+  fi
+
+  printf '%s' "$LABVIEW_ROOT/LabVIEW.ini"
+}
+
+INI_PATH="$(resolve_ini_path)"
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+normalize_path_for_compare() {
+  local value="$1"
+  value="${value//\\//}"
+  while [[ "$value" == */ ]]; do
+    value="${value%/}"
+  done
+  printf '%s' "${value,,}"
+}
+
+flatten_icon_api_layout() {
+  shopt -s dotglob nullglob
+  local current="$ICON_API_DIR"
+  while [[ -d "$current" ]]; do
+    local entries=("$current"/*)
+    if [[ ${#entries[@]} -eq 1 && -d "${entries[0]}" && "$(basename "${entries[0]}")" == "LabVIEW Icon API" ]]; then
+      local inner="${entries[0]}"
+      local tmp_path="$current.__tmp.$$"
+      mv "$inner" "$tmp_path"
+      rm -rf "$current"
+      mv "$tmp_path" "$current"
+      continue
+    fi
+    break
+  done
+  shopt -u dotglob nullglob
+}
+
+read_library_paths() {
+  if [[ ! -f "$INI_PATH" ]]; then
+    return
+  fi
+
+  local line
+  line="$(grep -i -m1 '^[[:space:]]*localhost\.librarypaths[[:space:]]*=' "$INI_PATH" || true)"
+  if [[ -z "$line" ]]; then
+    return
+  fi
+
+  local value="${line#*=}"
+  IFS=';' read -r -a raw_paths <<< "$value"
+  for item in "${raw_paths[@]}"; do
+    local cleaned
+    cleaned="$(trim "$item")"
+    cleaned="${cleaned%\"}"
+    cleaned="${cleaned#\"}"
+    cleaned="$(trim "$cleaned")"
+    if [[ -n "$cleaned" ]]; then
+      printf '%s\n' "$cleaned"
+    fi
+  done
+}
+
+write_library_paths() {
+  local paths=("$@")
+  mkdir -p "$(dirname "$INI_PATH")"
+  if [[ ! -f "$INI_PATH" ]]; then
+    touch "$INI_PATH"
+  fi
+
+  local set_line="0"
+  local newline=""
+  if [[ ${#paths[@]} -gt 0 ]]; then
+    set_line="1"
+    local serialized=()
+    for value in "${paths[@]}"; do
+      if [[ "$value" == *" "* ]]; then
+        serialized+=("\"$value\"")
+      else
+        serialized+=("$value")
+      fi
+    done
+    local joined
+    IFS=';'
+    joined="${serialized[*]}"
+    IFS=$' \t\n'
+    newline="Localhost.LibraryPaths=$joined"
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  awk -v newline="$newline" -v set_line="$set_line" '
+    BEGIN {
+      IGNORECASE = 1
+      replaced = 0
+    }
+    {
+      if ($0 ~ /^[[:space:]]*localhost\.librarypaths[[:space:]]*=/ && replaced == 0) {
+        if (set_line == "1") {
+          print newline
+        }
+        replaced = 1
+        next
+      }
+      print
+    }
+    END {
+      if (replaced == 0 && set_line == "1") {
+        print newline
+      }
+    }
+  ' "$INI_PATH" > "$tmp"
+  mv "$tmp" "$INI_PATH"
+}
+
+add_library_path() {
+  local target="$1"
+  local target_key
+  target_key="$(normalize_path_for_compare "$target")"
+  mapfile -t paths < <(read_library_paths)
+
+  local exists=0
+  for value in "${paths[@]}"; do
+    if [[ "$(normalize_path_for_compare "$value")" == "$target_key" ]]; then
+      exists=1
+      break
+    fi
+  done
+
+  if [[ "$exists" -eq 0 ]]; then
+    paths+=("$target")
+  fi
+
+  write_library_paths "${paths[@]}"
+}
+
+remove_library_path() {
+  local target="$1"
+  local target_key
+  target_key="$(normalize_path_for_compare "$target")"
+  mapfile -t paths < <(read_library_paths)
+
+  local remaining=()
+  for value in "${paths[@]}"; do
+    if [[ "$(normalize_path_for_compare "$value")" != "$target_key" ]]; then
+      remaining+=("$value")
+    fi
+  done
+
+  write_library_paths "${remaining[@]}"
+}
+
+contains_library_path() {
+  local target="$1"
+  local target_key
+  target_key="$(normalize_path_for_compare "$target")"
+  mapfile -t paths < <(read_library_paths)
+
+  for value in "${paths[@]}"; do
+    if [[ "$(normalize_path_for_compare "$value")" == "$target_key" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "ERROR: Required command '$name' is not available." >&2
+    exit 1
+  fi
+}
+
+enable_mode() {
+  require_command zip
+  mkdir -p "$PLUGIN_DIR"
+
+  if [[ -d "$ICON_API_DIR" ]]; then
+    flatten_icon_api_layout
+    rm -f "$ICON_API_ZIP"
+    (
+      cd "$LABVIEW_ROOT/vi.lib"
+      zip -qr "LabVIEW Icon API.zip" "LabVIEW Icon API"
+    )
+    rm -rf "$ICON_API_DIR"
+  elif [[ -f "$ICON_API_ZIP" ]]; then
+    echo "LabVIEW Icon API is already zipped."
+  else
+    echo "ERROR: Neither '$ICON_API_DIR' nor '$ICON_API_ZIP' exists." >&2
+    exit 1
+  fi
+
+  if [[ -f "$LVLIBP_PATH" ]]; then
+    rm -f "$SHIP_PATH"
+    mv "$LVLIBP_PATH" "$SHIP_PATH"
+  elif [[ -f "$SHIP_PATH" ]]; then
+    echo "lv_icon is already in dev-mode ship state."
+  else
+    echo "ERROR: Neither '$LVLIBP_PATH' nor '$SHIP_PATH' exists." >&2
+    exit 1
+  fi
+
+  add_library_path "$WORKSPACE_ROOT"
+
+  local issues=()
+  if [[ ! -f "$SHIP_PATH" || -f "$LVLIBP_PATH" || -d "$ICON_API_DIR" || ! -f "$ICON_API_ZIP" ]]; then
+    issues+=("install files did not reach enabled state")
+  fi
+  if ! contains_library_path "$WORKSPACE_ROOT"; then
+    issues+=("Localhost.LibraryPaths does not include workspace root")
+  fi
+  if [[ ${#issues[@]} -gt 0 ]]; then
+    echo "ERROR: Dev mode enable verification failed: ${issues[*]}" >&2
+    exit 1
+  fi
+}
+
+revert_mode() {
+  require_command unzip
+  mkdir -p "$PLUGIN_DIR"
+
+  if [[ -f "$ICON_API_ZIP" ]]; then
+    rm -rf "$ICON_API_DIR"
+    (
+      cd "$LABVIEW_ROOT/vi.lib"
+      unzip -oq "LabVIEW Icon API.zip"
+    )
+    rm -f "$ICON_API_ZIP"
+    flatten_icon_api_layout
+  elif [[ -d "$ICON_API_DIR" ]]; then
+    flatten_icon_api_layout
+    echo "LabVIEW Icon API folder already restored."
+  else
+    echo "ERROR: Neither '$ICON_API_ZIP' nor '$ICON_API_DIR' exists." >&2
+    exit 1
+  fi
+
+  if [[ -f "$SHIP_PATH" ]]; then
+    rm -f "$LVLIBP_PATH"
+    mv "$SHIP_PATH" "$LVLIBP_PATH"
+  elif [[ -f "$LVLIBP_PATH" ]]; then
+    echo "lv_icon is already in packaged lvlibp state."
+  else
+    echo "ERROR: Neither '$SHIP_PATH' nor '$LVLIBP_PATH' exists." >&2
+    exit 1
+  fi
+
+  remove_library_path "$WORKSPACE_ROOT"
+
+  local issues=()
+  if [[ ! -f "$LVLIBP_PATH" || -f "$SHIP_PATH" || ! -d "$ICON_API_DIR" || -f "$ICON_API_ZIP" ]]; then
+    issues+=("install files did not reach disabled state")
+  fi
+  if contains_library_path "$WORKSPACE_ROOT"; then
+    issues+=("Localhost.LibraryPaths still includes workspace root")
+  fi
+  if [[ ${#issues[@]} -gt 0 ]]; then
+    echo "ERROR: Dev mode revert verification failed: ${issues[*]}" >&2
+    exit 1
+  fi
+}
+
+case "$MODE" in
+  enable)
+    enable_mode
+    ;;
+  revert)
+    revert_mode
+    ;;
+  *)
+    echo "ERROR: Unsupported mode '$MODE'. Use enable or revert." >&2
+    exit 2
+    ;;
+esac

--- a/Tooling/container-parity/devmode-linux.sh
+++ b/Tooling/container-parity/devmode-linux.sh
@@ -132,20 +132,17 @@ write_library_paths() {
   awk -v newline="$newline" -v set_line="$set_line" '
     BEGIN {
       IGNORECASE = 1
-      replaced = 0
+      found = 0
     }
     {
-      if ($0 ~ /^[[:space:]]*localhost\.librarypaths[[:space:]]*=/ && replaced == 0) {
-        if (set_line == "1") {
-          print newline
-        }
-        replaced = 1
+      if ($0 ~ /^[[:space:]]*localhost\.librarypaths[[:space:]]*=/) {
+        found = 1
         next
       }
       print
     }
     END {
-      if (replaced == 0 && set_line == "1") {
+      if (set_line == "1") {
         print newline
       }
     }

--- a/Tooling/container-parity/runlabview-linux.sh
+++ b/Tooling/container-parity/runlabview-linux.sh
@@ -6,6 +6,71 @@ WORKSPACE_ROOT="${WORKSPACE_ROOT:-/workspace}"
 TARGET_DIR="${TARGET_DIR:-$WORKSPACE_ROOT/Test/Templates}"
 EXCLUDE_LIST="${CONTAINER_PARITY_EXCLUDE_FILES:-Polymorphic Template.vi}"
 LABVIEW_PATH="${LABVIEW_PATH:-/usr/local/natinst/LabVIEW-${LV_YEAR}-64/labviewprofull}"
+PROJECT_PATH="${PROJECT_PATH:-$WORKSPACE_ROOT/lv_icon_editor.lvproj}"
+BUILD_SPEC_NAME="${CONTAINER_PARITY_BUILD_SPEC_NAME:-Editor Packed Library}"
+TARGET_NAME="${CONTAINER_PARITY_TARGET_NAME:-My Computer}"
+BUILD_OUTPUT_RELATIVE_PATH="${CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH:-resource/plugins/lv_icon.lvlibp}"
+BUILD_OUTPUT_PATH="$WORKSPACE_ROOT/$BUILD_OUTPUT_RELATIVE_PATH"
+BUILD_SPEC_ENABLED_RAW="${CONTAINER_PARITY_BUILD_SPEC:-false}"
+LOG_ROOT="$WORKSPACE_ROOT/TestResults/container-parity/linux/logs"
+LABVIEW_ROOT="$(dirname "$LABVIEW_PATH")"
+DEVMODE_SCRIPT="$WORKSPACE_ROOT/Tooling/container-parity/devmode-linux.sh"
+
+is_enabled_value() {
+  local value="${1:-}"
+  shopt -s nocasematch
+  if [[ "$value" == "1" || "$value" == "true" || "$value" == "yes" ]]; then
+    shopt -u nocasematch
+    return 0
+  fi
+  shopt -u nocasematch
+  return 1
+}
+
+capture_labviewcli_logs() {
+  local operation="$1"
+  local output="$2"
+  local index=0
+  local timestamp
+  timestamp="$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$LOG_ROOT"
+
+  while IFS= read -r line; do
+    if [[ "$line" =~ LabVIEWCLI[[:space:]]started[[:space:]]logging[[:space:]]in[[:space:]]file:[[:space:]]*(.+)$ ]]; then
+      local raw_path="${BASH_REMATCH[1]}"
+      raw_path="${raw_path%$'\r'}"
+      raw_path="${raw_path%\"}"
+      raw_path="${raw_path#\"}"
+      if [[ -f "$raw_path" ]]; then
+        index=$((index + 1))
+        local destination="$LOG_ROOT/${operation,,}-${timestamp}-${index}.log"
+        cp "$raw_path" "$destination"
+        echo "Captured LabVIEWCLI log: $destination"
+      else
+        echo "WARN: LabVIEWCLI log path from output was not found: $raw_path" >&2
+      fi
+    fi
+  done <<< "$output"
+}
+
+invoke_labviewcli() {
+  local operation="$1"
+  shift
+
+  local output
+  local status
+  set +e
+  output="$(LabVIEWCLI "$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [[ -n "$output" ]]; then
+    printf '%s\n' "$output"
+    capture_labviewcli_logs "$operation" "$output"
+  fi
+
+  return "$status"
+}
 
 if ! command -v LabVIEWCLI >/dev/null 2>&1; then
   echo "ERROR: LabVIEWCLI is not available on PATH inside the container." >&2
@@ -23,7 +88,26 @@ echo "LabVIEW path: $LABVIEW_PATH"
 echo "Excluded templates: $EXCLUDE_LIST"
 
 STAGING_DIR="$(mktemp -d)"
-trap 'rm -rf "$STAGING_DIR"' EXIT
+DEVMODE_ENABLED=0
+cleanup() {
+  local original_exit="$?"
+  local final_exit="$original_exit"
+
+  if [[ "$DEVMODE_ENABLED" -eq 1 ]]; then
+    echo "Reverting no-LabVIEW dev mode after build-spec execution."
+    if ! "$DEVMODE_SCRIPT" revert "$LABVIEW_ROOT" "$WORKSPACE_ROOT"; then
+      echo "ERROR: Failed to revert no-LabVIEW dev mode." >&2
+      final_exit=1
+    fi
+  fi
+
+  rm -rf "$STAGING_DIR"
+  if [[ "$final_exit" -ne "$original_exit" ]]; then
+    exit "$final_exit"
+  fi
+}
+trap cleanup EXIT
+
 cp -a "$TARGET_DIR/." "$STAGING_DIR/"
 
 IFS=';' read -r -a _exclude_items <<< "$EXCLUDE_LIST"
@@ -39,10 +123,58 @@ for _item in "${_exclude_items[@]}"; do
   fi
 done
 
-LabVIEWCLI -LogToConsole TRUE \
+if ! invoke_labviewcli "MassCompile" \
+  -LogToConsole TRUE \
   -OperationName MassCompile \
   -DirectoryToCompile "$STAGING_DIR" \
   -LabVIEWPath "$LABVIEW_PATH" \
-  -Headless
+  -Headless; then
+  echo "ERROR: LabVIEWCLI MassCompile failed." >&2
+  exit 1
+fi
 
 echo "MassCompile completed successfully."
+
+if ! is_enabled_value "$BUILD_SPEC_ENABLED_RAW"; then
+  echo "Build specification step disabled (set CONTAINER_PARITY_BUILD_SPEC=true to enable)."
+  exit 0
+fi
+
+if [[ ! -f "$PROJECT_PATH" ]]; then
+  echo "ERROR: Project file does not exist: $PROJECT_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -x "$DEVMODE_SCRIPT" ]]; then
+  chmod +x "$DEVMODE_SCRIPT"
+fi
+
+echo "Preparing no-LabVIEW dev mode before build-spec execution."
+"$DEVMODE_SCRIPT" enable "$LABVIEW_ROOT" "$WORKSPACE_ROOT"
+DEVMODE_ENABLED=1
+
+echo "Running LabVIEWCLI ExecuteBuildSpec in headless mode."
+echo "Project path: $PROJECT_PATH"
+echo "Build specification: $BUILD_SPEC_NAME"
+echo "Target name: $TARGET_NAME"
+echo "Expected output: $BUILD_OUTPUT_PATH"
+
+if ! invoke_labviewcli "ExecuteBuildSpec" \
+  -LogToConsole TRUE \
+  -OperationName ExecuteBuildSpec \
+  -ProjectPath "$PROJECT_PATH" \
+  -BuildSpecName "$BUILD_SPEC_NAME" \
+  -TargetName "$TARGET_NAME" \
+  -LabVIEWPath "$LABVIEW_PATH" \
+  -Headless; then
+  echo "ERROR: LabVIEWCLI ExecuteBuildSpec failed." >&2
+  exit 1
+fi
+
+if [[ ! -f "$BUILD_OUTPUT_PATH" ]]; then
+  echo "ERROR: Build specification output not found at expected path: $BUILD_OUTPUT_PATH" >&2
+  exit 1
+fi
+
+bytes="$(wc -c < "$BUILD_OUTPUT_PATH" | xargs)"
+echo "Build specification completed: $BUILD_OUTPUT_PATH ($bytes bytes)"

--- a/Tooling/container-parity/runlabview-linux.sh
+++ b/Tooling/container-parity/runlabview-linux.sh
@@ -28,6 +28,49 @@ is_enabled_value() {
   return 1
 }
 
+sync_icon_editor_sources_for_build_spec() {
+  local repo_plugins="$WORKSPACE_ROOT/resource/plugins"
+  local install_plugins="$LABVIEW_ROOT/resource/plugins"
+  local repo_icon_api="$WORKSPACE_ROOT/vi.lib/LabVIEW Icon API"
+  local install_icon_api="$LABVIEW_ROOT/vi.lib/LabVIEW Icon API"
+
+  local required_paths=(
+    "$repo_plugins/NIIconEditor"
+    "$repo_plugins/lv_IconEditor.lvlib"
+    "$repo_plugins/lv_icon.vi"
+    "$repo_icon_api"
+  )
+
+  for path in "${required_paths[@]}"; do
+    if [[ ! -e "$path" ]]; then
+      echo "ERROR: Required Icon Editor source path is missing: $path" >&2
+      return 1
+    fi
+  done
+
+  mkdir -p "$install_plugins"
+  cp -a "$repo_plugins/NIIconEditor" "$install_plugins/"
+  for file_name in lv_IconEditor.lvlib lv_icon.vi lv_icon.vit SAMPLE_lv_icon.vi; do
+    local source_path="$repo_plugins/$file_name"
+    if [[ -e "$source_path" ]]; then
+      cp -a "$source_path" "$install_plugins/"
+    fi
+  done
+
+  mkdir -p "$install_icon_api"
+  cp -a "$repo_icon_api/." "$install_icon_api/"
+
+  local probe="$install_plugins/NIIconEditor/Miscellaneous/Classes Initialization.vi"
+  if [[ ! -f "$probe" ]]; then
+    echo "ERROR: Icon Editor source synchronization failed. Missing probe file: $probe" >&2
+    return 1
+  fi
+
+  echo "Synchronized Icon Editor sources into LabVIEW install:"
+  echo "  resource/plugins -> $install_plugins"
+  echo "  vi.lib/LabVIEW Icon API -> $install_icon_api"
+}
+
 list_labviewcli_temp_logs() {
   if compgen -G '/tmp/lvtemporary_*.log' > /dev/null; then
     compgen -G '/tmp/lvtemporary_*.log' | sort -u
@@ -150,6 +193,11 @@ fi
 
 if [[ ! -f "$PROJECT_PATH" ]]; then
   echo "ERROR: Project file does not exist: $PROJECT_PATH" >&2
+  exit 1
+fi
+
+echo "Synchronizing workspace Icon Editor sources into LabVIEW install before build-spec execution."
+if ! sync_icon_editor_sources_for_build_spec; then
   exit 1
 fi
 

--- a/Tooling/container-parity/runlabview-linux.sh
+++ b/Tooling/container-parity/runlabview-linux.sh
@@ -12,6 +12,7 @@ TARGET_NAME="${CONTAINER_PARITY_TARGET_NAME:-My Computer}"
 BUILD_OUTPUT_RELATIVE_PATH="${CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH:-resource/plugins/lv_icon.lvlibp}"
 BUILD_OUTPUT_PATH="$WORKSPACE_ROOT/$BUILD_OUTPUT_RELATIVE_PATH"
 BUILD_SPEC_ENABLED_RAW="${CONTAINER_PARITY_BUILD_SPEC:-false}"
+ENABLE_DEVMODE_RAW="${CONTAINER_PARITY_ENABLE_DEVMODE:-false}"
 LOG_ROOT="$WORKSPACE_ROOT/TestResults/container-parity/linux/logs"
 LABVIEW_ROOT="$(dirname "$LABVIEW_PATH")"
 DEVMODE_SCRIPT="$WORKSPACE_ROOT/Tooling/container-parity/devmode-linux.sh"
@@ -152,13 +153,16 @@ if [[ ! -f "$PROJECT_PATH" ]]; then
   exit 1
 fi
 
-if [[ ! -x "$DEVMODE_SCRIPT" ]]; then
-  chmod +x "$DEVMODE_SCRIPT"
+if is_enabled_value "$ENABLE_DEVMODE_RAW"; then
+  if [[ ! -x "$DEVMODE_SCRIPT" ]]; then
+    chmod +x "$DEVMODE_SCRIPT"
+  fi
+  echo "Preparing no-LabVIEW dev mode before build-spec execution."
+  "$DEVMODE_SCRIPT" enable "$LABVIEW_ROOT" "$WORKSPACE_ROOT"
+  DEVMODE_ENABLED=1
+else
+  echo "No-LabVIEW dev mode is disabled for container parity (set CONTAINER_PARITY_ENABLE_DEVMODE=true to enable)."
 fi
-
-echo "Preparing no-LabVIEW dev mode before build-spec execution."
-"$DEVMODE_SCRIPT" enable "$LABVIEW_ROOT" "$WORKSPACE_ROOT"
-DEVMODE_ENABLED=1
 
 echo "Running LabVIEWCLI ExecuteBuildSpec in headless mode."
 echo "Project path: $PROJECT_PATH"

--- a/Tooling/container-parity/runlabview-linux.sh
+++ b/Tooling/container-parity/runlabview-linux.sh
@@ -27,48 +27,55 @@ is_enabled_value() {
   return 1
 }
 
-capture_labviewcli_logs() {
-  local operation="$1"
-  local output="$2"
-  local index=0
-  local timestamp
-  timestamp="$(date +%Y%m%d-%H%M%S)"
-  mkdir -p "$LOG_ROOT"
-
-  while IFS= read -r line; do
-    if [[ "$line" =~ LabVIEWCLI[[:space:]]started[[:space:]]logging[[:space:]]in[[:space:]]file:[[:space:]]*(.+)$ ]]; then
-      local raw_path="${BASH_REMATCH[1]}"
-      raw_path="${raw_path%$'\r'}"
-      raw_path="${raw_path%\"}"
-      raw_path="${raw_path#\"}"
-      if [[ -f "$raw_path" ]]; then
-        index=$((index + 1))
-        local destination="$LOG_ROOT/${operation,,}-${timestamp}-${index}.log"
-        cp "$raw_path" "$destination"
-        echo "Captured LabVIEWCLI log: $destination"
-      else
-        echo "WARN: LabVIEWCLI log path from output was not found: $raw_path" >&2
-      fi
-    fi
-  done <<< "$output"
+list_labviewcli_temp_logs() {
+  if compgen -G '/tmp/lvtemporary_*.log' > /dev/null; then
+    compgen -G '/tmp/lvtemporary_*.log' | sort -u
+  fi
 }
 
 invoke_labviewcli() {
   local operation="$1"
   shift
 
-  local output
+  local before_logs_file
+  before_logs_file="$(mktemp)"
+  list_labviewcli_temp_logs > "$before_logs_file"
+
   local status
   set +e
-  output="$(LabVIEWCLI "$@" 2>&1)"
+  LabVIEWCLI "$@"
   status=$?
   set -e
 
-  if [[ -n "$output" ]]; then
-    printf '%s\n' "$output"
-    capture_labviewcli_logs "$operation" "$output"
+  local timestamp
+  timestamp="$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$LOG_ROOT"
+
+  local index=0
+  while IFS= read -r candidate; do
+    if [[ -z "$candidate" || ! -f "$candidate" ]]; then
+      continue
+    fi
+    if grep -Fxq "$candidate" "$before_logs_file"; then
+      continue
+    fi
+    index=$((index + 1))
+    local destination="$LOG_ROOT/${operation,,}-${timestamp}-${index}.log"
+    cp "$candidate" "$destination"
+    echo "Captured LabVIEWCLI log: $destination"
+  done < <(list_labviewcli_temp_logs)
+
+  if [[ "$index" -eq 0 ]]; then
+    local fallback
+    fallback="$(ls -1t /tmp/lvtemporary_*.log 2>/dev/null | head -n 1 || true)"
+    if [[ -n "$fallback" && -f "$fallback" ]]; then
+      local destination="$LOG_ROOT/${operation,,}-${timestamp}-fallback.log"
+      cp "$fallback" "$destination"
+      echo "Captured LabVIEWCLI log (fallback): $destination"
+    fi
   fi
 
+  rm -f "$before_logs_file"
   return "$status"
 }
 

--- a/Tooling/container-parity/runlabview-windows.ps1
+++ b/Tooling/container-parity/runlabview-windows.ps1
@@ -147,6 +147,7 @@ if ([string]::IsNullOrWhiteSpace($TargetName)) {
 }
 
 $buildSpecEnabled = $BuildProjectSpec.IsPresent -or (Test-EnabledValue -Value $env:CONTAINER_PARITY_BUILD_SPEC)
+$enableDevMode = Test-EnabledValue -Value $env:CONTAINER_PARITY_ENABLE_DEVMODE
 $buildOutputRelativePath = if ([string]::IsNullOrWhiteSpace($env:CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH)) {
     'resource\plugins\lv_icon.lvlibp'
 } else {
@@ -209,29 +210,38 @@ try {
         throw "Project file does not exist: $ProjectPath"
     }
 
-    $setDevModeScript = Join-Path $WorkspaceRoot 'Tooling\Set-DevelopmentMode-NoLabVIEW.ps1'
-    $revertDevModeScript = Join-Path $WorkspaceRoot 'Tooling\Revert-DevelopmentMode-NoLabVIEW.ps1'
-    if (-not (Test-Path -LiteralPath $setDevModeScript -PathType Leaf)) {
-        throw "Required script not found: $setDevModeScript"
-    }
-    if (-not (Test-Path -LiteralPath $revertDevModeScript -PathType Leaf)) {
-        throw "Required script not found: $revertDevModeScript"
-    }
+    $setDevModeScript = $null
+    $revertDevModeScript = $null
+    $labviewYear = $null
+    $devModeEnabled = $false
+    if ($enableDevMode) {
+        $setDevModeScript = Join-Path $WorkspaceRoot 'Tooling\Set-DevelopmentMode-NoLabVIEW.ps1'
+        $revertDevModeScript = Join-Path $WorkspaceRoot 'Tooling\Revert-DevelopmentMode-NoLabVIEW.ps1'
+        if (-not (Test-Path -LiteralPath $setDevModeScript -PathType Leaf)) {
+            throw "Required script not found: $setDevModeScript"
+        }
+        if (-not (Test-Path -LiteralPath $revertDevModeScript -PathType Leaf)) {
+            throw "Required script not found: $revertDevModeScript"
+        }
 
-    $labviewYear = Resolve-LabVIEWVersionYear -VersionInput $LabVIEWVersion -LabVIEWExecutablePath $LabVIEWPath
-    if ([string]::IsNullOrWhiteSpace($labviewYear)) {
-        throw "Unable to resolve LabVIEW version year for no-LabVIEW dev mode plumbing."
-    }
+        $labviewYear = Resolve-LabVIEWVersionYear -VersionInput $LabVIEWVersion -LabVIEWExecutablePath $LabVIEWPath
+        if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+            throw "Unable to resolve LabVIEW version year for no-LabVIEW dev mode plumbing."
+        }
 
-    Write-Output "Preparing no-LabVIEW dev mode before build-spec execution."
-    & $setDevModeScript `
-        -LabVIEWVersion $labviewYear `
-        -SupportedBitness 64 `
-        -RepoRoot $WorkspaceRoot `
-        -SkipProcessCheck `
-        -SkipRepoVersionCheck
-    if ($LASTEXITCODE -ne 0) {
-        throw "Set-DevelopmentMode-NoLabVIEW failed with exit code $LASTEXITCODE."
+        Write-Output "Preparing no-LabVIEW dev mode before build-spec execution."
+        & $setDevModeScript `
+            -LabVIEWVersion $labviewYear `
+            -SupportedBitness 64 `
+            -RepoRoot $WorkspaceRoot `
+            -SkipProcessCheck `
+            -SkipRepoVersionCheck
+        if ($LASTEXITCODE -ne 0) {
+            throw "Set-DevelopmentMode-NoLabVIEW failed with exit code $LASTEXITCODE."
+        }
+        $devModeEnabled = $true
+    } else {
+        Write-Output "No-LabVIEW dev mode is disabled for container parity (set CONTAINER_PARITY_ENABLE_DEVMODE=true to enable)."
     }
 
     $buildSpecError = $null
@@ -264,19 +274,21 @@ try {
     } catch {
         $buildSpecError = $_
     } finally {
-        Write-Output "Reverting no-LabVIEW dev mode after build-spec execution."
-        & $revertDevModeScript `
-            -LabVIEWVersion $labviewYear `
-            -SupportedBitness 64 `
-            -RepoRoot $WorkspaceRoot `
-            -SkipProcessCheck `
-            -SkipRepoVersionCheck
-        if ($LASTEXITCODE -ne 0) {
-            $revertError = "Revert-DevelopmentMode-NoLabVIEW failed with exit code $LASTEXITCODE."
-            if ($buildSpecError) {
-                throw ("{0} Revert error: {1}" -f $buildSpecError.Exception.Message, $revertError)
+        if ($devModeEnabled) {
+            Write-Output "Reverting no-LabVIEW dev mode after build-spec execution."
+            & $revertDevModeScript `
+                -LabVIEWVersion $labviewYear `
+                -SupportedBitness 64 `
+                -RepoRoot $WorkspaceRoot `
+                -SkipProcessCheck `
+                -SkipRepoVersionCheck
+            if ($LASTEXITCODE -ne 0) {
+                $revertError = "Revert-DevelopmentMode-NoLabVIEW failed with exit code $LASTEXITCODE."
+                if ($buildSpecError) {
+                    throw ("{0} Revert error: {1}" -f $buildSpecError.Exception.Message, $revertError)
+                }
+                throw $revertError
             }
-            throw $revertError
         }
     }
 

--- a/Tooling/container-parity/runlabview-windows.ps1
+++ b/Tooling/container-parity/runlabview-windows.ps1
@@ -47,53 +47,54 @@ function Resolve-LabVIEWVersionYear {
     return ''
 }
 
-function Get-LabVIEWCliLogPathsFromOutput {
+function Get-LabVIEWCliTempLogPath {
     param(
-        [object[]]$OutputLines
+        [string]$TempRoot = ([System.IO.Path]::GetTempPath())
     )
 
-    $results = @()
-    foreach ($line in $OutputLines) {
-        if ($null -eq $line) {
-            continue
-        }
-
-        $text = [string]$line
-        if ($text -match 'LabVIEWCLI started logging in file:\s*(?<path>.+)$') {
-            $path = $Matches['path'].Trim().Trim('"')
-            if (-not [string]::IsNullOrWhiteSpace($path)) {
-                $results += $path
-            }
-        }
-    }
-
-    return @($results | Select-Object -Unique)
+    return @(
+        Get-ChildItem -LiteralPath $TempRoot -Filter 'lvtemporary_*.log' -File -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTimeUtc -Descending |
+            Select-Object -ExpandProperty FullName
+    )
 }
 
 function Save-LabVIEWCliLog {
     param(
         [string]$WorkspaceRootPath,
         [string]$OperationName,
-        [string[]]$LogPaths
+        [string[]]$BeforeLogPaths
     )
-
-    $copied = @()
-    if ($LogPaths.Count -eq 0) {
-        return $copied
-    }
 
     $logRoot = Join-Path $WorkspaceRootPath 'TestResults\container-parity\windows\logs'
     New-Item -Path $logRoot -ItemType Directory -Force | Out-Null
     $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
-    $index = 0
+    $beforeSet = @{}
+    foreach ($path in $BeforeLogPaths) {
+        if (-not [string]::IsNullOrWhiteSpace($path)) {
+            $beforeSet[$path] = $true
+        }
+    }
 
-    foreach ($source in $LogPaths) {
-        $index++
+    $afterLogPaths = @(Get-LabVIEWCliTempLogPath)
+    $newLogPaths = @()
+    foreach ($source in $afterLogPaths) {
+        if (-not $beforeSet.ContainsKey($source)) {
+            $newLogPaths += $source
+        }
+    }
+
+    if ($newLogPaths.Count -eq 0 -and $afterLogPaths.Count -gt 0) {
+        $newLogPaths = @($afterLogPaths[0])
+    }
+
+    $copied = @()
+    $index = 0
+    foreach ($source in $newLogPaths) {
         if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-            Write-Warning "LabVIEWCLI log path from output was not found: $source"
             continue
         }
-
+        $index++
         $destination = Join-Path $logRoot ("{0}-{1}-{2}.log" -f $OperationName.ToLowerInvariant(), $timestamp, $index)
         Copy-Item -LiteralPath $source -Destination $destination -Force
         $copied += $destination
@@ -110,16 +111,10 @@ function Invoke-LabVIEWCliOperation {
         [string]$WorkspaceRootPath
     )
 
-    $outputLines = @(& LabVIEWCLI @Arguments 2>&1)
+    $beforeLogPaths = @(Get-LabVIEWCliTempLogPath)
+    & LabVIEWCLI @Arguments
     $exitCode = $LASTEXITCODE
-    foreach ($line in $outputLines) {
-        if ($null -ne $line) {
-            Write-Output ([string]$line)
-        }
-    }
-
-    $logPaths = Get-LabVIEWCliLogPathsFromOutput -OutputLines $outputLines
-    $copiedLogs = Save-LabVIEWCliLog -WorkspaceRootPath $WorkspaceRootPath -OperationName $OperationName -LogPaths $logPaths
+    $copiedLogs = Save-LabVIEWCliLog -WorkspaceRootPath $WorkspaceRootPath -OperationName $OperationName -BeforeLogPaths $beforeLogPaths
 
     return [pscustomobject]@{
         ExitCode   = $exitCode

--- a/Tooling/container-parity/runlabview-windows.ps1
+++ b/Tooling/container-parity/runlabview-windows.ps1
@@ -4,7 +4,8 @@ param(
     [string]$LabVIEWPath = "C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe",
     [string]$ProjectPath = "",
     [string]$BuildSpecName = "",
-    [string]$BuildTargetName = "",
+    [string]$TargetName = "",
+    [string]$LabVIEWVersion = "",
     [switch]$BuildProjectSpec
 )
 
@@ -25,6 +26,107 @@ function Test-EnabledValue {
         -or $Value.Equals('yes', [System.StringComparison]::OrdinalIgnoreCase)
 }
 
+function Resolve-LabVIEWVersionYear {
+    param(
+        [string]$VersionInput,
+        [string]$LabVIEWExecutablePath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($VersionInput)) {
+        return $VersionInput
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:CONTAINER_PARITY_LABVIEW_VERSION)) {
+        return $env:CONTAINER_PARITY_LABVIEW_VERSION
+    }
+
+    if ($LabVIEWExecutablePath -match 'LabVIEW\s+(?<year>\d{4})') {
+        return $Matches['year']
+    }
+
+    return ''
+}
+
+function Get-LabVIEWCliLogPathsFromOutput {
+    param(
+        [object[]]$OutputLines
+    )
+
+    $results = @()
+    foreach ($line in $OutputLines) {
+        if ($null -eq $line) {
+            continue
+        }
+
+        $text = [string]$line
+        if ($text -match 'LabVIEWCLI started logging in file:\s*(?<path>.+)$') {
+            $path = $Matches['path'].Trim().Trim('"')
+            if (-not [string]::IsNullOrWhiteSpace($path)) {
+                $results += $path
+            }
+        }
+    }
+
+    return @($results | Select-Object -Unique)
+}
+
+function Save-LabVIEWCliLog {
+    param(
+        [string]$WorkspaceRootPath,
+        [string]$OperationName,
+        [string[]]$LogPaths
+    )
+
+    $copied = @()
+    if ($LogPaths.Count -eq 0) {
+        return $copied
+    }
+
+    $logRoot = Join-Path $WorkspaceRootPath 'TestResults\container-parity\windows\logs'
+    New-Item -Path $logRoot -ItemType Directory -Force | Out-Null
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $index = 0
+
+    foreach ($source in $LogPaths) {
+        $index++
+        if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+            Write-Warning "LabVIEWCLI log path from output was not found: $source"
+            continue
+        }
+
+        $destination = Join-Path $logRoot ("{0}-{1}-{2}.log" -f $OperationName.ToLowerInvariant(), $timestamp, $index)
+        Copy-Item -LiteralPath $source -Destination $destination -Force
+        $copied += $destination
+        Write-Host "Captured LabVIEWCLI log: $destination"
+    }
+
+    return $copied
+}
+
+function Invoke-LabVIEWCliOperation {
+    param(
+        [string]$OperationName,
+        [string[]]$Arguments,
+        [string]$WorkspaceRootPath
+    )
+
+    $outputLines = @(& LabVIEWCLI @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
+    foreach ($line in $outputLines) {
+        if ($null -ne $line) {
+            Write-Host ([string]$line)
+        }
+    }
+
+    $logPaths = Get-LabVIEWCliLogPathsFromOutput -OutputLines $outputLines
+    $copiedLogs = Save-LabVIEWCliLog -WorkspaceRootPath $WorkspaceRootPath -OperationName $OperationName -LogPaths $logPaths
+
+    return [pscustomobject]@{
+        ExitCode   = $exitCode
+        CopiedLogs = $copiedLogs
+    }
+}
+
 if ([string]::IsNullOrWhiteSpace($TargetDir)) {
     $TargetDir = Join-Path $WorkspaceRoot 'Test\Templates'
 }
@@ -41,11 +143,11 @@ if ([string]::IsNullOrWhiteSpace($BuildSpecName)) {
     }
 }
 
-if ([string]::IsNullOrWhiteSpace($BuildTargetName)) {
-    $BuildTargetName = if ([string]::IsNullOrWhiteSpace($env:CONTAINER_PARITY_BUILD_TARGET_NAME)) {
+if ([string]::IsNullOrWhiteSpace($TargetName)) {
+    $TargetName = if ([string]::IsNullOrWhiteSpace($env:CONTAINER_PARITY_TARGET_NAME)) {
         'My Computer'
     } else {
-        $env:CONTAINER_PARITY_BUILD_TARGET_NAME
+        $env:CONTAINER_PARITY_TARGET_NAME
     }
 }
 
@@ -74,65 +176,120 @@ $excludeFiles = @($excludeRaw.Split(';', [System.StringSplitOptions]::RemoveEmpt
 $stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) ("lvie-parity-{0}" -f [Guid]::NewGuid().ToString('N'))
 New-Item -Path $stagingDir -ItemType Directory -Force | Out-Null
 
-Copy-Item -Path (Join-Path $TargetDir '*') -Destination $stagingDir -Recurse -Force
-foreach ($relativePath in $excludeFiles) {
-    $candidate = Join-Path $stagingDir $relativePath
-    if (Test-Path -LiteralPath $candidate) {
-        Write-Host "Excluding template from parity compile: $relativePath"
-        Remove-Item -LiteralPath $candidate -Recurse -Force
+try {
+    Copy-Item -Path (Join-Path $TargetDir '*') -Destination $stagingDir -Recurse -Force
+    foreach ($relativePath in $excludeFiles) {
+        $candidate = Join-Path $stagingDir $relativePath
+        if (Test-Path -LiteralPath $candidate) {
+            Write-Host "Excluding template from parity compile: $relativePath"
+            Remove-Item -LiteralPath $candidate -Recurse -Force
+        }
+    }
+
+    Write-Host "Running LabVIEWCLI MassCompile in headless mode."
+    Write-Host "Target directory: $TargetDir"
+    Write-Host "LabVIEW path: $LabVIEWPath"
+    Write-Host ("Excluded templates: {0}" -f ($excludeFiles -join '; '))
+    Write-Host "Staging directory: $stagingDir"
+
+    $massCompile = Invoke-LabVIEWCliOperation -OperationName 'MassCompile' -Arguments @(
+        '-LogToConsole', 'TRUE',
+        '-OperationName', 'MassCompile',
+        '-DirectoryToCompile', $stagingDir,
+        '-LabVIEWPath', $LabVIEWPath,
+        '-Headless'
+    ) -WorkspaceRootPath $WorkspaceRoot
+    if ($massCompile.ExitCode -ne 0) {
+        throw "LabVIEWCLI MassCompile failed with exit code $($massCompile.ExitCode)."
+    }
+
+    Write-Host "MassCompile completed successfully."
+
+    if (-not $buildSpecEnabled) {
+        Write-Host "Build specification step disabled (set CONTAINER_PARITY_BUILD_SPEC=true to enable)."
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $ProjectPath -PathType Leaf)) {
+        throw "Project file does not exist: $ProjectPath"
+    }
+
+    $setDevModeScript = Join-Path $WorkspaceRoot 'Tooling\Set-DevelopmentMode-NoLabVIEW.ps1'
+    $revertDevModeScript = Join-Path $WorkspaceRoot 'Tooling\Revert-DevelopmentMode-NoLabVIEW.ps1'
+    if (-not (Test-Path -LiteralPath $setDevModeScript -PathType Leaf)) {
+        throw "Required script not found: $setDevModeScript"
+    }
+    if (-not (Test-Path -LiteralPath $revertDevModeScript -PathType Leaf)) {
+        throw "Required script not found: $revertDevModeScript"
+    }
+
+    $labviewYear = Resolve-LabVIEWVersionYear -VersionInput $LabVIEWVersion -LabVIEWExecutablePath $LabVIEWPath
+    if ([string]::IsNullOrWhiteSpace($labviewYear)) {
+        throw "Unable to resolve LabVIEW version year for no-LabVIEW dev mode plumbing."
+    }
+
+    Write-Host "Preparing no-LabVIEW dev mode before build-spec execution."
+    & $setDevModeScript `
+        -LabVIEWVersion $labviewYear `
+        -SupportedBitness 64 `
+        -RepoRoot $WorkspaceRoot `
+        -SkipProcessCheck `
+        -SkipRepoVersionCheck
+    if ($LASTEXITCODE -ne 0) {
+        throw "Set-DevelopmentMode-NoLabVIEW failed with exit code $LASTEXITCODE."
+    }
+
+    $buildSpecError = $null
+    try {
+        Write-Host "Running LabVIEWCLI ExecuteBuildSpec in headless mode."
+        Write-Host "Project path: $ProjectPath"
+        Write-Host "Build specification: $BuildSpecName"
+        Write-Host "Target name: $TargetName"
+        Write-Host "Expected output: $buildOutputPath"
+
+        $buildSpec = Invoke-LabVIEWCliOperation -OperationName 'ExecuteBuildSpec' -Arguments @(
+            '-LogToConsole', 'TRUE',
+            '-OperationName', 'ExecuteBuildSpec',
+            '-ProjectPath', $ProjectPath,
+            '-BuildSpecName', $BuildSpecName,
+            '-TargetName', $TargetName,
+            '-LabVIEWPath', $LabVIEWPath,
+            '-Headless'
+        ) -WorkspaceRootPath $WorkspaceRoot
+        if ($buildSpec.ExitCode -ne 0) {
+            throw "LabVIEWCLI ExecuteBuildSpec failed with exit code $($buildSpec.ExitCode)."
+        }
+
+        if (-not (Test-Path -LiteralPath $buildOutputPath -PathType Leaf)) {
+            throw "Build specification output not found at expected path: $buildOutputPath"
+        }
+
+        $buildOutput = Get-Item -LiteralPath $buildOutputPath
+        Write-Host ("Build specification completed: {0} ({1} bytes)" -f $buildOutput.FullName, $buildOutput.Length)
+    } catch {
+        $buildSpecError = $_
+    } finally {
+        Write-Host "Reverting no-LabVIEW dev mode after build-spec execution."
+        & $revertDevModeScript `
+            -LabVIEWVersion $labviewYear `
+            -SupportedBitness 64 `
+            -RepoRoot $WorkspaceRoot `
+            -SkipProcessCheck `
+            -SkipRepoVersionCheck
+        if ($LASTEXITCODE -ne 0) {
+            $revertError = "Revert-DevelopmentMode-NoLabVIEW failed with exit code $LASTEXITCODE."
+            if ($buildSpecError) {
+                throw ("{0} Revert error: {1}" -f $buildSpecError.Exception.Message, $revertError)
+            }
+            throw $revertError
+        }
+    }
+
+    if ($buildSpecError) {
+        throw $buildSpecError.Exception
+    }
+} finally {
+    if (Test-Path -LiteralPath $stagingDir) {
+        Remove-Item -LiteralPath $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
-
-Write-Host "Running LabVIEWCLI MassCompile in headless mode."
-Write-Host "Target directory: $TargetDir"
-Write-Host "LabVIEW path: $LabVIEWPath"
-Write-Host ("Excluded templates: {0}" -f ($excludeFiles -join '; '))
-Write-Host "Staging directory: $stagingDir"
-
-& LabVIEWCLI `
-    -LogToConsole TRUE `
-    -OperationName MassCompile `
-    -DirectoryToCompile $stagingDir `
-    -LabVIEWPath $LabVIEWPath `
-    -Headless
-
-if ($LASTEXITCODE -ne 0) {
-    throw "LabVIEWCLI MassCompile failed with exit code $LASTEXITCODE."
-}
-
-Write-Host "MassCompile completed successfully."
-
-if (-not $buildSpecEnabled) {
-    Write-Host "Build specification step disabled (set CONTAINER_PARITY_BUILD_SPEC=true to enable)."
-    return
-}
-
-if (-not (Test-Path -LiteralPath $ProjectPath -PathType Leaf)) {
-    throw "Project file does not exist: $ProjectPath"
-}
-
-Write-Host "Running LabVIEWCLI ExecuteBuildSpec in headless mode."
-Write-Host "Project path: $ProjectPath"
-Write-Host "Build specification: $BuildSpecName"
-Write-Host "Build target: $BuildTargetName"
-Write-Host "Expected output: $buildOutputPath"
-
-& LabVIEWCLI `
-    -LogToConsole TRUE `
-    -OperationName ExecuteBuildSpec `
-    -ProjectPath $ProjectPath `
-    -BuildSpecName $BuildSpecName `
-    -BuildTargetName $BuildTargetName `
-    -LabVIEWPath $LabVIEWPath `
-    -Headless
-
-if ($LASTEXITCODE -ne 0) {
-    throw "LabVIEWCLI ExecuteBuildSpec failed with exit code $LASTEXITCODE."
-}
-
-if (-not (Test-Path -LiteralPath $buildOutputPath -PathType Leaf)) {
-    throw "Build specification output not found at expected path: $buildOutputPath"
-}
-
-$buildOutput = Get-Item -LiteralPath $buildOutputPath
-Write-Host ("Build specification completed: {0} ({1} bytes)" -f $buildOutput.FullName, $buildOutput.Length)

--- a/Tooling/container-parity/runlabview-windows.ps1
+++ b/Tooling/container-parity/runlabview-windows.ps1
@@ -47,6 +47,62 @@ function Resolve-LabVIEWVersionYear {
     return ''
 }
 
+function Sync-IconEditorSourcesForBuildSpec {
+    param(
+        [string]$WorkspaceRootPath,
+        [string]$LabVIEWExecutablePath
+    )
+
+    if (-not (Test-Path -LiteralPath $WorkspaceRootPath -PathType Container)) {
+        throw "Workspace root does not exist: $WorkspaceRootPath"
+    }
+
+    $labviewRoot = Split-Path -Path $LabVIEWExecutablePath -Parent
+    if ([string]::IsNullOrWhiteSpace($labviewRoot) -or -not (Test-Path -LiteralPath $labviewRoot -PathType Container)) {
+        throw "Unable to resolve LabVIEW install root from LabVIEW path: $LabVIEWExecutablePath"
+    }
+
+    $repoPlugins = Join-Path $WorkspaceRootPath 'resource\plugins'
+    $repoIconApi = Join-Path $WorkspaceRootPath 'vi.lib\LabVIEW Icon API'
+    $requiredPaths = @(
+        (Join-Path $repoPlugins 'NIIconEditor'),
+        (Join-Path $repoPlugins 'lv_IconEditor.lvlib'),
+        (Join-Path $repoPlugins 'lv_icon.vi'),
+        $repoIconApi
+    )
+
+    foreach ($path in $requiredPaths) {
+        if (-not (Test-Path -LiteralPath $path)) {
+            throw "Required Icon Editor source path is missing: $path"
+        }
+    }
+
+    $installPlugins = Join-Path $labviewRoot 'resource\plugins'
+    $installIconApi = Join-Path $labviewRoot 'vi.lib\LabVIEW Icon API'
+    New-Item -Path $installPlugins -ItemType Directory -Force | Out-Null
+    New-Item -Path $installIconApi -ItemType Directory -Force | Out-Null
+
+    Copy-Item -LiteralPath (Join-Path $repoPlugins 'NIIconEditor') -Destination $installPlugins -Recurse -Force
+
+    foreach ($fileName in @('lv_IconEditor.lvlib', 'lv_icon.vi', 'lv_icon.vit', 'SAMPLE_lv_icon.vi')) {
+        $sourcePath = Join-Path $repoPlugins $fileName
+        if (Test-Path -LiteralPath $sourcePath -PathType Leaf) {
+            Copy-Item -LiteralPath $sourcePath -Destination $installPlugins -Force
+        }
+    }
+
+    Get-ChildItem -LiteralPath $repoIconApi -Force | Copy-Item -Destination $installIconApi -Recurse -Force
+
+    $probe = Join-Path $installPlugins 'NIIconEditor\Miscellaneous\Classes Initialization.vi'
+    if (-not (Test-Path -LiteralPath $probe -PathType Leaf)) {
+        throw "Icon Editor source synchronization failed. Missing probe file: $probe"
+    }
+
+    Write-Output "Synchronized Icon Editor sources into LabVIEW install:"
+    Write-Output "  resource\\plugins -> $installPlugins"
+    Write-Output "  vi.lib\\LabVIEW Icon API -> $installIconApi"
+}
+
 function Get-LabVIEWCliTempLogPath {
     param(
         [string]$TempRoot = ([System.IO.Path]::GetTempPath())
@@ -209,6 +265,9 @@ try {
     if (-not (Test-Path -LiteralPath $ProjectPath -PathType Leaf)) {
         throw "Project file does not exist: $ProjectPath"
     }
+
+    Write-Output "Synchronizing workspace Icon Editor sources into LabVIEW install before build-spec execution."
+    Sync-IconEditorSourcesForBuildSpec -WorkspaceRootPath $WorkspaceRoot -LabVIEWExecutablePath $LabVIEWPath
 
     $setDevModeScript = $null
     $revertDevModeScript = $null

--- a/Tooling/container-parity/runlabview-windows.ps1
+++ b/Tooling/container-parity/runlabview-windows.ps1
@@ -1,14 +1,61 @@
 param(
     [string]$WorkspaceRoot = "C:\workspace",
     [string]$TargetDir = "",
-    [string]$LabVIEWPath = "C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe"
+    [string]$LabVIEWPath = "C:\Program Files\National Instruments\LabVIEW 2026\LabVIEW.exe",
+    [string]$ProjectPath = "",
+    [string]$BuildSpecName = "",
+    [string]$BuildTargetName = "",
+    [switch]$BuildProjectSpec
 )
 
 $ErrorActionPreference = 'Stop'
 
+function Test-EnabledValue {
+    param(
+        [AllowNull()]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
+    }
+
+    return $Value.Equals('1', [System.StringComparison]::OrdinalIgnoreCase) `
+        -or $Value.Equals('true', [System.StringComparison]::OrdinalIgnoreCase) `
+        -or $Value.Equals('yes', [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 if ([string]::IsNullOrWhiteSpace($TargetDir)) {
     $TargetDir = Join-Path $WorkspaceRoot 'Test\Templates'
 }
+
+if ([string]::IsNullOrWhiteSpace($ProjectPath)) {
+    $ProjectPath = Join-Path $WorkspaceRoot 'lv_icon_editor.lvproj'
+}
+
+if ([string]::IsNullOrWhiteSpace($BuildSpecName)) {
+    $BuildSpecName = if ([string]::IsNullOrWhiteSpace($env:CONTAINER_PARITY_BUILD_SPEC_NAME)) {
+        'Editor Packed Library'
+    } else {
+        $env:CONTAINER_PARITY_BUILD_SPEC_NAME
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($BuildTargetName)) {
+    $BuildTargetName = if ([string]::IsNullOrWhiteSpace($env:CONTAINER_PARITY_BUILD_TARGET_NAME)) {
+        'My Computer'
+    } else {
+        $env:CONTAINER_PARITY_BUILD_TARGET_NAME
+    }
+}
+
+$buildSpecEnabled = $BuildProjectSpec.IsPresent -or (Test-EnabledValue -Value $env:CONTAINER_PARITY_BUILD_SPEC)
+$buildOutputRelativePath = if ([string]::IsNullOrWhiteSpace($env:CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH)) {
+    'resource\plugins\lv_icon.lvlibp'
+} else {
+    $env:CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH
+}
+$buildOutputPath = Join-Path $WorkspaceRoot $buildOutputRelativePath
 
 if (-not (Get-Command LabVIEWCLI -ErrorAction SilentlyContinue)) {
     Write-Error "LabVIEWCLI is not available on PATH inside the container."
@@ -54,3 +101,38 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "MassCompile completed successfully."
+
+if (-not $buildSpecEnabled) {
+    Write-Host "Build specification step disabled (set CONTAINER_PARITY_BUILD_SPEC=true to enable)."
+    return
+}
+
+if (-not (Test-Path -LiteralPath $ProjectPath -PathType Leaf)) {
+    throw "Project file does not exist: $ProjectPath"
+}
+
+Write-Host "Running LabVIEWCLI ExecuteBuildSpec in headless mode."
+Write-Host "Project path: $ProjectPath"
+Write-Host "Build specification: $BuildSpecName"
+Write-Host "Build target: $BuildTargetName"
+Write-Host "Expected output: $buildOutputPath"
+
+& LabVIEWCLI `
+    -LogToConsole TRUE `
+    -OperationName ExecuteBuildSpec `
+    -ProjectPath $ProjectPath `
+    -BuildSpecName $BuildSpecName `
+    -BuildTargetName $BuildTargetName `
+    -LabVIEWPath $LabVIEWPath `
+    -Headless
+
+if ($LASTEXITCODE -ne 0) {
+    throw "LabVIEWCLI ExecuteBuildSpec failed with exit code $LASTEXITCODE."
+}
+
+if (-not (Test-Path -LiteralPath $buildOutputPath -PathType Leaf)) {
+    throw "Build specification output not found at expected path: $buildOutputPath"
+}
+
+$buildOutput = Get-Item -LiteralPath $buildOutputPath
+Write-Host ("Build specification completed: {0} ({1} bytes)" -f $buildOutput.FullName, $buildOutput.Length)

--- a/Tooling/container-parity/runlabview-windows.ps1
+++ b/Tooling/container-parity/runlabview-windows.ps1
@@ -97,7 +97,7 @@ function Save-LabVIEWCliLog {
         $destination = Join-Path $logRoot ("{0}-{1}-{2}.log" -f $OperationName.ToLowerInvariant(), $timestamp, $index)
         Copy-Item -LiteralPath $source -Destination $destination -Force
         $copied += $destination
-        Write-Host "Captured LabVIEWCLI log: $destination"
+        Write-Output "Captured LabVIEWCLI log: $destination"
     }
 
     return $copied
@@ -114,7 +114,7 @@ function Invoke-LabVIEWCliOperation {
     $exitCode = $LASTEXITCODE
     foreach ($line in $outputLines) {
         if ($null -ne $line) {
-            Write-Host ([string]$line)
+            Write-Output ([string]$line)
         }
     }
 
@@ -181,16 +181,16 @@ try {
     foreach ($relativePath in $excludeFiles) {
         $candidate = Join-Path $stagingDir $relativePath
         if (Test-Path -LiteralPath $candidate) {
-            Write-Host "Excluding template from parity compile: $relativePath"
+            Write-Output "Excluding template from parity compile: $relativePath"
             Remove-Item -LiteralPath $candidate -Recurse -Force
         }
     }
 
-    Write-Host "Running LabVIEWCLI MassCompile in headless mode."
-    Write-Host "Target directory: $TargetDir"
-    Write-Host "LabVIEW path: $LabVIEWPath"
-    Write-Host ("Excluded templates: {0}" -f ($excludeFiles -join '; '))
-    Write-Host "Staging directory: $stagingDir"
+    Write-Output "Running LabVIEWCLI MassCompile in headless mode."
+    Write-Output "Target directory: $TargetDir"
+    Write-Output "LabVIEW path: $LabVIEWPath"
+    Write-Output ("Excluded templates: {0}" -f ($excludeFiles -join '; '))
+    Write-Output "Staging directory: $stagingDir"
 
     $massCompile = Invoke-LabVIEWCliOperation -OperationName 'MassCompile' -Arguments @(
         '-LogToConsole', 'TRUE',
@@ -203,10 +203,10 @@ try {
         throw "LabVIEWCLI MassCompile failed with exit code $($massCompile.ExitCode)."
     }
 
-    Write-Host "MassCompile completed successfully."
+    Write-Output "MassCompile completed successfully."
 
     if (-not $buildSpecEnabled) {
-        Write-Host "Build specification step disabled (set CONTAINER_PARITY_BUILD_SPEC=true to enable)."
+        Write-Output "Build specification step disabled (set CONTAINER_PARITY_BUILD_SPEC=true to enable)."
         return
     }
 
@@ -228,7 +228,7 @@ try {
         throw "Unable to resolve LabVIEW version year for no-LabVIEW dev mode plumbing."
     }
 
-    Write-Host "Preparing no-LabVIEW dev mode before build-spec execution."
+    Write-Output "Preparing no-LabVIEW dev mode before build-spec execution."
     & $setDevModeScript `
         -LabVIEWVersion $labviewYear `
         -SupportedBitness 64 `
@@ -241,11 +241,11 @@ try {
 
     $buildSpecError = $null
     try {
-        Write-Host "Running LabVIEWCLI ExecuteBuildSpec in headless mode."
-        Write-Host "Project path: $ProjectPath"
-        Write-Host "Build specification: $BuildSpecName"
-        Write-Host "Target name: $TargetName"
-        Write-Host "Expected output: $buildOutputPath"
+        Write-Output "Running LabVIEWCLI ExecuteBuildSpec in headless mode."
+        Write-Output "Project path: $ProjectPath"
+        Write-Output "Build specification: $BuildSpecName"
+        Write-Output "Target name: $TargetName"
+        Write-Output "Expected output: $buildOutputPath"
 
         $buildSpec = Invoke-LabVIEWCliOperation -OperationName 'ExecuteBuildSpec' -Arguments @(
             '-LogToConsole', 'TRUE',
@@ -265,11 +265,11 @@ try {
         }
 
         $buildOutput = Get-Item -LiteralPath $buildOutputPath
-        Write-Host ("Build specification completed: {0} ({1} bytes)" -f $buildOutput.FullName, $buildOutput.Length)
+        Write-Output ("Build specification completed: {0} ({1} bytes)" -f $buildOutput.FullName, $buildOutput.Length)
     } catch {
         $buildSpecError = $_
     } finally {
-        Write-Host "Reverting no-LabVIEW dev mode after build-spec execution."
+        Write-Output "Reverting no-LabVIEW dev mode after build-spec execution."
         & $revertDevModeScript `
             -LabVIEWVersion $labviewYear `
             -SupportedBitness 64 `

--- a/docs/labview-container-parity.md
+++ b/docs/labview-container-parity.md
@@ -23,8 +23,9 @@ Build-spec parity is enabled by default and is a blocking check.
 
 - Manual input: `run_build_spec` (`true` or `false`, default `true`).
 - Gate behavior:
-  - `pull_request`: runs `ExecuteBuildSpec` for `Editor Packed Library` by default.
-  - `workflow_dispatch`: runs `ExecuteBuildSpec` by default; set `run_build_spec=false` only when explicitly skipping build-spec diagnostics.
+  - `pull_request`: Linux parity runs by default; Windows parity is intentionally skipped to keep PR feedback fast for collaborators.
+  - `push` to `develop`: both Linux and Windows parity run, including `ExecuteBuildSpec`.
+  - `workflow_dispatch`: both Linux and Windows parity run by default; set `run_build_spec=false` only when explicitly skipping build-spec diagnostics.
 - Hard-fail policy: when build-spec is enabled (default), Linux and Windows lanes must both pass.
 
 Build-spec environment contract used by container scripts:

--- a/docs/labview-container-parity.md
+++ b/docs/labview-container-parity.md
@@ -33,12 +33,14 @@ Build-spec environment contract used by container scripts:
 - `CONTAINER_PARITY_BUILD_SPEC_NAME`
 - `CONTAINER_PARITY_TARGET_NAME`
 - `CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH`
+- `CONTAINER_PARITY_ENABLE_DEVMODE` (optional; default disabled)
 
 Default build-spec settings:
 
 - Build spec name: `Editor Packed Library`
 - Target name: `My Computer`
 - Output path: `resource/plugins/lv_icon.lvlibp`
+- Dev-mode install mutation: disabled by default in parity runs to avoid removing required source items during build.
 
 ## Artifacts and Logs
 

--- a/docs/labview-container-parity.md
+++ b/docs/labview-container-parity.md
@@ -40,6 +40,7 @@ Default build-spec settings:
 - Build spec name: `Editor Packed Library`
 - Target name: `My Computer`
 - Output path: `resource/plugins/lv_icon.lvlibp`
+- Source sync before build-spec: container scripts copy `resource/plugins` Icon Editor sources and `vi.lib/LabVIEW Icon API` from the mounted workspace into the container LabVIEW install so `<resource>`/`<vilib>` project references resolve in headless builds.
 - Dev-mode install mutation: disabled by default in parity runs to avoid removing required source items during build.
 
 ## Artifacts and Logs

--- a/docs/labview-container-parity.md
+++ b/docs/labview-container-parity.md
@@ -17,15 +17,15 @@ This repository includes a hosted parity workflow at `.github/workflows/labview-
 
 The workflow defaults to release tag `2026q1`, and supports override via `workflow_dispatch` input `lv_release`.
 
-## Manual-Only Build-Spec Phase
+## Default Build-Spec Behavior
 
-Build-spec parity is manual-only in this phase and does not run on pull requests by default.
+Build-spec parity is enabled by default and is a blocking check.
 
-- Manual input: `run_build_spec` (`true` or `false`, default `false`).
+- Manual input: `run_build_spec` (`true` or `false`, default `true`).
 - Gate behavior:
-  - `workflow_dispatch` with `run_build_spec=true`: runs `ExecuteBuildSpec` for `Editor Packed Library`.
-  - `pull_request`: forces build-spec off and runs only MassCompile parity.
-- Hard-fail policy: when build-spec is enabled, Linux and Windows lanes must both pass.
+  - `pull_request`: runs `ExecuteBuildSpec` for `Editor Packed Library` by default.
+  - `workflow_dispatch`: runs `ExecuteBuildSpec` by default; set `run_build_spec=false` only when explicitly skipping build-spec diagnostics.
+- Hard-fail policy: when build-spec is enabled (default), Linux and Windows lanes must both pass.
 
 Build-spec environment contract used by container scripts:
 
@@ -58,9 +58,9 @@ Manual run:
 
 1. Open Actions and run **LabVIEW Container Parity**.
 2. Optionally set `lv_release` (for example `2026q1`).
-3. Set `run_build_spec=true` only when you want build-spec parity checks.
+3. Leave `run_build_spec=true` (default) to keep packed-library parity enabled; set it to `false` only when intentionally bypassing build-spec execution.
 
 PR run:
 
 - Triggered automatically when parity workflow/script files, `.lvversion`, `lv_icon_editor.lvproj`, or `Test/Templates` change.
-- PR runs execute MassCompile parity only.
+- PR runs execute both MassCompile parity and packed-library build-spec parity by default.

--- a/docs/labview-container-parity.md
+++ b/docs/labview-container-parity.md
@@ -12,10 +12,45 @@ This repository includes a hosted parity workflow at `.github/workflows/labview-
 
 - Linux container image: `nationalinstruments/labview:<release>-linux`
 - Windows container image: `nationalinstruments/labview:<release>-windows`
-- Operation: `LabVIEWCLI MassCompile` on `Test/Templates`
+- Always-on operation: `LabVIEWCLI MassCompile` on `Test/Templates`
 - Default exclusion: `Polymorphic Template.vi` is excluded from parity MassCompile via `CONTAINER_PARITY_EXCLUDE_FILES` because it is a known headless bad VI in container runs.
 
 The workflow defaults to release tag `2026q1`, and supports override via `workflow_dispatch` input `lv_release`.
+
+## Manual-Only Build-Spec Phase
+
+Build-spec parity is manual-only in this phase and does not run on pull requests by default.
+
+- Manual input: `run_build_spec` (`true` or `false`, default `false`).
+- Gate behavior:
+  - `workflow_dispatch` with `run_build_spec=true`: runs `ExecuteBuildSpec` for `Editor Packed Library`.
+  - `pull_request`: forces build-spec off and runs only MassCompile parity.
+- Hard-fail policy: when build-spec is enabled, Linux and Windows lanes must both pass.
+
+Build-spec environment contract used by container scripts:
+
+- `CONTAINER_PARITY_BUILD_SPEC`
+- `CONTAINER_PARITY_BUILD_SPEC_NAME`
+- `CONTAINER_PARITY_TARGET_NAME`
+- `CONTAINER_PARITY_BUILD_OUTPUT_RELATIVE_PATH`
+
+Default build-spec settings:
+
+- Build spec name: `Editor Packed Library`
+- Target name: `My Computer`
+- Output path: `resource/plugins/lv_icon.lvlibp`
+
+## Artifacts and Logs
+
+Build-spec outputs in this phase are diagnostic-only artifacts (not release inputs):
+
+- `labview-container-editor-packed-library-windows`
+- `labview-container-editor-packed-library-linux`
+
+LabVIEWCLI operation logs are captured and uploaded per OS as diagnostics:
+
+- `labview-container-logs-windows`
+- `labview-container-logs-linux`
 
 ## How To Run
 
@@ -23,12 +58,9 @@ Manual run:
 
 1. Open Actions and run **LabVIEW Container Parity**.
 2. Optionally set `lv_release` (for example `2026q1`).
+3. Set `run_build_spec=true` only when you want build-spec parity checks.
 
 PR run:
 
 - Triggered automatically when parity workflow/script files, `.lvversion`, `lv_icon_editor.lvproj`, or `Test/Templates` change.
-
-## Next Extension Candidates
-
-- Add a Linux/Windows VI Analyzer parity step once a stable repo-owned `.viancfg` is available.
-- Add a separate VIPM CLI lane on Linux for dependency-install parity, while keeping LabVIEWCLI as the primary execution surface.
+- PR runs execute MassCompile parity only.


### PR DESCRIPTION
## Summary
- extend LabVIEW container parity workflow so Docker also builds the LabVIEW project build specification from `lv_icon_editor.lvproj`
- keep MassCompile parity behavior and add an optional ExecuteBuildSpec path in the Windows container script
- verify generated `resource/plugins/lv_icon.lvlibp` and upload it as a workflow artifact

## Why
- shifts part of build workload from self-hosted runners to containerized CI
- provides early feedback that the project build spec remains executable in container parity lanes

## Changes
- `.github/workflows/labview-container-parity.yml`
  - enable build-spec execution in Windows container run
  - add post-run artifact verification step
  - upload built `lv_icon.lvlibp` artifact
- `Tooling/container-parity/runlabview-windows.ps1`
  - add build-spec gate and parameters/env handling
  - run `LabVIEWCLI -OperationName ExecuteBuildSpec` against `lv_icon_editor.lvproj`
  - assert expected output exists and report artifact info

## Validation
- `Invoke-ScriptAnalyzer -Path Tooling/container-parity/runlabview-windows.ps1 -Severity Error,Warning` (no errors; existing Write-Host warnings only)
- PowerShell parser check for `runlabview-windows.ps1`

## Notes
- no changes to self-hosted runner workflows
- default build target/spec names are `My Computer` and `Editor Packed Library`
