### PR TITLE
Fix ci-debt-train GH token for workflow dispatch

### DIFF
--- a/.github/workflows/ci-debt-train.yml
+++ b/.github/workflows/ci-debt-train.yml
@@ -29,6 +29,8 @@ jobs:
   analyze:
     name: Analyze CI Debt Run
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary\n- set job-level GH_TOKEN in ci-debt-train workflow\n- allow Invoke-CiDebtAnalysis to call gh in GitHub Actions workflow_dispatch runs\n\n## Validation\n- will re-run ci-debt-train after merge