### PR TITLE
ci: enforce Linux VI Package gate for PRs to develop

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -31,6 +31,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
       - release/*
       - feature/*
       - hotfix/*
@@ -906,8 +907,98 @@ jobs:
           close_labview: 'true'
           close_bitness: 64
 
+  build-vip-linux:
+    name: Build VI Package (Linux)
+    needs: [run-metadata, version-gate, build-ppl-x86, version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate release notes
+        shell: pwsh
+        run: |
+          & ".github/actions/generate-release-notes/GenerateReleaseNotes.ps1" -OutputPath "Tooling/deployment/release_notes.md"
+      - name: Download packed library artifact (32-bit)
+        uses: actions/download-artifact@v4
+        with:
+          name: lv_icon_x86.lvlibp
+          path: ${{ github.workspace }}/resource/plugins
+      - name: Download packed library artifact (64-bit)
+        uses: actions/download-artifact@v4
+        with:
+          name: lv_icon_x64.lvlibp
+          path: ${{ github.workspace }}/resource/plugins
+      - name: Pull LabVIEW Linux image
+        shell: bash
+        run: |
+          set -euo pipefail
+          LV_RELEASE="2026q1"
+          IMAGE="nationalinstruments/labview:${LV_RELEASE}-linux"
+          echo "Using image: ${IMAGE}"
+          docker pull "${IMAGE}"
+          echo "LV_RELEASE=${LV_RELEASE}" >> "$GITHUB_ENV"
+          echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+      - name: Build VI Package in Linux container
+        shell: bash
+        run: |
+          set -euo pipefail
+          VIP_VERSION="${{ needs.version.outputs.MAJOR }}.${{ needs.version.outputs.MINOR }}.${{ needs.version.outputs.PATCH }}.${{ needs.version.outputs.BUILD }}"
+          LV_YEAR="${LV_RELEASE:0:4}"
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -e WORKSPACE_ROOT=/workspace \
+            -e "LV_RELEASE=${LV_RELEASE}" \
+            -e "LV_YEAR=${LV_YEAR}" \
+            -e "CONTAINER_VIPB_PATH=Tooling/deployment/NI Icon editor.vipb" \
+            -e "CONTAINER_VIP_VERSION=${VIP_VERSION}" \
+            -e "CONTAINER_RELEASE_NOTES_PATH=Tooling/deployment/release_notes.md" \
+            -e "CONTAINER_VIPM_TIMEOUT_SECONDS=900" \
+            "${IMAGE}" \
+            bash -lc "chmod +x /workspace/Tooling/container-parity/build-vip-linux.sh && /workspace/Tooling/container-parity/build-vip-linux.sh"
+      - name: Locate built VI package
+        id: locate-vip-linux
+        shell: bash
+        run: |
+          set -euo pipefail
+          VIP_DIR="${GITHUB_WORKSPACE}/builds/VI Package"
+          if [[ ! -d "${VIP_DIR}" ]]; then
+            echo "VI Package directory not found: ${VIP_DIR}" >&2
+            exit 1
+          fi
+          latest_line="$(
+            find "${VIP_DIR}" -type f -name '*.vip' -printf '%T@|%p\n' \
+              | sort -nr \
+              | head -n 1
+          )"
+          if [[ -z "${latest_line}" ]]; then
+            echo "No .vip file found under ${VIP_DIR}" >&2
+            exit 1
+          fi
+          vip_path="${latest_line#*|}"
+          version="${{ needs.version.outputs.MAJOR }}.${{ needs.version.outputs.MINOR }}.${{ needs.version.outputs.PATCH }}.${{ needs.version.outputs.BUILD }}"
+          echo "Selected .vip: ${vip_path}"
+          echo "vip_path=${vip_path}" >> "$GITHUB_OUTPUT"
+          echo "vip_name=$(basename "${vip_path}")" >> "$GITHUB_OUTPUT"
+          echo "vip_artifact=vip-linux-${version}" >> "$GITHUB_OUTPUT"
+      - name: Upload VI Package (Linux)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.locate-vip-linux.outputs.vip_artifact }}
+          path: ${{ steps.locate-vip-linux.outputs.vip_path }}
+          if-no-files-found: error
+      - name: Upload g-cli logs (Linux VIP)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gcli-logs-linux-vip
+          path: ${{ github.workspace }}/builds/logs
+          if-no-files-found: warn
+
   build-vip:
     name: Build VI Package
+    if: ${{ github.event_name != 'pull_request' }}
     # Chain after 32-bit PPL build (which depends on 64-bit PPL build).
     needs: [run-metadata, version-gate, build-ppl-x86, version]
     runs-on: ${{ vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}
@@ -1169,6 +1260,7 @@ jobs:
       - unit-tests
       - build-ppl-x64
       - build-ppl-x86
+      - build-vip-linux
       - build-vip
       - version
       - conformance-full
@@ -1196,10 +1288,13 @@ jobs:
             'unit-tests',
             'build-ppl-x64',
             'build-ppl-x86',
-            'build-vip',
+            'build-vip-linux',
             'version',
             'conformance-full'
           )
+          if ('${{ github.event_name }}' -ne 'pull_request') {
+            $required += 'build-vip'
+          }
           $needs = ConvertFrom-Json -InputObject '${{ toJson(needs) }}'
           $needsProps = $needs.PSObject.Properties
           $failed = @()

--- a/Tooling/container-parity/build-vip-linux.sh
+++ b/Tooling/container-parity/build-vip-linux.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKSPACE_ROOT="${WORKSPACE_ROOT:-/workspace}"
+LV_RELEASE="${LV_RELEASE:-2026q1}"
+LV_YEAR="${LV_YEAR:-${LV_RELEASE:0:4}}"
+CONTAINER_VIPB_PATH="${CONTAINER_VIPB_PATH:-Tooling/deployment/NI Icon editor.vipb}"
+CONTAINER_VIP_VERSION="${CONTAINER_VIP_VERSION:-}"
+CONTAINER_RELEASE_NOTES_PATH="${CONTAINER_RELEASE_NOTES_PATH:-Tooling/deployment/release_notes.md}"
+CONTAINER_VIPM_TIMEOUT_SECONDS="${CONTAINER_VIPM_TIMEOUT_SECONDS:-900}"
+
+LOG_DIR="${WORKSPACE_ROOT}/builds/logs"
+GCLI_LOG="${LOG_DIR}/gcli-build-linux.log"
+VIP_OUTPUT_DIR="${WORKSPACE_ROOT}/builds/VI Package"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+resolve_workspace_path() {
+  local path_value="$1"
+  if [[ "$path_value" = /* ]]; then
+    printf '%s\n' "$path_value"
+  else
+    printf '%s\n' "${WORKSPACE_ROOT}/${path_value}"
+  fi
+}
+
+require_file() {
+  local path_value="$1"
+  local label="$2"
+  if [[ ! -f "$path_value" ]]; then
+    fail "$label not found: $path_value"
+  fi
+}
+
+if [[ -z "$CONTAINER_VIP_VERSION" ]]; then
+  fail "CONTAINER_VIP_VERSION is required (expected format: major.minor.patch.build)."
+fi
+
+if [[ ! "$LV_YEAR" =~ ^[0-9]{4}$ ]]; then
+  fail "LV_YEAR must be a 4-digit year. Resolved value: '$LV_YEAR'"
+fi
+
+if ! command -v g-cli >/dev/null 2>&1; then
+  fail "g-cli is not available on PATH in this container."
+fi
+
+VIPB_PATH="$(resolve_workspace_path "$CONTAINER_VIPB_PATH")"
+RELEASE_NOTES_PATH="$(resolve_workspace_path "$CONTAINER_RELEASE_NOTES_PATH")"
+PPL_X86_PATH="${WORKSPACE_ROOT}/resource/plugins/lv_icon_x86.lvlibp"
+PPL_X64_PATH="${WORKSPACE_ROOT}/resource/plugins/lv_icon_x64.lvlibp"
+
+require_file "$VIPB_PATH" "VIPB file"
+require_file "$RELEASE_NOTES_PATH" "Release notes file"
+require_file "$PPL_X86_PATH" "32-bit packed library"
+require_file "$PPL_X64_PATH" "64-bit packed library"
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$VIP_OUTPUT_DIR"
+
+build_started_epoch="$(date +%s)"
+
+gcli_args=(
+  --lv-ver "$LV_YEAR"
+  --arch 64
+  --connect-timeout 120000
+  --kill
+  --kill-timeout 20000
+  --verbose
+  vipb --
+  --buildspec "$VIPB_PATH"
+  -v "$CONTAINER_VIP_VERSION"
+  --release-notes "$RELEASE_NOTES_PATH"
+  --timeout "$CONTAINER_VIPM_TIMEOUT_SECONDS"
+)
+
+echo "Building VI Package on Linux container."
+echo "Workspace root: $WORKSPACE_ROOT"
+echo "LabVIEW release/year: $LV_RELEASE / $LV_YEAR"
+echo "VIPB path: $VIPB_PATH"
+echo "Release notes path: $RELEASE_NOTES_PATH"
+echo "Required PPLs:"
+echo "  - $PPL_X86_PATH"
+echo "  - $PPL_X64_PATH"
+echo "Log path: $GCLI_LOG"
+
+printf 'Executing: g-cli'
+for arg in "${gcli_args[@]}"; do
+  printf ' %q' "$arg"
+done
+printf '\n'
+
+set +e
+g-cli "${gcli_args[@]}" 2>&1 | tee "$GCLI_LOG"
+gcli_exit="${PIPESTATUS[0]}"
+set -e
+
+if [[ "$gcli_exit" -ne 0 ]]; then
+  fail "g-cli VIP build failed with exit code $gcli_exit. See $GCLI_LOG"
+fi
+
+latest_vip_line="$(
+  find "$VIP_OUTPUT_DIR" -type f -name '*.vip' -printf '%T@|%p\n' 2>/dev/null \
+    | sort -nr \
+    | head -n 1
+)"
+
+if [[ -z "$latest_vip_line" ]]; then
+  fail "No .vip output was found under $VIP_OUTPUT_DIR"
+fi
+
+latest_vip_path="${latest_vip_line#*|}"
+if [[ ! -f "$latest_vip_path" ]]; then
+  fail "Resolved VIP output path does not exist: $latest_vip_path"
+fi
+
+latest_vip_epoch="$(stat -c %Y "$latest_vip_path")"
+if [[ "$latest_vip_epoch" -lt "$build_started_epoch" ]]; then
+  fail "No newly generated .vip file detected after build start. Latest file: $latest_vip_path"
+fi
+
+latest_vip_size="$(wc -c < "$latest_vip_path" | xargs)"
+echo "VI Package build succeeded: $latest_vip_path ($latest_vip_size bytes)"
+echo "VIP_PATH=$latest_vip_path"

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -1,6 +1,6 @@
 # Local CI/CD Workflows
 
-**Last updated:** 2026-02-07
+**Last updated:** 2026-02-08
 
 Quick link: `.github/workflows/runner-cli.yml` (Runner CLI consolidated workflow).
 
@@ -56,7 +56,9 @@ Automating your Icon Editor builds and tests:
      - A concurrency group cancels any previous run on the same branch, ensuring only the latest pipeline execution continues.
 
 5. **Build VI Package**
-   - Produces `.vip` artifacts automatically. By default, the workflow populates the **“Company Name”** with `github.repository_owner` and the **“Author Name”** with `github.event.repository.name`, so each build is branded with your GitHub account and repository.
+   - Produces `.vip` artifacts automatically. On PR and `develop` pushes, packaging runs in Linux (`build-vip-linux`) using the `nationalinstruments/labview:2026q1-linux` container and consumes both PPL artifacts (`lv_icon_x86.lvlibp`, `lv_icon_x64.lvlibp`).
+   - The existing Windows `build-vip` job is retained as the release-authoritative path for non-PR events (`push`/`workflow_dispatch`).
+   - By default, the workflow populates the **“Company Name”** with `github.repository_owner` and the **“Author Name”** with `github.event.repository.name`, so each build is branded with your GitHub account and repository.
    - To use different branding, edit the **“Generate display information JSON”** step in [`.github/workflows/ci-composite.yml`](../.github/workflows/ci-composite.yml) and supply custom values for these fields.
    - Uses **label-based** version bumping (major/minor/patch) on pull requests.
    - Generates `Tooling/deployment/release_notes.md` summarizing recent commits. Use this file to draft changelogs or release notes.
@@ -116,11 +118,22 @@ The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks 
 - **missing-in-project-check** – verifies every source file is referenced in the `.lvproj`.
 - **test** – runs LabVIEW unit tests on Windows in LabVIEW 2021 (32- and 64-bit).
 - **build-ppl** – uses a matrix to build 32-bit and 64-bit packed libraries, then uses the `rename-file` action to append the bitness to each library’s filename.
-- **build-vi-package** – packages the final VI Package using the built libraries and version information. In `ci-composite.yml` this job passes `supported_bitness: 64`, so it produces only a 64-bit `.vip`.
+- **build-vip-linux** – packages the VI Package on `ubuntu-latest` by running `Tooling/container-parity/build-vip-linux.sh` inside `nationalinstruments/labview:2026q1-linux`. This job requires both PPL artifacts (`lv_icon_x86.lvlibp`, `lv_icon_x64.lvlibp`).
+- **build-vip** – existing Windows/self-hosted VI Package packaging path. It is retained for non-PR release-authoritative builds and is skipped for pull requests.
 
-Both `build-ppl` and `build-vi-package` run a `close-labview` step after their build actions finish but before any steps that rename files or upload artifacts, so it isn't the job's final step.
+Windows self-hosted build jobs (`build-ppl-*` and `build-vip`) run a `close-labview` step after their build actions finish but before any steps that rename files or upload artifacts, so it is not the final step.
 
 The `build-ppl` job uses a matrix to produce both bitnesses rather than distinct jobs.
+
+#### Event matrix (VIP packaging)
+
+| Event | `build-vip-linux` | `build-vip` (Windows) |
+| --- | --- | --- |
+| `pull_request` | Runs (required) | Skipped |
+| `push` to `develop` | Runs (required) | Runs |
+| `workflow_dispatch` | Runs (required) | Runs |
+
+Branch protection recommendation: require `CI Pipeline (Composite) / Build VI Package (Linux)` for pull requests, and keep Docker parity checks required as configured.
 
 *(The **Run Unit Tests** workflow has been consolidated into the main CI process.)*
 

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -94,7 +94,7 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 
 ### 3.1 How the Action Is Triggered
 The `build-vi-package` directory defines a **composite action**. It does not listen for events on its own; instead, the CI workflow in [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) invokes it.
-That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. Early jobs like `run-metadata`, `version-gate`, and `changes` run on GitHub-hosted `ubuntu-latest`. Subsequent jobs that require LabVIEW—`apply-deps`, `version`, `test`, `build-ppl`, and `build-vi-package`—execute on a self-hosted Windows runner (`self-hosted-windows-lv-ie`). Only Windows-specific jobs (e.g., `test`, `build-ppl`, `build-vi-package`) require the self-hosted runner. Linux support is considered a future or custom expansion: you would need to extend the matrix and provide a corresponding runner label (for example, `self-hosted-linux-lv`). The branch filters for push/PR triggers live in `ci-composite.yml` (see `on.push.branches` and `on.pull_request.branches`).
+That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. Early jobs like `run-metadata`, `version-gate`, and `changes` run on GitHub-hosted `ubuntu-latest`. Windows self-hosted jobs still handle LabVIEW testing and PPL generation (`apply-deps`, `version`, `test`, `build-ppl`). In phase 1, VI Package packaging is split by event: `build-vip-linux` runs on hosted Linux (containerized LabVIEW, `2026q1`) for pull requests and `develop` pushes, while the existing Windows `build-vip` path is retained for non-PR release-authoritative runs (`push` and `workflow_dispatch`). The branch filters for push/PR triggers live in `ci-composite.yml` (see `on.push.branches` and `on.pull_request.branches`).
 
 ### 3.2 Configurable Inputs / Parameters
 `ci-composite.yml` calls this action and provides all required inputs automatically. When invoking
@@ -156,11 +156,13 @@ components remain unchanged and only the build number increases.
 
 5. **Build the Icon Editor VI Package**
    - Uses the `build-lvlibp` action to compile the packed libraries.
+   - Downloads both packed libraries (`lv_icon_x86.lvlibp`, `lv_icon_x64.lvlibp`) as required inputs for packaging.
    - Generates a display-information JSON blob that now includes:
      - semantic-version components (`major`, `minor`, `patch`, `build`),
      - repository-derived metadata (company/author names, homepage URL, and description), and
      - the markdown release notes captured from `Tooling/deployment/release_notes.md`.
-   - Runs the `build-vi-package` action to generate the final `.vip` file with those values embedded.
+   - For PR and `develop` push validation, runs Linux packaging inside `nationalinstruments/labview:2026q1-linux` via `Tooling/container-parity/build-vip-linux.sh`.
+   - For non-PR release-authoritative runs, keeps the Windows `build-vip` packaging path.
 
 6. **Capture & Upload Artifacts**
    - Uploads the generated `.vip` as an ephemeral artifact for the current Actions run.
@@ -238,7 +240,7 @@ components remain unchanged and only the build number increases.
 ### 7.2 Direct Push to Main or Develop
 - **Scenario**: You quickly push a fix to `develop` without opening a PR.
 - **Action**: With no pull request labels available, major/minor/patch remain unchanged while the build number increments automatically.
-- **Result**: The version might progress from `v1.2.3-build46` to `v1.2.3-build47`.
+- **Result**: The version might progress from `v1.2.3-build46` to `v1.2.3-build47`, and the pipeline runs Linux VI Package packaging plus the non-PR Windows packaging path.
 
 ### 7.3 Working on a Release Branch
 - **Scenario**: You branch off `release-rc/1.2`.


### PR DESCRIPTION
## Summary
- add develop to ci-composite.yml pull_request trigger scope
- add Linux-hosted VI Package build job (uild-vip-linux) using 
ationalinstruments/labview:2026q1-linux
- keep Windows uild-vip as non-PR release-authoritative path
- update pipeline contract to require uild-vip-linux on all events and uild-vip only on non-PR events
- update CI docs for phase-1 Linux VIP packaging

## Validation
- ash -n Tooling/container-parity/build-vip-linux.sh
- git diff --check

## Follow-up
- add required status check Build VI Package (Linux) to the develop ruleset (keep Parity (Linux Container))