### PR TITLE
Fix ci-debt-train GH token for workflow dispatch

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     about: "Let us help you if you hit a roadblock!"
 
   - name: 📖 Read the Docs
-    url: https://github.com/ni/labview-icon-editor#labview-icon-editor
+    url: https://ni.github.io/labview-icon-editor/
     about: "Check the documentation for common questions before opening an issue."
 
 issue_templates:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        **IMPORTANT:** Start the discussion on our Discord channel [#icon-editor-dev](https://discord.gg/q4d3ggrFVA) or create a [GitHub Discussion](https://github.com/ni/labview-icon-editor/discussions/new/choose) **only** if you are requesting changes to the shipping version of the Icon Editor.
+        **IMPORTANT:** Start the discussion on our Discord channel [#icon-editor-dev](https://discord.gg/q4d3ggrFVA) or create a GitHub Discussion in this repository (Discussions tab) **only** if you are requesting changes to the shipping version of the Icon Editor.
 
   - type: textarea
     attributes:

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -636,18 +636,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Initialize VerifyIEPaths archive folder
+        shell: pwsh
+        run: |
+          New-Item -Path "$env:RUNNER_TEMP\\verify-iepaths" -ItemType Directory -Force | Out-Null
       - name: Job setup
+        id: job_setup
         uses: ./.github/actions/lvie-job-setup
         with:
           checkout: 'false'
           bitness: ${{ matrix.bitness }}
           create_worktree: 'true'
           worktree_root_mode: runner_temp
-      - name: Initialize VerifyIEPaths archive folder
+      - name: Re-initialize VerifyIEPaths archive folder
         shell: pwsh
         run: |
           New-Item -Path "$env:RUNNER_TEMP\\verify-iepaths" -ItemType Directory -Force | Out-Null
       - name: Verify IE Paths (LV ${{ matrix.bitness }}-bit)
+        id: verify_ie_paths
         shell: pwsh
         run: |
           pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:REPO_ROOT\\Tooling\\Invoke-MissingIEFilesFromLVInstall.ps1" `
@@ -660,12 +666,74 @@ jobs:
             -StatusFileArchiveDirectory "$env:RUNNER_TEMP\\verify-iepaths" `
             -EnableDevModeNoLabVIEW `
             -AutoRevertIfEnabled
-      - name: Upload VerifyIEPaths status (on failure)
-        if: failure()
+      - name: Capture VerifyIEPaths diagnostics
+        if: ${{ always() }}
+        shell: pwsh
+        run: |
+          $archiveRoot = Join-Path $env:RUNNER_TEMP 'verify-iepaths'
+          New-Item -Path $archiveRoot -ItemType Directory -Force | Out-Null
+
+          $jobSetupOutcome = '${{ steps.job_setup.outcome }}'
+          $verifyOutcome = '${{ steps.verify_ie_paths.outcome }}'
+          $classification = ''
+          $summary = ''
+          $hints = New-Object System.Collections.Generic.List[string]
+
+          if ($jobSetupOutcome -ne 'success') {
+            $classification = 'setup-failure'
+            $summary = 'lvie-job-setup failed before Verify IE Paths executed.'
+            if ([string]::IsNullOrWhiteSpace($env:REPO_ROOT)) {
+              $hints.Add('REPO_ROOT was not exported by job setup.') | Out-Null
+            }
+            if (-not (Get-Command gk -ErrorAction SilentlyContinue)) {
+              $hints.Add("GitKraken CLI 'gk' was not detected on PATH.") | Out-Null
+            }
+            if (-not (Test-Path (Join-Path $env:GITHUB_WORKSPACE 'Tooling\\New-CIWorktreeForJob.ps1'))) {
+              $hints.Add('Tooling\\New-CIWorktreeForJob.ps1 was not found.') | Out-Null
+            }
+          } elseif ($verifyOutcome -eq 'failure') {
+            $classification = 'verify-iepaths-failure'
+            $summary = 'Verify IE Paths execution failed after successful job setup.'
+          } else {
+            $classification = 'no-diagnostics-required'
+            $summary = 'No setup or Verify IE Paths failure detected.'
+          }
+
+          $diagnostic = [ordered]@{
+            classification = $classification
+            summary = $summary
+            bitness = '${{ matrix.bitness }}'
+            run_id = '${{ github.run_id }}'
+            run_attempt = '${{ github.run_attempt }}'
+            repository = '${{ github.repository }}'
+            workflow = '${{ github.workflow }}'
+            job_setup_outcome = $jobSetupOutcome
+            verify_ie_paths_outcome = $verifyOutcome
+            repo_root = $env:REPO_ROOT
+            hints = @($hints)
+            captured_utc = (Get-Date).ToUniversalTime().ToString('o')
+          }
+
+          $diagnosticPath = Join-Path $archiveRoot ("verify-iepaths-diagnostics-{0}-bit.json" -f '${{ matrix.bitness }}')
+          $diagnostic | ConvertTo-Json -Depth 8 | Out-File -FilePath $diagnosticPath -Encoding utf8
+          Write-Host ("Wrote Verify IE Paths diagnostics: {0}" -f $diagnosticPath)
+
+          if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+            @(
+              "### Verify IE Paths diagnostics (${{ matrix.bitness }}-bit)"
+              "- Classification: $classification"
+              "- Job setup outcome: $jobSetupOutcome"
+              "- Verify step outcome: $verifyOutcome"
+              "- Summary: $summary"
+            ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
+      - name: Upload VerifyIEPaths status and diagnostics
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: verify-iepaths-${{ matrix.bitness }}-bit
           path: ${{ runner.temp }}\verify-iepaths
+          if-no-files-found: warn
       - name: Job teardown
         if: always()
         uses: ./.github/actions/lvie-job-teardown
@@ -2034,7 +2102,9 @@ jobs:
           }
           $needs = ConvertFrom-Json -InputObject '${{ toJson(needs) }}'
           $needsProps = $needs.PSObject.Properties
-          $failed = @()
+          $missing = @()
+          $rootCauseFailures = @()
+          $cascaded = @()
 
           $vipStatus = $null
           $vipStatusPath = Join-Path -Path $PWD -ChildPath 'vip-build-status/vip-build.json'
@@ -2046,28 +2116,54 @@ jobs:
             }
           }
 
