### PR TITLE
Enforce repo-agnostic issue/discussion routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     about: "Let us help you if you hit a roadblock!"
 
   - name: 📖 Read the Docs
-    url: https://github.com/ni/labview-icon-editor#labview-icon-editor
+    url: https://ni.github.io/labview-icon-editor/
     about: "Check the documentation for common questions before opening an issue."
 
 issue_templates:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        **IMPORTANT:** Start the discussion on our Discord channel [#icon-editor-dev](https://discord.gg/q4d3ggrFVA) or create a [GitHub Discussion](https://github.com/ni/labview-icon-editor/discussions/new/choose) **only** if you are requesting changes to the shipping version of the Icon Editor.
+        **IMPORTANT:** Start the discussion on our Discord channel [#icon-editor-dev](https://discord.gg/q4d3ggrFVA) or create a GitHub Discussion in this repository (Discussions tab) **only** if you are requesting changes to the shipping version of the Icon Editor.
 
   - type: textarea
     attributes:

--- a/.github/workflows/repo-agnostic-issue-routing.yml
+++ b/.github/workflows/repo-agnostic-issue-routing.yml
@@ -1,0 +1,24 @@
+name: Repo-Agnostic Issue Routing
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Repo-Agnostic Issue/Discussion Routing
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate repo-agnostic issue/discussion routing
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\Tooling\Test-RepoAgnosticIssueRouting.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,27 +13,39 @@ This repository uses LabVIEW, g-cli, and PowerShell tooling. Follow the steps be
 - Open a PowerShell terminal at the repo root.
 - Confirm `g-cli` is available:
   - `g-cli --version`
-- Pin `gh` to the fork for this shell:
-  - `$env:GH_REPO='svelderrainruiz/labview-icon-editor'`
+- Resolve the current repository for `gh` commands:
+  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  - `GH_REPO` is an optional override.
 - If you need to open a PR from the current branch, use `gh`:
-  - Default template: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
-  - Draft PR: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md --draft`
+  - Default template: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  - Draft PR: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md --draft`
+
+## Repo-Agnostic Issue/Discussion Policy
+- Issue and discussion actions operate on the repository currently being worked in.
+- Use this command before issue/PR/workflow operations:
+  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+- Examples:
+  - Create issue: `gh issue create --repo $repo --template "Bug Report"`
+  - Create PR: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  - List issues: `gh issue list --repo $repo --limit 50`
+  - Run workflow: `gh workflow run labels-sync.yml --repo $repo -f dry_run=true -f include_aliases=true`
 
 ## GitHub Templates and Labels
 - Use issue templates with `gh` (preferred):
-  - Bug report: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Bug Report"`
-  - Feature request: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Feature request"`
+  - Bug report: `gh issue create --repo $repo --template "Bug Report"`
+  - Feature request: `gh issue create --repo $repo --template "Feature request"`
 - Use PR templates with `gh`:
-  - Generic: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
-  - Bug fix: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
-  - Feature addition: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
-  - Documentation update: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
-  - Infrastructure change: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
+  - Generic: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  - Bug fix: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
+  - Feature addition: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
+  - Documentation update: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
+  - Infrastructure change: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
 - Web fallback links:
-  - Issues: `https://github.com/svelderrainruiz/labview-icon-editor/issues/new/choose`
-  - Bug form: `https://github.com/svelderrainruiz/labview-icon-editor/issues/new?template=bug_report.yml`
-  - Feature form: `https://github.com/svelderrainruiz/labview-icon-editor/issues/new?template=feature_request.yml`
-  - PR page: `https://github.com/svelderrainruiz/labview-icon-editor/compare`
+  - Resolve repository URL: `$repoUrl = gh repo view --repo $repo --json url --jq .url`
+  - Issues: `"$repoUrl/issues/new/choose"`
+  - Bug form: `"$repoUrl/issues/new?template=bug_report.yml"`
+  - Feature form: `"$repoUrl/issues/new?template=feature_request.yml"`
+  - PR page: `"$repoUrl/compare"`
 
 Label policy:
 - Canonical release labels:
@@ -50,8 +62,8 @@ Label policy:
   - `bug` -> `Issue group: Bug`
   - `enhancement` -> `Type: Enhancement`
 - Sync labels from contract (manual workflow):
-  - Dry run: `gh workflow run labels-sync.yml --repo svelderrainruiz/labview-icon-editor -f dry_run=true -f include_aliases=true`
-  - Apply: `gh workflow run labels-sync.yml --repo svelderrainruiz/labview-icon-editor -f dry_run=false -f include_aliases=true`
+  - Dry run: `gh workflow run labels-sync.yml --repo $repo -f dry_run=true -f include_aliases=true`
+  - Apply: `gh workflow run labels-sync.yml --repo $repo -f dry_run=false -f include_aliases=true`
 
 Stale issue policy:
 - Workflow: `.github/workflows/stale-issues.yml`
@@ -76,17 +88,17 @@ Stale issue policy:
       '-label:"Issue group: Added to agenda"'
       '-label:"good first issue"'
     ) -join ' '
-    gh issue list --repo svelderrainruiz/labview-icon-editor --state open --search $query --limit 200
+    gh issue list --repo $repo --state open --search $query --limit 200
     ```
 
 Metadata quick-checks:
 - Unlabeled PRs (no normalized release label):
-  - `gh pr list --repo svelderrainruiz/labview-icon-editor --state open --search "-label:'Version Increment: Major' -label:'Version Increment: Minor' -label:'Version Increment: Patch' -label:major -label:minor -label:patch"`
+  - `gh pr list --repo $repo --state open --search "-label:'Version Increment: Major' -label:'Version Increment: Minor' -label:'Version Increment: Patch' -label:major -label:minor -label:patch"`
 - Unlabeled issues:
-  - `gh issue list --repo svelderrainruiz/labview-icon-editor --state open --search "no:label" --limit 200`
+  - `gh issue list --repo $repo --state open --search "no:label" --limit 200`
 - Alias-only issue types:
   - ```
-    $items = gh issue list --repo svelderrainruiz/labview-icon-editor --state open --limit 200 --json number,title,labels | ConvertFrom-Json
+    $items = gh issue list --repo $repo --state open --limit 200 --json number,title,labels | ConvertFrom-Json
     $items | Where-Object {
       ($_.labels.name -contains 'enhancement' -or $_.labels.name -contains 'bug') -and
       -not ($_.labels.name -contains 'Type: Enhancement' -or $_.labels.name -contains 'Issue group: Bug')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,12 @@ This repo follows a typical fork-and-pull model on [GitHub](https://github.com/n
 
 We welcome both code and non-code contributions. Here are some ways to help:
 
-- 🐛 **Bug Reports:** We can’t catch every issue. If you find a bug, first search the [issues list](https://github.com/ni/labview-icon-editor/issues) to see if it’s already reported. If not, [open a new issue](https://github.com/ni/labview-icon-editor/issues/new/choose) describing the problem so we can address it.
-- 💬 **Q&A and Feedback:** Participate in discussions! If you have an idea for a new feature or changes, start a conversation on our [GitHub Discussions board](https://github.com/ni/labview-icon-editor/discussions/new?category=ideas) or join the community on [Discord](https://discord.gg/q4d3ggrFVA). Your feedback on planned features (see the [New Features discussions](https://github.com/ni/labview-icon-editor/discussions/categories/new-features)) is valuable.
-- 🎬 **Tackle “Good First Issues”:** Check out issues labeled [**Good first issue**](https://github.com/ni/labview-icon-editor/labels/good%20first%20issue). These are entry-level tasks that are great for new contributors. You can comment on an issue to be assigned and start working on it.
+For command examples below, resolve your current repository once:
+- `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+
+- 🐛 **Bug Reports:** We can’t catch every issue. If you find a bug, first search issues in the current repository (`gh issue list --repo $repo --state open --limit 200`). If not reported, open a new issue with the bug template (`gh issue create --repo $repo --template "Bug Report"`).
+- 💬 **Q&A and Feedback:** Participate in discussions. If you have an idea for a new feature or changes, open Discussions in the current repository (Discussions tab) or join the community on [Discord](https://discord.gg/q4d3ggrFVA).
+- 🎬 **Tackle “Good First Issues”:** Check out issues labeled **good first issue** in the current repository (`gh issue list --repo $repo --label "good first issue"`). These are entry-level tasks that are great for new contributors.
 - ✏️ **Improve Documentation:** Contributing to docs is just as important as code. If you spot outdated or unclear documentation, feel free to propose changes. Our documentation is in this repo and the companion [documentation site](https://ni.github.io/labview-icon-editor/) (you can use the “Edit this page” link on the docs site).
 
 All interactions should be respectful and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
@@ -27,7 +30,7 @@ All interactions should be respectful and follow our [Code of Conduct](CODE_OF_C
 4. **Follow Workflow:** We use a branching strategy where official development happens on feature branches and merges go first into `develop`, then through pre-release branches (e.g. `release-alpha`, `release-beta`, `release-rc`) before merging into `main` for the final release. External contributors will typically collaborate on feature branches created by NI maintainers (once an issue is approved and labeled "Open to contribution"). If you’re working on a fork, you can still develop on your own branch and submit a PR to the appropriate branch in the main repo.
 5. **Write and Test Code:** Make your changes in LabVIEW. If you’ve applied the dependencies and run the `Tooling\Prepare LV to Use Icon Editor Source.vi` (or used the PowerShell scripts to set development mode), you can open `lv_icon_editor.lvproj` and begin editing the VIs. We encourage writing or updating tests if applicable (see `Test` folder or ask maintainers how to run tests – we have a CLI script `RunUnitTests.ps1` that uses the included testing framework).
 6. **Commit Guidelines:** Commit messages should be clear. Please **sign off** your commits (this adds a `Signed-off-by:` line to your commit message, indicating you agree to the Developer Certificate of Origin). If using Git from command line, `git commit -s` will do this. Ensure each commit builds and passes tests.
-7. **Submit a Pull Request:** Push your branch to your fork and open a PR against this repository. In the PR description, clearly explain the purpose of the change, what was changed, and reference any issue it addresses (e.g., “Closes #123”). Include any relevant testing steps or screenshots. For this fork, pin `gh` commands to `--repo svelderrainruiz/labview-icon-editor`. You can use the default PR template with `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md` or a specialized template under `.github/PULL_REQUEST_TEMPLATE/`. A good PR description has:
+7. **Submit a Pull Request:** Push your branch to your fork and open a PR against this repository. In the PR description, clearly explain the purpose of the change, what was changed, and reference any issue it addresses (e.g., “Closes #123”). Include any relevant testing steps or screenshots. Use the default PR template with `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md` or a specialized template under `.github/PULL_REQUEST_TEMPLATE/`. A good PR description has:
    - **Purpose** – Why is this change being made?
    - **Changes Made** – What did you do? 
    - **Issue Reference** – Link the issue number if one exists.
@@ -42,7 +45,7 @@ All interactions should be respectful and follow our [Code of Conduct](CODE_OF_C
 
 ## Feature Requests & Enhancements
 
-If you have an idea for a new feature or a significant change, please start by creating a discussion in the [**New Features** category](https://github.com/ni/labview-icon-editor/discussions/categories/new-features) rather than directly opening an issue or PR. In your discussion post, describe the problem your idea would solve or the use-case it would enable. The core team and community can then provide feedback and determine if it aligns with the project’s goals. 
+If you have an idea for a new feature or a significant change, start with a discussion in the current repository (Discussions tab) rather than directly opening an issue or PR. In your discussion post, describe the problem your idea would solve or the use-case it would enable. The core team and community can then provide feedback and determine if it aligns with the project’s goals. 
 
 After discussion, if the idea is accepted for development, the maintainers will label an issue for it (and often create a feature branch as described in the workflow above). You can then proceed to implement the feature on that branch via a pull request.
 
@@ -66,9 +69,9 @@ Be patient and responsive during the review. We might ask you to make changes �
 
 When opening an issue (bug report or documentation issue), please provide as much detail as possible to help us understand and reproduce the problem:
 
-- Prefer issue templates via `gh` on this fork:
-  - `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Bug Report"`
-  - `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Feature request"`
+- Prefer issue templates via `gh` in the current repository:
+  - `gh issue create --repo $repo --template "Bug Report"`
+  - `gh issue create --repo $repo --template "Feature request"`
 
 - **Title:** A clear, concise title that summarizes the issue.
 - **Description:** Explain the issue in detail. For a bug, describe what happens and what you expected to happen instead.

--- a/Tooling/README.md
+++ b/Tooling/README.md
@@ -20,16 +20,16 @@ Common entrypoints:
   Example: `pwsh -NoProfile -File .\\Tooling\\Invoke-WorktreeOrchestrator.ps1 -Run -RunArgs -LabVIEWVersion 2021 -EnsureCleanState`
 - `gh pr create` (recommended for opening PRs)
   Opens a GitHub PR for the current branch with the desired template.
-  Fork-safe default: `$env:GH_REPO='svelderrainruiz/labview-icon-editor'`
-  Example: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  Resolve repo: `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  Example: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
   Specialized templates:
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
 - `gh issue create` (recommended for template-driven issues)
-  Bug report: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Bug Report"`
-  Feature request: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Feature request"`
+  Bug report: `gh issue create --repo $repo --template "Bug Report"`
+  Feature request: `gh issue create --repo $repo --template "Feature request"`
 - `Get-PylaviOffenders.ps1`  
   Summarizes the latest pylavi offenders report for agent handoffs or automation.  
   Example: `pwsh -NoProfile -File .\\Tooling\\Get-PylaviOffenders.ps1`  

--- a/Tooling/Test-RepoAgnosticIssueRouting.ps1
+++ b/Tooling/Test-RepoAgnosticIssueRouting.ps1
@@ -1,0 +1,128 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string[]]$TargetFiles
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    param([string]$PathOverride)
+
+    if (-not [string]::IsNullOrWhiteSpace($PathOverride)) {
+        return (Resolve-Path -Path $PathOverride -ErrorAction Stop).Path
+    }
+
+    $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $PSCommandPath }
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($git) {
+        try {
+            $gitRoot = git -C $scriptRoot rev-parse --show-toplevel 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitRoot)) {
+                return (Resolve-Path -Path $gitRoot.Trim() -ErrorAction Stop).Path
+            }
+        } catch {
+            Write-Verbose ("git rev-parse failed: {0}" -f $_.Exception.Message)
+        }
+    }
+
+    return (Resolve-Path -Path (Join-Path $scriptRoot '..')).Path
+}
+
+$resolvedRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+
+$defaultTargets = @(
+    'AGENTS.md',
+    'CONTRIBUTING.md',
+    'Tooling/README.md',
+    'docs/ci/actions/maintainers-guide.md',
+    '.github/ISSUE_TEMPLATE/config.yml',
+    '.github/ISSUE_TEMPLATE/feature_request.yml'
+)
+
+$targets = if ($TargetFiles -and $TargetFiles.Count -gt 0) { $TargetFiles } else { $defaultTargets }
+
+$rules = @(
+    [pscustomobject]@{
+        Id = 'upstream-issues-url'
+        Pattern = 'https://github\.com/ni/labview-icon-editor/issues'
+        Message = 'Hardcoded upstream issue URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'upstream-discussions-url'
+        Pattern = 'https://github\.com/ni/labview-icon-editor/discussions'
+        Message = 'Hardcoded upstream discussion URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'fork-issues-url'
+        Pattern = 'https://github\.com/svelderrainruiz/labview-icon-editor/issues'
+        Message = 'Hardcoded fork issue URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'fork-discussions-url'
+        Pattern = 'https://github\.com/svelderrainruiz/labview-icon-editor/discussions'
+        Message = 'Hardcoded fork discussion URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'fixed-repo-flag-upstream'
+        Pattern = '--repo\s+ni/labview-icon-editor'
+        Message = 'Fixed --repo target is not allowed. Resolve current repository first and use --repo $repo.'
+    },
+    [pscustomobject]@{
+        Id = 'fixed-repo-flag-fork'
+        Pattern = '--repo\s+svelderrainruiz/labview-icon-editor'
+        Message = 'Fixed --repo target is not allowed. Resolve current repository first and use --repo $repo.'
+    }
+)
+
+$findings = New-Object System.Collections.Generic.List[object]
+
+foreach ($relativePath in $targets) {
+    $fullPath = if ([System.IO.Path]::IsPathRooted($relativePath)) {
+        $relativePath
+    } else {
+        Join-Path $resolvedRoot $relativePath
+    }
+
+    if (-not (Test-Path -Path $fullPath)) {
+        $findings.Add([pscustomobject]@{
+            File = $relativePath
+            Line = 1
+            Rule = 'missing-file'
+            Message = 'Target file not found.'
+            Match = ''
+        })
+        continue
+    }
+
+    $lineNumber = 0
+    Get-Content -Path $fullPath | ForEach-Object {
+        $lineNumber++
+        $line = $_
+        foreach ($rule in $rules) {
+            if ($line -match $rule.Pattern) {
+                $findings.Add([pscustomobject]@{
+                    File = $relativePath
+                    Line = $lineNumber
+                    Rule = $rule.Id
+                    Message = $rule.Message
+                    Match = $Matches[0]
+                })
+            }
+        }
+    }
+}
+
+if ($findings.Count -gt 0) {
+    Write-Host 'Repo-agnostic issue/discussion routing check failed.'
+    foreach ($finding in $findings) {
+        Write-Host ("- {0}:{1} [{2}] {3} Match='{4}'" -f $finding.File, $finding.Line, $finding.Rule, $finding.Message, $finding.Match)
+    }
+    throw ("Found {0} repo-routing violation(s)." -f $findings.Count)
+}
+
+Write-Host ("Repo-agnostic issue/discussion routing check passed for {0} file(s)." -f $targets.Count)

--- a/docs/ci/actions/maintainers-guide.md
+++ b/docs/ci/actions/maintainers-guide.md
@@ -87,8 +87,9 @@ Debug-only/manual validation:
 - Alias retirement is documented but not auto-enforced in this phase.
 - Use `labels-sync.yml` to create/update contract labels from
   `.github/labels/label-contract.json`.
-- For fork operations, pin `gh` to `svelderrainruiz/labview-icon-editor` (or set
-  `GH_REPO`) so metadata commands do not target upstream.
+- Resolve the repository for `gh` commands:
+  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  - `GH_REPO` is optional override when maintainers need to target a specific repo.
 
 ## Label Metadata Automation
 


### PR DESCRIPTION
## Summary
- enforce repo-agnostic issue/discussion routing across agent and maintainer docs
- remove hardcoded upstream/fork issue and discussion links from templates
- add CI guard script and workflow to prevent regressions

## Validation
- pwsh -NoProfile -File .\Tooling\Test-RepoAgnosticIssueRouting.ps1
- python YAML parse for updated templates/workflow
- gh issue/pr current-repo smoke using $repo resolution pattern