+          function Get-JobEntryLabel {
+            param(
+              [string]$JobName,
+              [string]$Result,
+              [object]$VipStatusObject
+            )
+
+            if ($JobName -eq 'build-vip' -and $VipStatusObject) {
+              $label = if ($VipStatusObject.reason) { $VipStatusObject.reason } elseif ($VipStatusObject.status) { $VipStatusObject.status } else { $null }
+              if ($label) {
+                return "{0}:{1} ({2})" -f $JobName, $Result, $label
+              }
+            }
+
+            return "{0}:{1}" -f $JobName, $Result
+          }
+
           foreach ($job in $required) {
             $entryProp = $needsProps[$job]
             if (-not $entryProp) {
-              $failed += "$($job):missing"
+              $missing += "$($job):missing"
               continue
             }
             $result = $entryProp.Value.result
             if ($result -ne 'success') {
-              if ($job -eq 'build-vip' -and $vipStatus) {
-                $label = if ($vipStatus.reason) { $vipStatus.reason } elseif ($vipStatus.status) { $vipStatus.status } else { $null }
-                if ($label) {
-                  $failed += "$($job):$result ($label)"
-                } else {
-                  $failed += "$($job):$result"
-                }
+              $entry = Get-JobEntryLabel -JobName $job -Result $result -VipStatusObject $vipStatus
+              if ($result -in @('failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure')) {
+                $rootCauseFailures += $entry
+              } elseif ($result -eq 'skipped') {
+                $cascaded += $entry
               } else {
-                $failed += "$($job):$result"
+                $rootCauseFailures += $entry
               }
             }
           }
-          if ($failed.Count -gt 0) {
-            Write-Error ("Pipeline contract failed: {0}" -f ($failed -join ', '))
+
+          $requiredJobVerdict = if ($missing.Count -eq 0 -and $rootCauseFailures.Count -eq 0 -and $cascaded.Count -eq 0) { 'pass' } else { 'fail' }
+          $rootCauseLabel = if ($rootCauseFailures.Count -gt 0) { $rootCauseFailures -join ', ' } else { '<none>' }
+          $cascadedLabel = if ($cascaded.Count -gt 0) { $cascaded -join ', ' } else { '<none>' }
+          $missingLabel = if ($missing.Count -gt 0) { $missing -join ', ' } else { '<none>' }
+
+          Write-Host ("Required job verdict: {0}" -f $requiredJobVerdict)
+          Write-Host ("Root-cause failures: {0}" -f $rootCauseLabel)
+          Write-Host ("Cascaded/skipped jobs: {0}" -f $cascadedLabel)
+          Write-Host ("Missing required jobs: {0}" -f $missingLabel)
+
+          if ($requiredJobVerdict -eq 'fail') {
+            Write-Error ("Pipeline contract failed: required-job verdict={0}; root-cause failures={1}; cascaded/skipped={2}; missing={3}" -f $requiredJobVerdict, $rootCauseLabel, $cascadedLabel, $missingLabel)
           } else {
             Write-Host 'Pipeline contract satisfied.'
           }

--- a/.github/workflows/ci-debt-policy-gate.yml
+++ b/.github/workflows/ci-debt-policy-gate.yml
@@ -1,0 +1,38 @@
+name: CI Debt Policy Gate
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Policy mode override"
+        required: false
+        default: warn
+        type: choice
+        options:
+          - warn
+          - enforce
+
+permissions:
+  contents: read
+
+jobs:
+  root_cause_contract:
+    name: Root Cause Contract
+    runs-on: ubuntu-latest
+    env:
+      CI_DEBT_POLICY_ENFORCE_AFTER_UTC: "2026-02-19T00:00:00Z"
+      CI_DEBT_POLICY_MODE: ${{ github.event.inputs.mode || vars.CI_DEBT_POLICY_MODE || '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate CI debt policy contract
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File "$env:GITHUB_WORKSPACE\Tooling\agents\ci-debt\Test-CiDebtPolicyGate.ps1"

--- a/.github/workflows/ci-debt-train.yml
+++ b/.github/workflows/ci-debt-train.yml
@@ -1,0 +1,131 @@
+name: CI Debt Train
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Actions run ID to analyze (optional; defaults to latest failed ci-composite run)"
+        required: false
+        type: string
+      issue_number:
+        description: "Issue number for status comments"
+        required: false
+        default: "74"
+        type: string
+      post_comment:
+        description: "Post markdown summary as issue comment"
+        required: false
+        default: true
+        type: boolean
+  schedule:
+    - cron: "30 9 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  analyze:
+    name: Analyze CI Debt Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve target run and comment behavior
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function parsePositiveInt(value) {
+              const parsed = Number.parseInt(String(value || '').trim(), 10);
+              return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+            }
+
+            const inputs = context.payload.inputs || {};
+            let runId = parsePositiveInt(inputs.run_id);
+            if (!runId) {
+              const response = await github.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci-composite.yml',
+                status: 'completed',
+                conclusion: 'failure',
+                per_page: 1,
+              });
+              const latest = (response.data.workflow_runs || [])[0];
+              if (!latest) {
+                core.setFailed('No failed ci-composite workflow runs were found.');
+                return;
+              }
+              runId = latest.id;
+            }
+
+            const issueNumber = parsePositiveInt(inputs.issue_number) || 74;
+            const postCommentRaw = String(inputs.post_comment ?? 'true').trim().toLowerCase();
+            const postComment = (postCommentRaw === 'false' || postCommentRaw === '0') ? 'false' : 'true';
+
+            core.setOutput('run_id', String(runId));
+            core.setOutput('issue_number', String(issueNumber));
+            core.setOutput('post_comment', postComment);
+
+      - name: Analyze run
+        id: analyze
+        shell: pwsh
+        run: |
+          $runId = '${{ steps.resolve.outputs.run_id }}'
+          if ([string]::IsNullOrWhiteSpace($runId)) {
+            throw 'Resolved run_id is empty.'
+          }
+
+          $outDir = Join-Path $env:GITHUB_WORKSPACE 'TestResults\agent-logs\ci-debt'
+          New-Item -Path $outDir -ItemType Directory -Force | Out-Null
+
+          $outJson = Join-Path $outDir "$runId.analysis.json"
+          $outMarkdown = Join-Path $outDir "$runId.analysis.md"
+
+          pwsh -NoProfile -File "$env:GITHUB_WORKSPACE\Tooling\agents\ci-debt\Invoke-CiDebtAnalysis.ps1" `
+            -Repo "${{ github.repository }}" `
+            -RunId $runId `
+            -OutJson $outJson `
+            -OutMarkdown $outMarkdown
+
+          "out_json=$outJson" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+          "out_markdown=$outMarkdown" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Upload CI debt analysis artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-debt-analysis-${{ steps.resolve.outputs.run_id }}
+          path: |
+            ${{ steps.analyze.outputs.out_json }}
+            ${{ steps.analyze.outputs.out_markdown }}
+          if-no-files-found: error
+
+      - name: Comment on tracking issue
+        if: ${{ steps.resolve.outputs.post_comment == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ steps.resolve.outputs.issue_number }}
+          MARKDOWN_PATH: ${{ steps.analyze.outputs.out_markdown }}
+        with:
+          script: |
+            const fs = require('fs');
+            const issueNumber = Number.parseInt(process.env.ISSUE_NUMBER || '', 10);
+            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+              core.notice('Issue number not provided or invalid; skipping comment.');
+              return;
+            }
+            const markdownPath = process.env.MARKDOWN_PATH;
+            if (!markdownPath || !fs.existsSync(markdownPath)) {
+              core.setFailed(`Markdown summary not found at ${markdownPath || '<empty>'}`);
+              return;
+            }
+            const body = fs.readFileSync(markdownPath, 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body,
+            });

--- a/.github/workflows/ci-debt-train.yml
+++ b/.github/workflows/ci-debt-train.yml
@@ -29,6 +29,8 @@ jobs:
   analyze:
     name: Analyze CI Debt Run
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/repo-agnostic-issue-routing.yml
+++ b/.github/workflows/repo-agnostic-issue-routing.yml
@@ -1,0 +1,24 @@
+name: Repo-Agnostic Issue Routing
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Repo-Agnostic Issue/Discussion Routing
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate repo-agnostic issue/discussion routing
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .\Tooling\Test-RepoAgnosticIssueRouting.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,27 +13,39 @@ This repository uses LabVIEW, g-cli, and PowerShell tooling. Follow the steps be
 - Open a PowerShell terminal at the repo root.
 - Confirm `g-cli` is available:
   - `g-cli --version`
-- Pin `gh` to the fork for this shell:
-  - `$env:GH_REPO='svelderrainruiz/labview-icon-editor'`
+- Resolve the current repository for `gh` commands:
+  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  - `GH_REPO` is an optional override.
 - If you need to open a PR from the current branch, use `gh`:
-  - Default template: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
-  - Draft PR: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md --draft`
+  - Default template: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  - Draft PR: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md --draft`
+
+## Repo-Agnostic Issue/Discussion Policy
+- Issue and discussion actions operate on the repository currently being worked in.
+- Use this command before issue/PR/workflow operations:
+  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+- Examples:
+  - Create issue: `gh issue create --repo $repo --template "Bug Report"`
+  - Create PR: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  - List issues: `gh issue list --repo $repo --limit 50`
+  - Run workflow: `gh workflow run labels-sync.yml --repo $repo -f dry_run=true -f include_aliases=true`
 
 ## GitHub Templates and Labels
 - Use issue templates with `gh` (preferred):
-  - Bug report: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Bug Report"`
-  - Feature request: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Feature request"`
+  - Bug report: `gh issue create --repo $repo --template "Bug Report"`
+  - Feature request: `gh issue create --repo $repo --template "Feature request"`
 - Use PR templates with `gh`:
-  - Generic: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
-  - Bug fix: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
-  - Feature addition: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
-  - Documentation update: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
-  - Infrastructure change: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
+  - Generic: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  - Bug fix: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
+  - Feature addition: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
+  - Documentation update: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
+  - Infrastructure change: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
 - Web fallback links:
-  - Issues: `https://github.com/svelderrainruiz/labview-icon-editor/issues/new/choose`
-  - Bug form: `https://github.com/svelderrainruiz/labview-icon-editor/issues/new?template=bug_report.yml`
-  - Feature form: `https://github.com/svelderrainruiz/labview-icon-editor/issues/new?template=feature_request.yml`
-  - PR page: `https://github.com/svelderrainruiz/labview-icon-editor/compare`
+  - Resolve repository URL: `$repoUrl = gh repo view --repo $repo --json url --jq .url`
+  - Issues: `"$repoUrl/issues/new/choose"`
+  - Bug form: `"$repoUrl/issues/new?template=bug_report.yml"`
+  - Feature form: `"$repoUrl/issues/new?template=feature_request.yml"`
+  - PR page: `"$repoUrl/compare"`
 
 Label policy:
 - Canonical release labels:
@@ -50,8 +62,8 @@ Label policy:
   - `bug` -> `Issue group: Bug`
   - `enhancement` -> `Type: Enhancement`
 - Sync labels from contract (manual workflow):
-  - Dry run: `gh workflow run labels-sync.yml --repo svelderrainruiz/labview-icon-editor -f dry_run=true -f include_aliases=true`
-  - Apply: `gh workflow run labels-sync.yml --repo svelderrainruiz/labview-icon-editor -f dry_run=false -f include_aliases=true`
+  - Dry run: `gh workflow run labels-sync.yml --repo $repo -f dry_run=true -f include_aliases=true`
+  - Apply: `gh workflow run labels-sync.yml --repo $repo -f dry_run=false -f include_aliases=true`
 
 Stale issue policy:
 - Workflow: `.github/workflows/stale-issues.yml`
@@ -76,17 +88,17 @@ Stale issue policy:
       '-label:"Issue group: Added to agenda"'
       '-label:"good first issue"'
     ) -join ' '
-    gh issue list --repo svelderrainruiz/labview-icon-editor --state open --search $query --limit 200
+    gh issue list --repo $repo --state open --search $query --limit 200
     ```
 
 Metadata quick-checks:
 - Unlabeled PRs (no normalized release label):
-  - `gh pr list --repo svelderrainruiz/labview-icon-editor --state open --search "-label:'Version Increment: Major' -label:'Version Increment: Minor' -label:'Version Increment: Patch' -label:major -label:minor -label:patch"`
+  - `gh pr list --repo $repo --state open --search "-label:'Version Increment: Major' -label:'Version Increment: Minor' -label:'Version Increment: Patch' -label:major -label:minor -label:patch"`
 - Unlabeled issues:
-  - `gh issue list --repo svelderrainruiz/labview-icon-editor --state open --search "no:label" --limit 200`
+  - `gh issue list --repo $repo --state open --search "no:label" --limit 200`
 - Alias-only issue types:
   - ```
-    $items = gh issue list --repo svelderrainruiz/labview-icon-editor --state open --limit 200 --json number,title,labels | ConvertFrom-Json
+    $items = gh issue list --repo $repo --state open --limit 200 --json number,title,labels | ConvertFrom-Json
     $items | Where-Object {
       ($_.labels.name -contains 'enhancement' -or $_.labels.name -contains 'bug') -and
       -not ($_.labels.name -contains 'Type: Enhancement' -or $_.labels.name -contains 'Issue group: Bug')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,24 @@ Metadata quick-checks:
     } | Select-Object number,title,@{Name='labels';Expression={ $_.labels.name -join ', ' }}
     ```
 
+## CI Debt Training (Issue #74)
+- Canonical signatures are stored in:
+  - `Tooling/agents/ci-debt/signatures.json`
+- Remediation notes are stored in:
+  - `Tooling/agents/ci-debt/playbook.md`
+- Analyze a specific CI run:
+  - `pwsh -NoProfile -File .\Tooling\agents\ci-debt\Invoke-CiDebtAnalysis.ps1 -Repo $repo -RunId 21840801109`
+- Use fixture-only local validation (no live API calls):
+  - `pwsh -NoProfile -File .\Tooling\agents\ci-debt\Invoke-CiDebtAnalysis.ps1 -Repo $repo -RunId 21840801109 -FixturePath .\Tooling\agents\ci-debt\fixtures\run-21840801109.json`
+- Enforce unknown-signature failures during training:
+  - `pwsh -NoProfile -File .\Tooling\agents\ci-debt\Invoke-CiDebtAnalysis.ps1 -Repo $repo -RunId 21840801109 -FailOnUnknown`
+- Run training workflow manually:
+  - `gh workflow run ci-debt-train.yml --repo $repo -f run_id=21840801109 -f issue_number=74 -f post_comment=true`
+- Run policy gate manually:
+  - `gh workflow run ci-debt-policy-gate.yml --repo $repo -f mode=warn`
+- Local policy check:
+  - `pwsh -NoProfile -File .\Tooling\agents\ci-debt\Test-CiDebtPolicyGate.ps1 -Mode warn`
+
 ## pylavi / vi_validate gate
 - The local CI parity run includes a fast LabVIEW file validation step powered by `pylavi` (`vi_validate`) and runs **before** any g-cli/LabVIEW work.
 - The gate uses `.lvversion` as the canonical LabVIEW version and passes it to `vi_validate --eq` automatically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,12 @@ This repo follows a typical fork-and-pull model on [GitHub](https://github.com/n
 
 We welcome both code and non-code contributions. Here are some ways to help:
 
-- 🐛 **Bug Reports:** We can’t catch every issue. If you find a bug, first search the [issues list](https://github.com/ni/labview-icon-editor/issues) to see if it’s already reported. If not, [open a new issue](https://github.com/ni/labview-icon-editor/issues/new/choose) describing the problem so we can address it.
-- 💬 **Q&A and Feedback:** Participate in discussions! If you have an idea for a new feature or changes, start a conversation on our [GitHub Discussions board](https://github.com/ni/labview-icon-editor/discussions/new?category=ideas) or join the community on [Discord](https://discord.gg/q4d3ggrFVA). Your feedback on planned features (see the [New Features discussions](https://github.com/ni/labview-icon-editor/discussions/categories/new-features)) is valuable.
-- 🎬 **Tackle “Good First Issues”:** Check out issues labeled [**Good first issue**](https://github.com/ni/labview-icon-editor/labels/good%20first%20issue). These are entry-level tasks that are great for new contributors. You can comment on an issue to be assigned and start working on it.
+For command examples below, resolve your current repository once:
+- `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+
+- 🐛 **Bug Reports:** We can’t catch every issue. If you find a bug, first search issues in the current repository (`gh issue list --repo $repo --state open --limit 200`). If not reported, open a new issue with the bug template (`gh issue create --repo $repo --template "Bug Report"`).
+- 💬 **Q&A and Feedback:** Participate in discussions. If you have an idea for a new feature or changes, open Discussions in the current repository (Discussions tab) or join the community on [Discord](https://discord.gg/q4d3ggrFVA).
+- 🎬 **Tackle “Good First Issues”:** Check out issues labeled **good first issue** in the current repository (`gh issue list --repo $repo --label "good first issue"`). These are entry-level tasks that are great for new contributors.
 - ✏️ **Improve Documentation:** Contributing to docs is just as important as code. If you spot outdated or unclear documentation, feel free to propose changes. Our documentation is in this repo and the companion [documentation site](https://ni.github.io/labview-icon-editor/) (you can use the “Edit this page” link on the docs site).
 
 All interactions should be respectful and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
@@ -27,7 +30,7 @@ All interactions should be respectful and follow our [Code of Conduct](CODE_OF_C
 4. **Follow Workflow:** We use a branching strategy where official development happens on feature branches and merges go first into `develop`, then through pre-release branches (e.g. `release-alpha`, `release-beta`, `release-rc`) before merging into `main` for the final release. External contributors will typically collaborate on feature branches created by NI maintainers (once an issue is approved and labeled "Open to contribution"). If you’re working on a fork, you can still develop on your own branch and submit a PR to the appropriate branch in the main repo.
 5. **Write and Test Code:** Make your changes in LabVIEW. If you’ve applied the dependencies and run the `Tooling\Prepare LV to Use Icon Editor Source.vi` (or used the PowerShell scripts to set development mode), you can open `lv_icon_editor.lvproj` and begin editing the VIs. We encourage writing or updating tests if applicable (see `Test` folder or ask maintainers how to run tests – we have a CLI script `RunUnitTests.ps1` that uses the included testing framework).
 6. **Commit Guidelines:** Commit messages should be clear. Please **sign off** your commits (this adds a `Signed-off-by:` line to your commit message, indicating you agree to the Developer Certificate of Origin). If using Git from command line, `git commit -s` will do this. Ensure each commit builds and passes tests.
-7. **Submit a Pull Request:** Push your branch to your fork and open a PR against this repository. In the PR description, clearly explain the purpose of the change, what was changed, and reference any issue it addresses (e.g., “Closes #123”). Include any relevant testing steps or screenshots. For this fork, pin `gh` commands to `--repo svelderrainruiz/labview-icon-editor`. You can use the default PR template with `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md` or a specialized template under `.github/PULL_REQUEST_TEMPLATE/`. A good PR description has:
+7. **Submit a Pull Request:** Push your branch to your fork and open a PR against this repository. In the PR description, clearly explain the purpose of the change, what was changed, and reference any issue it addresses (e.g., “Closes #123”). Include any relevant testing steps or screenshots. Use the default PR template with `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md` or a specialized template under `.github/PULL_REQUEST_TEMPLATE/`. A good PR description has:
    - **Purpose** – Why is this change being made?
    - **Changes Made** – What did you do? 
    - **Issue Reference** – Link the issue number if one exists.
@@ -42,7 +45,7 @@ All interactions should be respectful and follow our [Code of Conduct](CODE_OF_C
 
 ## Feature Requests & Enhancements
 
-If you have an idea for a new feature or a significant change, please start by creating a discussion in the [**New Features** category](https://github.com/ni/labview-icon-editor/discussions/categories/new-features) rather than directly opening an issue or PR. In your discussion post, describe the problem your idea would solve or the use-case it would enable. The core team and community can then provide feedback and determine if it aligns with the project’s goals. 
+If you have an idea for a new feature or a significant change, start with a discussion in the current repository (Discussions tab) rather than directly opening an issue or PR. In your discussion post, describe the problem your idea would solve or the use-case it would enable. The core team and community can then provide feedback and determine if it aligns with the project’s goals. 
 
 After discussion, if the idea is accepted for development, the maintainers will label an issue for it (and often create a feature branch as described in the workflow above). You can then proceed to implement the feature on that branch via a pull request.
 
@@ -66,9 +69,9 @@ Be patient and responsive during the review. We might ask you to make changes �
 
 When opening an issue (bug report or documentation issue), please provide as much detail as possible to help us understand and reproduce the problem:
 
-- Prefer issue templates via `gh` on this fork:
-  - `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Bug Report"`
-  - `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Feature request"`
+- Prefer issue templates via `gh` in the current repository:
+  - `gh issue create --repo $repo --template "Bug Report"`
+  - `gh issue create --repo $repo --template "Feature request"`
 
 - **Title:** A clear, concise title that summarizes the issue.
 - **Description:** Explain the issue in detail. For a bug, describe what happens and what you expected to happen instead.

--- a/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
+++ b/Tooling/Invoke-MissingIEFilesFromLVInstall.ps1
@@ -176,7 +176,11 @@ if (-not (Test-Path -Path $gitKrakenScript)) {
     throw "GitKraken CLI helper not found at $gitKrakenScript"
 }
 . $gitKrakenScript
-Enable-GitKrakenGitShim -Require | Out-Null
+$requireGitKraken = $env:LVIE_REQUIRE_GITKRAKEN_CLI -eq '1'
+$gitKrakenEnabled = Enable-GitKrakenGitShim -Require:$requireGitKraken
+if (-not $gitKrakenEnabled) {
+    Write-Warning "GitKraken CLI 'gk' not found. Using system git. Set LVIE_REQUIRE_GITKRAKEN_CLI=1 to enforce gk."
+}
 
 $devModeRequested = $EnableDevMode -or $EnableDevModeNoLabVIEW
 if ($EnableDevMode -and $EnableDevModeNoLabVIEW) {

--- a/Tooling/Invoke-PSScriptAnalyzer.ps1
+++ b/Tooling/Invoke-PSScriptAnalyzer.ps1
@@ -59,7 +59,11 @@ if (-not (Test-Path -Path $gitKrakenScript)) {
     throw "GitKraken CLI helper not found at $gitKrakenScript"
 }
 . $gitKrakenScript
-Enable-GitKrakenGitShim -Require | Out-Null
+$requireGitKraken = $env:LVIE_REQUIRE_GITKRAKEN_CLI -eq '1'
+$gitKrakenEnabled = Enable-GitKrakenGitShim -Require:$requireGitKraken
+if (-not $gitKrakenEnabled) {
+    Write-Warning "GitKraken CLI 'gk' not found. Using system git. Set LVIE_REQUIRE_GITKRAKEN_CLI=1 to enforce gk."
+}
 
 function Resolve-RepoRoot {
     param([string]$PathOverride)

--- a/Tooling/New-CIWorktree.ps1
+++ b/Tooling/New-CIWorktree.ps1
@@ -21,13 +21,6 @@
     Optional override for the worktree root.
 #>
 
-$gitKrakenScript = Join-Path $PSScriptRoot 'support\GitKrakenCli.ps1'
-if (-not (Test-Path -Path $gitKrakenScript)) {
-    throw "GitKraken CLI helper not found at $gitKrakenScript"
-}
-. $gitKrakenScript
-Enable-GitKrakenGitShim -Require | Out-Null
-
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
@@ -47,6 +40,17 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+$gitKrakenScript = Join-Path $PSScriptRoot 'support\GitKrakenCli.ps1'
+if (-not (Test-Path -Path $gitKrakenScript)) {
+    throw "GitKraken CLI helper not found at $gitKrakenScript"
+}
+. $gitKrakenScript
+$requireGitKraken = $env:LVIE_REQUIRE_GITKRAKEN_CLI -eq '1'
+$gitKrakenEnabled = Enable-GitKrakenGitShim -Require:$requireGitKraken
+if (-not $gitKrakenEnabled) {
+    Write-Warning "GitKraken CLI 'gk' not found. Using system git. Set LVIE_REQUIRE_GITKRAKEN_CLI=1 to enforce gk."
+}
 
 function Resolve-RepoRoot {
     param([string]$BasePath)

--- a/Tooling/New-CIWorktreeForJob.ps1
+++ b/Tooling/New-CIWorktreeForJob.ps1
@@ -41,13 +41,6 @@
     location is used.
 #>
 
-$gitKrakenScript = Join-Path $PSScriptRoot 'support\GitKrakenCli.ps1'
-if (-not (Test-Path -Path $gitKrakenScript)) {
-    throw "GitKraken CLI helper not found at $gitKrakenScript"
-}
-. $gitKrakenScript
-Enable-GitKrakenGitShim -Require | Out-Null
-
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
@@ -74,6 +67,17 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+$gitKrakenScript = Join-Path $PSScriptRoot 'support\GitKrakenCli.ps1'
+if (-not (Test-Path -Path $gitKrakenScript)) {
+    throw "GitKraken CLI helper not found at $gitKrakenScript"
+}
+. $gitKrakenScript
+$requireGitKraken = $env:LVIE_REQUIRE_GITKRAKEN_CLI -eq '1'
+$gitKrakenEnabled = Enable-GitKrakenGitShim -Require:$requireGitKraken
+if (-not $gitKrakenEnabled) {
+    Write-Warning "GitKraken CLI 'gk' not found. Using system git. Set LVIE_REQUIRE_GITKRAKEN_CLI=1 to enforce gk."
+}
 
 function Resolve-RepoRoot {
     param([string]$BasePath)

--- a/Tooling/README.md
+++ b/Tooling/README.md
@@ -20,16 +20,16 @@ Common entrypoints:
   Example: `pwsh -NoProfile -File .\\Tooling\\Invoke-WorktreeOrchestrator.ps1 -Run -RunArgs -LabVIEWVersion 2021 -EnsureCleanState`
 - `gh pr create` (recommended for opening PRs)
   Opens a GitHub PR for the current branch with the desired template.
-  Fork-safe default: `$env:GH_REPO='svelderrainruiz/labview-icon-editor'`
-  Example: `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
+  Resolve repo: `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  Example: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
   Specialized templates:
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
-  `gh pr create --repo svelderrainruiz/labview-icon-editor --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/feature_request.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
+  `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
 - `gh issue create` (recommended for template-driven issues)
-  Bug report: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Bug Report"`
-  Feature request: `gh issue create --repo svelderrainruiz/labview-icon-editor --template "Feature request"`
+  Bug report: `gh issue create --repo $repo --template "Bug Report"`
+  Feature request: `gh issue create --repo $repo --template "Feature request"`
 - `Get-PylaviOffenders.ps1`  
   Summarizes the latest pylavi offenders report for agent handoffs or automation.  
   Example: `pwsh -NoProfile -File .\\Tooling\\Get-PylaviOffenders.ps1`  

--- a/Tooling/README.md
+++ b/Tooling/README.md
@@ -48,6 +48,13 @@ Common entrypoints:
   Example: `runner-cli pylavi summarize --repo-root .`  
   Example: `runner-cli pylavi fetch --repo <owner/name> --branch develop`
   Example (baseline delta): `runner-cli pylavi summarize --path TestResults/agent-logs/pylavi-offenders.latest.json --baseline Tooling/pylavi/pylavi-offenders.baseline.json --fail-on-delta`
+- `agents/ci-debt/Invoke-CiDebtAnalysis.ps1`
+  Analyzes failed GitHub Actions runs and maps incidents to deterministic signatures for Issue #74 remediation.
+  Example: `pwsh -NoProfile -File .\\Tooling\\agents\\ci-debt\\Invoke-CiDebtAnalysis.ps1 -Repo $repo -RunId 21840801109`
+  Fixture-only example: `pwsh -NoProfile -File .\\Tooling\\agents\\ci-debt\\Invoke-CiDebtAnalysis.ps1 -Repo $repo -RunId 21840801109 -FixturePath .\\Tooling\\agents\\ci-debt\\fixtures\\run-21840801109.json`
+  Signatures and playbook:
+  - `Tooling/agents/ci-debt/signatures.json`
+  - `Tooling/agents/ci-debt/playbook.md`
 
 Related config:
 - `pylavi/vi-validate.yml`  

--- a/Tooling/Test-RepoAgnosticIssueRouting.ps1
+++ b/Tooling/Test-RepoAgnosticIssueRouting.ps1
@@ -1,0 +1,128 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string[]]$TargetFiles
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    param([string]$PathOverride)
+
+    if (-not [string]::IsNullOrWhiteSpace($PathOverride)) {
+        return (Resolve-Path -Path $PathOverride -ErrorAction Stop).Path
+    }
+
+    $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $PSCommandPath }
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($git) {
+        try {
+            $gitRoot = git -C $scriptRoot rev-parse --show-toplevel 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitRoot)) {
+                return (Resolve-Path -Path $gitRoot.Trim() -ErrorAction Stop).Path
+            }
+        } catch {
+            Write-Verbose ("git rev-parse failed: {0}" -f $_.Exception.Message)
+        }
+    }
+
+    return (Resolve-Path -Path (Join-Path $scriptRoot '..')).Path
+}
+
+$resolvedRoot = Resolve-RepoRoot -PathOverride $RepoRoot
+
+$defaultTargets = @(
+    'AGENTS.md',
+    'CONTRIBUTING.md',
+    'Tooling/README.md',
+    'docs/ci/actions/maintainers-guide.md',
+    '.github/ISSUE_TEMPLATE/config.yml',
+    '.github/ISSUE_TEMPLATE/feature_request.yml'
+)
+
+$targets = if ($TargetFiles -and $TargetFiles.Count -gt 0) { $TargetFiles } else { $defaultTargets }
+
+$rules = @(
+    [pscustomobject]@{
+        Id = 'upstream-issues-url'
+        Pattern = 'https://github\.com/ni/labview-icon-editor/issues'
+        Message = 'Hardcoded upstream issue URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'upstream-discussions-url'
+        Pattern = 'https://github\.com/ni/labview-icon-editor/discussions'
+        Message = 'Hardcoded upstream discussion URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'fork-issues-url'
+        Pattern = 'https://github\.com/svelderrainruiz/labview-icon-editor/issues'
+        Message = 'Hardcoded fork issue URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'fork-discussions-url'
+        Pattern = 'https://github\.com/svelderrainruiz/labview-icon-editor/discussions'
+        Message = 'Hardcoded fork discussion URL is not allowed. Use current-repository routing.'
+    },
+    [pscustomobject]@{
+        Id = 'fixed-repo-flag-upstream'
+        Pattern = '--repo\s+ni/labview-icon-editor'
+        Message = 'Fixed --repo target is not allowed. Resolve current repository first and use --repo $repo.'
+    },
+    [pscustomobject]@{
+        Id = 'fixed-repo-flag-fork'
+        Pattern = '--repo\s+svelderrainruiz/labview-icon-editor'
+        Message = 'Fixed --repo target is not allowed. Resolve current repository first and use --repo $repo.'
+    }
+)
+
+$findings = New-Object System.Collections.Generic.List[object]
+
+foreach ($relativePath in $targets) {
+    $fullPath = if ([System.IO.Path]::IsPathRooted($relativePath)) {
+        $relativePath
+    } else {
+        Join-Path $resolvedRoot $relativePath
+    }
+
+    if (-not (Test-Path -Path $fullPath)) {
+        $findings.Add([pscustomobject]@{
+            File = $relativePath
+            Line = 1
+            Rule = 'missing-file'
+            Message = 'Target file not found.'
+            Match = ''
+        })
+        continue
+    }
+
+    $lineNumber = 0
+    Get-Content -Path $fullPath | ForEach-Object {
+        $lineNumber++
+        $line = $_
+        foreach ($rule in $rules) {
+            if ($line -match $rule.Pattern) {
+                $findings.Add([pscustomobject]@{
+                    File = $relativePath
+                    Line = $lineNumber
+                    Rule = $rule.Id
+                    Message = $rule.Message
+                    Match = $Matches[0]
+                })
+            }
+        }
+    }
+}
+
+if ($findings.Count -gt 0) {
+    Write-Host 'Repo-agnostic issue/discussion routing check failed.'
+    foreach ($finding in $findings) {
+        Write-Host ("- {0}:{1} [{2}] {3} Match='{4}'" -f $finding.File, $finding.Line, $finding.Rule, $finding.Message, $finding.Match)
+    }
+    throw ("Found {0} repo-routing violation(s)." -f $findings.Count)
+}
+
+Write-Host ("Repo-agnostic issue/discussion routing check passed for {0} file(s)." -f $targets.Count)

--- a/Tooling/agents/ci-debt/Invoke-CiDebtAnalysis.ps1
+++ b/Tooling/agents/ci-debt/Invoke-CiDebtAnalysis.ps1
@@ -1,0 +1,457 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Repo,
+
+    [Parameter(Mandatory = $false)]
+    [long]$RunId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutJson,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutMarkdown,
+
+    [Parameter(Mandatory = $false)]
+    [string]$SignaturePath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$FixturePath,
+
+    [switch]$FailOnUnknown
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-CiDebtRepoRoot {
+    $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $PSCommandPath }
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($git) {
+        try {
+            $gitRoot = git -C $scriptRoot rev-parse --show-toplevel 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitRoot)) {
+                return (Resolve-Path -Path $gitRoot.Trim() -ErrorAction Stop).Path
+            }
+        } catch {
+            Write-Verbose ("git rev-parse failed: {0}" -f $_.Exception.Message)
+        }
+    }
+
+    return (Resolve-Path -Path (Join-Path $scriptRoot '..\..\..') -ErrorAction Stop).Path
+}
+
+function Resolve-CiDebtRepoName {
+    param([string]$RepoOverride)
+
+    if (-not [string]::IsNullOrWhiteSpace($RepoOverride)) {
+        return $RepoOverride.Trim()
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GH_REPO)) {
+        return $env:GH_REPO.Trim()
+    }
+
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) {
+        throw "Unable to resolve repository: gh CLI not found and GH_REPO not set."
+    }
+
+    $resolved = gh repo view --json nameWithOwner --jq .nameWithOwner 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($resolved)) {
+        throw "Unable to resolve repository via gh repo view."
+    }
+
+    return $resolved.Trim()
+}
+
+function Resolve-CiDebtOutPath {
+    param(
+        [string]$RepoRoot,
+        [long]$RunIdentifier,
+        [string]$OutPath,
+        [string]$Extension
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($OutPath)) {
+        return $OutPath
+    }
+
+    $fileName = if ($RunIdentifier -gt 0) { "{0}.analysis.{1}" -f $RunIdentifier, $Extension } else { "latest.analysis.{0}" -f $Extension }
+    return Join-Path $RepoRoot ("TestResults\agent-logs\ci-debt\{0}" -f $fileName)
+}
+
+function Ensure-CiDebtParentDirectory {
+    param([string]$Path)
+    $parent = Split-Path -Path $Path -Parent
+    if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -Path $parent)) {
+        New-Item -Path $parent -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Load-CiDebtSignatures {
+    param([string]$Path)
+
+    if (-not (Test-Path -Path $Path)) {
+        throw "CI debt signature file not found at $Path"
+    }
+
+    $raw = Get-Content -Path $Path -Raw -ErrorAction Stop
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw "CI debt signature file is empty at $Path"
+    }
+
+    $doc = $raw | ConvertFrom-Json -ErrorAction Stop
+    $signatureList = @($doc.signatures)
+    if ($signatureList.Count -eq 0) {
+        throw "CI debt signature file contains no signatures at $Path"
+    }
+
+    foreach ($signature in $signatureList) {
+        if ([string]::IsNullOrWhiteSpace([string]$signature.id)) {
+            throw "Signature entry is missing required field 'id'."
+        }
+        if ([string]::IsNullOrWhiteSpace([string]$signature.job)) {
+            throw "Signature '$($signature.id)' is missing required field 'job'."
+        }
+        if (@($signature.containsAny).Count -eq 0) {
+            throw "Signature '$($signature.id)' is missing required field 'containsAny'."
+        }
+    }
+
+    return $signatureList
+}
+
+function Get-CiDebtRunFromGh {
+    param(
+        [string]$RepoName,
+        [long]$RunIdentifier
+    )
+
+    if ($RunIdentifier -le 0) {
+        throw "RunId must be provided when FixturePath is not used."
+    }
+
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) {
+        throw "gh CLI is required to analyze live CI run data."
+    }
+
+    $runJson = gh run view $RunIdentifier --repo $RepoName --json databaseId,workflowName,name,url,status,conclusion,event,headBranch,headSha,createdAt,updatedAt,jobs
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($runJson)) {
+        throw "Failed to read run metadata for run $RunIdentifier in $RepoName."
+    }
+
+    $runData = $runJson | ConvertFrom-Json -ErrorAction Stop
+    $jobs = @($runData.jobs)
+    foreach ($job in $jobs) {
+        $jobId = [long]$job.databaseId
+        $jobLog = ''
+        if ($jobId -gt 0) {
+            try {
+                $logOutput = gh run view $RunIdentifier --repo $RepoName --job $jobId --log 2>&1
+                if ($LASTEXITCODE -eq 0) {
+                    $jobLog = if ($logOutput -is [array]) { $logOutput -join [Environment]::NewLine } else { [string]$logOutput }
+                } else {
+                    $jobLog = "Unable to fetch job log (exit code $LASTEXITCODE)."
+                }
+            } catch {
+                $jobLog = "Unable to fetch job log: $($_.Exception.Message)"
+            }
+        }
+        Add-Member -InputObject $job -NotePropertyName log -NotePropertyValue $jobLog -Force
+    }
+
+    return [pscustomobject]@{
+        run = $runData
+        jobs = $jobs
+    }
+}
+
+function Get-CiDebtRunFromFixture {
+    param([string]$Path)
+
+    if (-not (Test-Path -Path $Path)) {
+        throw "Fixture file not found at $Path"
+    }
+
+    $raw = Get-Content -Path $Path -Raw -ErrorAction Stop
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw "Fixture file is empty at $Path"
+    }
+
+    $fixture = $raw | ConvertFrom-Json -ErrorAction Stop
+    if (-not $fixture.run) {
+        throw "Fixture file missing required root property 'run'."
+    }
+    if (-not $fixture.jobs) {
+        throw "Fixture file missing required root property 'jobs'."
+    }
+
+    return [pscustomobject]@{
+        run = $fixture.run
+        jobs = @($fixture.jobs)
+    }
+}
+
+function Find-CiDebtSignatureMatch {
+    param(
+        [string]$JobName,
+        [string]$LogText,
+        [object[]]$Signatures
+    )
+
+    $jobKey = [string]$JobName
+    $jobLower = $jobKey.ToLowerInvariant()
+    $logLower = [string]$LogText
+    $logLower = $logLower.ToLowerInvariant()
+
+    foreach ($signature in $Signatures) {
+        $signatureJob = [string]$signature.job
+        if ([string]::IsNullOrWhiteSpace($signatureJob)) {
+            continue
+        }
+        if ($jobLower -notlike "*$($signatureJob.ToLowerInvariant())*") {
+            continue
+        }
+
+        $fragments = @($signature.containsAny) | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) }
+        $matched = New-Object System.Collections.Generic.List[string]
+        foreach ($fragment in $fragments) {
+            $fragmentText = [string]$fragment
+            if ($logLower.Contains($fragmentText.ToLowerInvariant())) {
+                $matched.Add($fragmentText) | Out-Null
+            }
+        }
+
+        if ($matched.Count -gt 0) {
+            return [pscustomobject]@{
+                Signature = $signature
+                MatchedFragments = @($matched)
+            }
+        }
+    }
+
+    return $null
+}
+
+function New-CiDebtMarkdown {
+    param(
+        [object]$Run,
+        [object[]]$Incidents,
+        [int]$UnknownCount
+    )
+
+    $runId = [string]$Run.databaseId
+    $runUrl = [string]$Run.url
+    $workflowName = [string]$Run.workflowName
+    if ([string]::IsNullOrWhiteSpace($workflowName)) {
+        $workflowName = [string]$Run.name
+    }
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add("## CI Debt Analysis ($runId)") | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add("- Workflow: $workflowName") | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($runUrl)) {
+        $lines.Add("- Run URL: $runUrl") | Out-Null
+    }
+    $lines.Add("- Conclusion: $($Run.conclusion)") | Out-Null
+    $lines.Add("- Open incidents: $($Incidents.Count)") | Out-Null
+    $lines.Add("- Unknown incidents: $UnknownCount") | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('### Incident Table') | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('| Job | Signature | Classification | Severity |') | Out-Null
+    $lines.Add('| --- | --- | --- | --- |') | Out-Null
+    foreach ($incident in $Incidents) {
+        $lines.Add("| $($incident.job) | $($incident.id) | $($incident.classification) | $($incident.severity) |") | Out-Null
+    }
+    if ($Incidents.Count -eq 0) {
+        $lines.Add('| <none> | <none> | <none> | <none> |') | Out-Null
+    }
+    $lines.Add('') | Out-Null
+
+    $signatureIds = @($Incidents | ForEach-Object { $_.id })
+    $hasLint = $signatureIds -contains 'powershell-lint.gk-missing'
+    $hasVerify = $signatureIds -contains 'verify-iepaths.setup-failed'
+    $hasPipeline = $signatureIds -contains 'pipeline-contract.cascade-failure'
+
+    $lines.Add('### Issue #74 Checklist') | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add(("{0} Lint fix (powershell-lint.gk-missing)" -f ($(if ($hasLint) { '[ ]' } else { '[x]' })))) | Out-Null
+    $lines.Add(("{0} Verify IE Paths 64/32 fix (verify-iepaths.setup-failed)" -f ($(if ($hasVerify) { '[ ]' } else { '[x]' })))) | Out-Null
+    $lines.Add(("{0} Pipeline Contract fix (pipeline-contract.cascade-failure)" -f ($(if ($hasPipeline) { '[ ]' } else { '[x]' })))) | Out-Null
+    $lines.Add(("{0} Hardening/tests updated for new signatures" -f ($(if ($UnknownCount -gt 0) { '[ ]' } else { '[x]' })))) | Out-Null
+    $lines.Add('') | Out-Null
+
+    if ($UnknownCount -gt 0) {
+        $lines.Add('### Unknown Incidents') | Out-Null
+        $lines.Add('') | Out-Null
+        $unknownIncidents = @($Incidents | Where-Object { $_.classification -eq 'unknown' })
+        foreach ($incident in $unknownIncidents) {
+            $lines.Add("- $($incident.job): no signature matched.") | Out-Null
+        }
+        $lines.Add('') | Out-Null
+    }
+
+    $lines.Add('<!-- ci-debt-train:v1 -->') | Out-Null
+    return ($lines -join [Environment]::NewLine) + [Environment]::NewLine
+}
+
+function Invoke-CiDebtAnalysis {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Repo,
+
+        [Parameter(Mandatory = $false)]
+        [long]$RunId,
+
+        [Parameter(Mandatory = $false)]
+        [string]$OutJson,
+
+        [Parameter(Mandatory = $false)]
+        [string]$OutMarkdown,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SignaturePath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$FixturePath,
+
+        [switch]$FailOnUnknown
+    )
+
+    $repoRoot = Resolve-CiDebtRepoRoot
+    $repoName = Resolve-CiDebtRepoName -RepoOverride $Repo
+    $resolvedSignaturePath = if (-not [string]::IsNullOrWhiteSpace($SignaturePath)) {
+        $SignaturePath
+    } else {
+        Join-Path $repoRoot 'Tooling\agents\ci-debt\signatures.json'
+    }
+    $signatures = Load-CiDebtSignatures -Path $resolvedSignaturePath
+
+    $runPayload = if (-not [string]::IsNullOrWhiteSpace($FixturePath)) {
+        Get-CiDebtRunFromFixture -Path $FixturePath
+    } else {
+        Get-CiDebtRunFromGh -RepoName $repoName -RunIdentifier $RunId
+    }
+
+    $run = $runPayload.run
+    $jobs = @($runPayload.jobs)
+    $actionableConclusions = @('failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure')
+    $failedJobs = @(
+        $jobs | Where-Object {
+            $conclusion = [string]$_.conclusion
+            -not [string]::IsNullOrWhiteSpace($conclusion) -and $actionableConclusions -contains $conclusion.ToLowerInvariant()
+        }
+    )
+
+    $incidents = New-Object System.Collections.Generic.List[object]
+    foreach ($job in $failedJobs) {
+        $jobName = [string]$job.name
+        $jobLog = [string]$job.log
+        $match = Find-CiDebtSignatureMatch -JobName $jobName -LogText $jobLog -Signatures $signatures
+
+        if ($match) {
+            $signature = $match.Signature
+            $incidents.Add([pscustomobject]@{
+                id = [string]$signature.id
+                job = $jobName
+                job_id = [long]$job.databaseId
+                status = [string]$job.status
+                conclusion = [string]$job.conclusion
+                classification = [string]$signature.classification
+                severity = [string]$signature.severity
+                matched_fragments = @($match.MatchedFragments)
+                recommended_actions = @($signature.recommendedActions)
+                preventive_check = [string]$signature.preventiveCheck
+            }) | Out-Null
+            continue
+        }
+
+        $incidents.Add([pscustomobject]@{
+            id = 'unknown'
+            job = $jobName
+            job_id = [long]$job.databaseId
+            status = [string]$job.status
+            conclusion = [string]$job.conclusion
+            classification = 'unknown'
+            severity = 'unknown'
+            matched_fragments = @()
+            recommended_actions = @(
+                'Add a deterministic signature in Tooling/agents/ci-debt/signatures.json.',
+                'Add a fixture and playbook entry in the remediation PR.'
+            )
+            preventive_check = 'CI Debt Policy Gate / Root Cause Contract'
+        }) | Out-Null
+    }
+
+    $unknownIncidents = @($incidents | Where-Object { $_.classification -eq 'unknown' })
+    $unknownCount = $unknownIncidents.Count
+    $incidentArray = $incidents.ToArray()
+    $openSignatureIds = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($incident in $incidentArray) {
+        $incidentId = [string]$incident.id
+        if (-not [string]::IsNullOrWhiteSpace($incidentId) -and $incidentId -ne 'unknown') {
+            $openSignatureIds.Add($incidentId) | Out-Null
+        }
+    }
+    $openSignatureCount = $openSignatureIds.Count
+
+    $runIdentifier = [long]$run.databaseId
+    $resolvedJson = Resolve-CiDebtOutPath -RepoRoot $repoRoot -RunIdentifier $runIdentifier -OutPath $OutJson -Extension 'json'
+    $resolvedMarkdown = Resolve-CiDebtOutPath -RepoRoot $repoRoot -RunIdentifier $runIdentifier -OutPath $OutMarkdown -Extension 'md'
+    Ensure-CiDebtParentDirectory -Path $resolvedJson
+    Ensure-CiDebtParentDirectory -Path $resolvedMarkdown
+
+    $analysis = [ordered]@{
+        schema_version = '1.0'
+        generated_utc = (Get-Date).ToUniversalTime().ToString('o')
+        repository = $repoName
+        run = [ordered]@{
+            id = $runIdentifier
+            workflow_name = [string]$run.workflowName
+            name = [string]$run.name
+            url = [string]$run.url
+            status = [string]$run.status
+            conclusion = [string]$run.conclusion
+            event = [string]$run.event
+            head_branch = [string]$run.headBranch
+            head_sha = [string]$run.headSha
+            created_at = [string]$run.createdAt
+            updated_at = [string]$run.updatedAt
+        }
+        failed_job_count = $failedJobs.Count
+        incident_count = $incidentArray.Count
+        unknown_incident_count = $unknownCount
+        open_signature_count = $openSignatureCount
+        incidents = $incidentArray
+    }
+
+    $analysis | ConvertTo-Json -Depth 10 | Out-File -FilePath $resolvedJson -Encoding utf8
+    $markdown = New-CiDebtMarkdown -Run $run -Incidents $incidentArray -UnknownCount $unknownCount
+    $markdown | Out-File -FilePath $resolvedMarkdown -Encoding utf8
+
+    Write-Host ("CI debt analysis written to: {0}" -f $resolvedJson)
+    Write-Host ("CI debt markdown written to: {0}" -f $resolvedMarkdown)
+    Write-Host ("Incidents: {0}; Unknown: {1}" -f $incidentArray.Count, $unknownCount)
+
+    if ($FailOnUnknown -and $unknownCount -gt 0) {
+        throw ("Unknown CI debt incidents detected: {0}" -f $unknownCount)
+    }
+
+    return [pscustomobject]@{
+        Repo = $repoName
+        RunId = $runIdentifier
+        OutJson = $resolvedJson
+        OutMarkdown = $resolvedMarkdown
+        IncidentCount = $incidentArray.Count
+        UnknownIncidentCount = $unknownCount
+    }
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-CiDebtAnalysis @PSBoundParameters | Out-Null
+}

--- a/Tooling/agents/ci-debt/Test-CiDebtPolicyGate.ps1
+++ b/Tooling/agents/ci-debt/Test-CiDebtPolicyGate.ps1
@@ -1,0 +1,202 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('warn', 'enforce')]
+    [string]$Mode
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-CiDebtRepoRoot {
+    param([string]$PathOverride)
+
+    if (-not [string]::IsNullOrWhiteSpace($PathOverride)) {
+        return (Resolve-Path -Path $PathOverride -ErrorAction Stop).Path
+    }
+
+    $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $PSCommandPath }
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($git) {
+        try {
+            $gitRoot = git -C $scriptRoot rev-parse --show-toplevel 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitRoot)) {
+                return (Resolve-Path -Path $gitRoot.Trim() -ErrorAction Stop).Path
+            }
+        } catch {
+            Write-Verbose ("git rev-parse failed: {0}" -f $_.Exception.Message)
+        }
+    }
+
+    return (Resolve-Path -Path (Join-Path $scriptRoot '..\..\..') -ErrorAction Stop).Path
+}
+
+function Resolve-PolicyMode {
+    param([string]$ModeOverride)
+
+    if (-not [string]::IsNullOrWhiteSpace($ModeOverride)) {
+        return $ModeOverride
+    }
+
+    $envMode = [string]$env:CI_DEBT_POLICY_MODE
+    if (-not [string]::IsNullOrWhiteSpace($envMode)) {
+        $normalized = $envMode.Trim().ToLowerInvariant()
+        if ($normalized -in @('warn', 'enforce')) {
+            return $normalized
+        }
+    }
+
+    $enforceAfter = [string]$env:CI_DEBT_POLICY_ENFORCE_AFTER_UTC
+    if ([string]::IsNullOrWhiteSpace($enforceAfter)) {
+        $enforceAfter = '2026-02-19T00:00:00Z'
+    }
+
+    $enforceAfterUtc = [DateTimeOffset]::Parse($enforceAfter)
+    if ([DateTimeOffset]::UtcNow -ge $enforceAfterUtc) {
+        return 'enforce'
+    }
+
+    return 'warn'
+}
+
+function Add-Finding {
+    param(
+        [System.Collections.Generic.List[object]]$Findings,
+        [string]$Rule,
+        [string]$File,
+        [string]$Message
+    )
+
+    $Findings.Add([pscustomobject]@{
+        Rule = $Rule
+        File = $File
+        Message = $Message
+    }) | Out-Null
+}
+
+function Test-ForbidPattern {
+    param(
+        [string]$Root,
+        [string]$RelativePath,
+        [string]$Pattern,
+        [string]$Rule,
+        [string]$Message,
+        [System.Collections.Generic.List[object]]$Findings
+    )
+
+    $path = Join-Path $Root $RelativePath
+    if (-not (Test-Path -Path $path)) {
+        Add-Finding -Findings $Findings -Rule "$Rule.missing-file" -File $RelativePath -Message 'Expected file is missing.'
+        return
+    }
+
+    $lineNumber = 0
+    Get-Content -Path $path | ForEach-Object {
+        $lineNumber++
+        if ($_ -match $Pattern) {
+            Add-Finding -Findings $Findings -Rule $Rule -File ("{0}:{1}" -f $RelativePath, $lineNumber) -Message $Message
+        }
+    }
+}
+
+function Test-RequirePattern {
+    param(
+        [string]$Root,
+        [string]$RelativePath,
+        [string]$Pattern,
+        [string]$Rule,
+        [string]$Message,
+        [System.Collections.Generic.List[object]]$Findings
+    )
+
+    $path = Join-Path $Root $RelativePath
+    if (-not (Test-Path -Path $path)) {
+        Add-Finding -Findings $Findings -Rule "$Rule.missing-file" -File $RelativePath -Message 'Expected file is missing.'
+        return
+    }
+
+    $raw = Get-Content -Path $path -Raw
+    if ($raw -notmatch $Pattern) {
+        Add-Finding -Findings $Findings -Rule $Rule -File $RelativePath -Message $Message
+    }
+}
+
+$resolvedRoot = Resolve-CiDebtRepoRoot -PathOverride $RepoRoot
+$policyMode = Resolve-PolicyMode -ModeOverride $Mode
+$findings = New-Object System.Collections.Generic.List[object]
+
+$criticalScripts = @(
+    'Tooling/Invoke-PSScriptAnalyzer.ps1',
+    'Tooling/New-CIWorktree.ps1',
+    'Tooling/New-CIWorktreeForJob.ps1',
+    'Tooling/Invoke-MissingIEFilesFromLVInstall.ps1'
+)
+
+foreach ($scriptPath in $criticalScripts) {
+    Test-ForbidPattern `
+        -Root $resolvedRoot `
+        -RelativePath $scriptPath `
+        -Pattern 'Enable-GitKrakenGitShim\s+-Require(?!:)' `
+        -Rule 'fatal-gk-assumption' `
+        -Message "Critical scripts must not hard-require gk without a fallback guard." `
+        -Findings $findings
+}
+
+Test-RequirePattern `
+    -Root $resolvedRoot `
+    -RelativePath '.github/workflows/ci-composite.yml' `
+    -Pattern 'Capture VerifyIEPaths diagnostics' `
+    -Rule 'verify-iepaths-diagnostics-contract' `
+    -Message "ci-composite must emit explicit Verify IE Paths setup diagnostics." `
+    -Findings $findings
+
+Test-RequirePattern `
+    -Root $resolvedRoot `
+    -RelativePath '.github/workflows/ci-composite.yml' `
+    -Pattern 'Required job verdict:' `
+    -Rule 'pipeline-contract-verdict-contract' `
+    -Message "Pipeline Contract must emit required-job verdict output." `
+    -Findings $findings
+
+Test-RequirePattern `
+    -Root $resolvedRoot `
+    -RelativePath '.github/workflows/ci-composite.yml' `
+    -Pattern 'Root-cause failures:' `
+    -Rule 'pipeline-contract-root-cause-contract' `
+    -Message "Pipeline Contract must emit root-cause failure output." `
+    -Findings $findings
+
+$summaryLines = @(
+    "## CI Debt Policy Gate",
+    "",
+    "- Mode: $policyMode",
+    "- Findings: $($findings.Count)",
+    ""
+)
+
+if ($findings.Count -gt 0) {
+    $summaryLines += "### Findings"
+    foreach ($finding in $findings) {
+        $summaryLines += "- [$($finding.Rule)] $($finding.File): $($finding.Message)"
+    }
+} else {
+    $summaryLines += "No policy findings detected."
+}
+$summaryLines += ""
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+    $summaryLines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+}
+
+if ($findings.Count -gt 0) {
+    if ($policyMode -eq 'enforce') {
+        throw ("CI debt policy gate failed with {0} finding(s)." -f $findings.Count)
+    }
+
+    Write-Warning ("CI debt policy gate found {0} finding(s) in warn mode." -f $findings.Count)
+} else {
+    Write-Host "CI debt policy gate passed."
+}

--- a/Tooling/agents/ci-debt/fixtures/run-21840801109.json
+++ b/Tooling/agents/ci-debt/fixtures/run-21840801109.json
@@ -1,0 +1,43 @@
+{
+  "run": {
+    "databaseId": 21840801109,
+    "workflowName": "CI Pipeline (Composite)",
+    "name": "CI Pipeline (Composite)",
+    "url": "https://github.com/svelderrainruiz/labview-icon-editor/actions/runs/21840801109",
+    "status": "completed",
+    "conclusion": "failure",
+    "event": "pull_request",
+    "headBranch": "tooling/repo-agnostic-issue-routing",
+    "headSha": "0000000000000000000000000000000000000000"
+  },
+  "jobs": [
+    {
+      "databaseId": 63024287085,
+      "name": "PowerShell Lint",
+      "status": "completed",
+      "conclusion": "failure",
+      "log": "Exception: GitKraken CLI 'gk' not found. Install it or add it to PATH."
+    },
+    {
+      "databaseId": 63024513106,
+      "name": "Verify IE Paths Gate (LV 64-bit)",
+      "status": "completed",
+      "conclusion": "failure",
+      "log": "Job setup failed. runner-cli not found; using PowerShell fallback. Process completed with exit code 1."
+    },
+    {
+      "databaseId": 63024513120,
+      "name": "Verify IE Paths Gate (LV 32-bit)",
+      "status": "completed",
+      "conclusion": "failure",
+      "log": "Job setup failed. runner-cli not found; using PowerShell fallback. Process completed with exit code 1."
+    },
+    {
+      "databaseId": 63024631666,
+      "name": "Pipeline Contract",
+      "status": "completed",
+      "conclusion": "failure",
+      "log": "Write-Error (\"Pipeline contract failed: powershell-lint:failure, dev-mode-gate:failure\")"
+    }
+  ]
+}

--- a/Tooling/agents/ci-debt/playbook.md
+++ b/Tooling/agents/ci-debt/playbook.md
@@ -1,0 +1,30 @@
+# CI Debt Remediation Playbook
+
+This playbook is the deterministic remediation guide used by CI debt analysis.
+
+## Signature: `powershell-lint.gk-missing`
+- Symptom: `PowerShell Lint` fails with `GitKraken CLI 'gk' not found`.
+- Detection rule: Job contains one of the signature fragments in `signatures.json`.
+- Fix: Keep `gk` optional by default and use system `git` fallback unless `LVIE_REQUIRE_GITKRAKEN_CLI=1`.
+- Prevention: `CI Debt Policy Gate / Root Cause Contract` rejects strict-only `gk` assumptions in critical scripts.
+
+## Signature: `verify-iepaths.setup-failed`
+- Symptom: `Verify IE Paths Gate` fails during setup and no clear reason is surfaced.
+- Detection rule: Setup/fallback/exit fragments detected in the gate job log.
+- Fix: Emit classified setup diagnostics and always upload `verify-iepaths` artifact.
+- Prevention: `CI Debt Policy Gate / Root Cause Contract` requires setup diagnostics contract in `ci-composite.yml`.
+
+## Signature: `pipeline-contract.cascade-failure`
+- Symptom: `Pipeline Contract` fails with mixed root cause and cascaded statuses in one opaque line.
+- Detection rule: Contract failure fragments plus upstream failure references.
+- Fix: Emit `Required job verdict`, `Root-cause failures`, and `Cascaded/skipped jobs` explicitly.
+- Prevention: `CI Debt Policy Gate / Root Cause Contract` validates contract output markers in workflow definition.
+
+## Training Loop
+1. Capture run evidence (`Invoke-CiDebtAnalysis.ps1`) for failing run IDs.
+2. Match incidents against signatures.
+3. If an incident is unknown, add:
+- one new signature entry,
+- one fixture update,
+- one playbook entry.
+4. Re-run fixture tests before closing remediation PR.

--- a/Tooling/agents/ci-debt/signatures.json
+++ b/Tooling/agents/ci-debt/signatures.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0",
+  "signatures": [
+    {
+      "id": "powershell-lint.gk-missing",
+      "job": "PowerShell Lint",
+      "containsAny": [
+        "GitKraken CLI 'gk' not found",
+        "Enable-GitKrakenGitShim -Require",
+        "GitKraken CLI helper not found"
+      ],
+      "classification": "fatal-tool-dependency",
+      "severity": "high",
+      "recommendedActions": [
+        "Make gk optional by default and fall back to system git unless explicitly required.",
+        "Use LVIE_REQUIRE_GITKRAKEN_CLI=1 only on call paths that truly require gk behavior."
+      ],
+      "preventiveCheck": "CI Debt Policy Gate / Root Cause Contract"
+    },
+    {
+      "id": "verify-iepaths.setup-failed",
+      "job": "Verify IE Paths Gate",
+      "containsAny": [
+        "Job setup",
+        "runner-cli not found; using PowerShell fallback.",
+        "Process completed with exit code 1"
+      ],
+      "classification": "setup-failure",
+      "severity": "high",
+      "recommendedActions": [
+        "Emit explicit Verify IE Paths setup diagnostics with classification and hints.",
+        "Always upload verify-iepaths diagnostics artifacts even when setup fails."
+      ],
+      "preventiveCheck": "CI Debt Policy Gate / Root Cause Contract"
+    },
+    {
+      "id": "pipeline-contract.cascade-failure",
+      "job": "Pipeline Contract",
+      "containsAny": [
+        "Pipeline contract failed:",
+        "powershell-lint:failure",
+        "dev-mode-gate:failure"
+      ],
+      "classification": "cascaded-contract-failure",
+      "severity": "medium",
+      "recommendedActions": [
+        "Separate root-cause failures from cascaded/skipped jobs in pipeline contract output.",
+        "Emit required-job verdict plus root-cause list to speed remediation."
+      ],
+      "preventiveCheck": "CI Debt Policy Gate / Root Cause Contract"
+    }
+  ]
+}

--- a/Tooling/tests/CiDebtAnalysis.Tests.ps1
+++ b/Tooling/tests/CiDebtAnalysis.Tests.ps1
@@ -1,0 +1,76 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+BeforeAll {
+    $Script:ToolingRoot = Split-Path -Parent $PSScriptRoot
+    $Script:AnalysisScript = Join-Path $Script:ToolingRoot 'agents/ci-debt/Invoke-CiDebtAnalysis.ps1'
+    $Script:FixturePath = Join-Path $Script:ToolingRoot 'agents/ci-debt/fixtures/run-21840801109.json'
+
+    . $Script:AnalysisScript
+}
+
+Describe 'Invoke-CiDebtAnalysis' {
+    It 'maps fixture run 21840801109 to known signatures' {
+        $outJson = Join-Path $TestDrive 'analysis.json'
+        $outMarkdown = Join-Path $TestDrive 'analysis.md'
+
+        $result = Invoke-CiDebtAnalysis `
+            -Repo 'example/labview-icon-editor' `
+            -RunId 21840801109 `
+            -FixturePath $Script:FixturePath `
+            -OutJson $outJson `
+            -OutMarkdown $outMarkdown
+
+        $result.IncidentCount | Should -Be 4
+        $result.UnknownIncidentCount | Should -Be 0
+        $outJson | Should -Exist
+        $outMarkdown | Should -Exist
+
+        $analysis = Get-Content -Path $outJson -Raw | ConvertFrom-Json
+        $incidentIds = @($analysis.incidents | ForEach-Object { $_.id })
+        $incidentIds | Should -Contain 'powershell-lint.gk-missing'
+        $incidentIds | Should -Contain 'verify-iepaths.setup-failed'
+        $incidentIds | Should -Contain 'pipeline-contract.cascade-failure'
+        $analysis.unknown_incident_count | Should -Be 0
+    }
+
+    It 'fails when unknown incidents exist and FailOnUnknown is set' {
+        $unknownFixture = Join-Path $TestDrive 'unknown-fixture.json'
+        @'
+{
+  "run": {
+    "databaseId": 123456,
+    "workflowName": "CI Pipeline (Composite)",
+    "url": "https://example.invalid/run/123456",
+    "status": "completed",
+    "conclusion": "failure",
+    "event": "pull_request",
+    "headBranch": "feature/x",
+    "headSha": "abc"
+  },
+  "jobs": [
+    {
+      "databaseId": 101,
+      "name": "Custom Failure Job",
+      "status": "completed",
+      "conclusion": "failure",
+      "log": "This is a new failure pattern not covered by signatures."
+    }
+  ]
+}
+'@ | Out-File -FilePath $unknownFixture -Encoding utf8
+
+        $outJson = Join-Path $TestDrive 'analysis-unknown.json'
+        $outMarkdown = Join-Path $TestDrive 'analysis-unknown.md'
+
+        {
+            Invoke-CiDebtAnalysis `
+                -Repo 'example/labview-icon-editor' `
+                -RunId 123456 `
+                -FixturePath $unknownFixture `
+                -OutJson $outJson `
+                -OutMarkdown $outMarkdown `
+                -FailOnUnknown
+        } | Should -Throw '*Unknown CI debt incidents detected*'
+    }
+}

--- a/docs/ci/actions/maintainers-guide.md
+++ b/docs/ci/actions/maintainers-guide.md
@@ -87,8 +87,9 @@ Debug-only/manual validation:
 - Alias retirement is documented but not auto-enforced in this phase.
 - Use `labels-sync.yml` to create/update contract labels from
   `.github/labels/label-contract.json`.
-- For fork operations, pin `gh` to `svelderrainruiz/labview-icon-editor` (or set
-  `GH_REPO`) so metadata commands do not target upstream.
+- Resolve the repository for `gh` commands:
+  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  - `GH_REPO` is optional override when maintainers need to target a specific repo.
 
 ## Label Metadata Automation
 


### PR DESCRIPTION
## Summary\n- set job-level GH_TOKEN in ci-debt-train workflow\n- allow Invoke-CiDebtAnalysis to call gh in GitHub Actions workflow_dispatch runs\n\n## Validation\n- ci-debt-policy-gate workflow_dispatch on develop succeeded\n- will re-run ci-debt-train after merge