### PR TITLE
Fix repo resolution routing and unblock Issue 74 CI debt failures

### DIFF
--- a/.github/workflows/ci-debt-policy-gate.yml
+++ b/.github/workflows/ci-debt-policy-gate.yml
@@ -36,3 +36,14 @@ jobs:
         shell: pwsh
         run: |
           pwsh -NoProfile -File "$env:GITHUB_WORKSPACE\Tooling\agents\ci-debt\Test-CiDebtPolicyGate.ps1"
+
+      - name: Validate repo-agnostic issue/discussion routing guard
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File "$env:GITHUB_WORKSPACE\Tooling\Test-RepoAgnosticIssueRouting.ps1"
+
+      - name: Run repository resolver tests
+        shell: pwsh
+        run: |
+          $testPath = Join-Path $env:GITHUB_WORKSPACE 'Tooling\tests\ResolveGitHubRepo.Tests.ps1'
+          Invoke-Pester -Path $testPath -Output Detailed

--- a/.github/workflows/repo-agnostic-issue-routing.yml
+++ b/.github/workflows/repo-agnostic-issue-routing.yml
@@ -22,3 +22,8 @@ jobs:
         shell: pwsh
         run: |
           pwsh -NoProfile -File .\Tooling\Test-RepoAgnosticIssueRouting.ps1
+
+      - name: Run repository resolver tests
+        shell: pwsh
+        run: |
+          Invoke-Pester -Path .\Tooling\tests\ResolveGitHubRepo.Tests.ps1 -Output Detailed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ This repository uses LabVIEW, g-cli, and PowerShell tooling. Follow the steps be
 - Confirm `g-cli` is available:
   - `g-cli --version`
 - Resolve the current repository for `gh` commands:
-  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
-  - `GH_REPO` is an optional override.
+  - `$repo = pwsh -NoProfile -File .\Tooling\Resolve-GitHubRepo.ps1`
+  - `GH_REPO` is an optional override and takes precedence when set.
 - If you need to open a PR from the current branch, use `gh`:
   - Default template: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
   - Draft PR: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md --draft`
@@ -23,7 +23,7 @@ This repository uses LabVIEW, g-cli, and PowerShell tooling. Follow the steps be
 ## Repo-Agnostic Issue/Discussion Policy
 - Issue and discussion actions operate on the repository currently being worked in.
 - Use this command before issue/PR/workflow operations:
-  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  - `$repo = pwsh -NoProfile -File .\Tooling\Resolve-GitHubRepo.ps1`
 - Examples:
   - Create issue: `gh issue create --repo $repo --template "Bug Report"`
   - Create PR: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
@@ -41,7 +41,7 @@ This repository uses LabVIEW, g-cli, and PowerShell tooling. Follow the steps be
   - Documentation update: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/documentation.md`
   - Infrastructure change: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/infrastructure_change.md`
 - Web fallback links:
-  - Resolve repository URL: `$repoUrl = gh repo view --repo $repo --json url --jq .url`
+  - Resolve repository URL: `$repoUrl = gh repo view $repo --json url --jq .url`
   - Issues: `"$repoUrl/issues/new/choose"`
   - Bug form: `"$repoUrl/issues/new?template=bug_report.yml"`
   - Feature form: `"$repoUrl/issues/new?template=feature_request.yml"`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ This repo follows a typical fork-and-pull model on [GitHub](https://github.com/n
 We welcome both code and non-code contributions. Here are some ways to help:
 
 For command examples below, resolve your current repository once:
-- `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+- `$repo = pwsh -NoProfile -File .\Tooling\Resolve-GitHubRepo.ps1`
+- `GH_REPO` is an optional override and takes precedence when set.
 
 - 🐛 **Bug Reports:** We can’t catch every issue. If you find a bug, first search issues in the current repository (`gh issue list --repo $repo --state open --limit 200`). If not reported, open a new issue with the bug template (`gh issue create --repo $repo --template "Bug Report"`).
 - 💬 **Q&A and Feedback:** Participate in discussions. If you have an idea for a new feature or changes, open Discussions in the current repository (Discussions tab) or join the community on [Discord](https://discord.gg/q4d3ggrFVA).

--- a/Tooling/Ensure-RunnerCli.ps1
+++ b/Tooling/Ensure-RunnerCli.ps1
@@ -46,7 +46,11 @@ if (-not (Test-Path -Path $gitKrakenScript)) {
     throw "GitKraken CLI helper not found at $gitKrakenScript"
 }
 . $gitKrakenScript
-Enable-GitKrakenGitShim -Require | Out-Null
+$requireGitKraken = $env:LVIE_REQUIRE_GITKRAKEN_CLI -eq '1'
+$gitKrakenEnabled = Enable-GitKrakenGitShim -Require:$requireGitKraken
+if (-not $gitKrakenEnabled) {
+    Write-Warning "GitKraken CLI 'gk' not found. Using system git. Set LVIE_REQUIRE_GITKRAKEN_CLI=1 to enforce gk."
+}
 $requireEnabled = $Require.IsPresent -or ($env:LVIE_REQUIRE_RUNNER_CLI -eq '1')
 $skipBuildEnabled = $SkipBuild.IsPresent -or ($env:LVIE_RUNNER_CLI_SKIP_BUILD -eq '1')
 $skipDownloadEnabled = $SkipDownload.IsPresent -or ($env:LVIE_RUNNER_CLI_SKIP_DOWNLOAD -eq '1')

--- a/Tooling/Invoke-Preflight.ps1
+++ b/Tooling/Invoke-Preflight.ps1
@@ -13,7 +13,11 @@ if (-not (Test-Path -Path $gitKrakenScript)) {
     throw "GitKraken CLI helper not found at $gitKrakenScript"
 }
 . $gitKrakenScript
-Enable-GitKrakenGitShim -Require | Out-Null
+$requireGitKraken = $env:LVIE_REQUIRE_GITKRAKEN_CLI -eq '1'
+$gitKrakenEnabled = Enable-GitKrakenGitShim -Require:$requireGitKraken
+if (-not $gitKrakenEnabled) {
+    Write-Warning "GitKraken CLI 'gk' not found. Using system git. Set LVIE_REQUIRE_GITKRAKEN_CLI=1 to enforce gk."
+}
 
 function Convert-BoundParametersToArgumentList {
     param(

--- a/Tooling/README.md
+++ b/Tooling/README.md
@@ -3,6 +3,11 @@
 This folder contains PowerShell scripts used for local CI parity, packaging, and developer workflows.
 
 Common entrypoints:
+- `Resolve-GitHubRepo.ps1`
+  Resolves the current GitHub repository as `owner/name` without relying on `gh repo view` auto-resolution.
+  Precedence: `-Repo` argument, `GH_REPO` env var, then `origin` remote URL.
+  Example: `pwsh -NoProfile -File .\\Tooling\\Resolve-GitHubRepo.ps1`
+  Optional shell hygiene: `pwsh -NoProfile -File .\\Tooling\\Resolve-GitHubRepo.ps1 -SetGhDefault`
 - `Run-ViValidate.ps1`  
   Runs the fast pylavi `vi_validate` gate only. Uses `.lvversion` as the canonical LabVIEW version.  
   Example: `pwsh -NoProfile -File .\\Tooling\\Run-ViValidate.ps1`  
@@ -20,7 +25,8 @@ Common entrypoints:
   Example: `pwsh -NoProfile -File .\\Tooling\\Invoke-WorktreeOrchestrator.ps1 -Run -RunArgs -LabVIEWVersion 2021 -EnsureCleanState`
 - `gh pr create` (recommended for opening PRs)
   Opens a GitHub PR for the current branch with the desired template.
-  Resolve repo: `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
+  Resolve repo: `$repo = pwsh -NoProfile -File .\\Tooling\\Resolve-GitHubRepo.ps1`
+  `GH_REPO` is an optional override and takes precedence when set.
   Example: `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE.md`
   Specialized templates:
   `gh pr create --repo $repo --base develop -T .github/PULL_REQUEST_TEMPLATE/bug_fix.md`
@@ -71,8 +77,8 @@ Issue-type labels:
 
 ## Local GitHub Auth and Fork Remotes
 
-Tooling expects GitKraken CLI (`gk`) to be available and routes git calls through it.
-If `gk` is missing, scripts will fail fast.
+Most tooling can fall back to system `git` when GitKraken CLI (`gk`) is missing.
+Set `LVIE_REQUIRE_GITKRAKEN_CLI=1` only when a call path must require `gk`.
 
 Some tooling fetches GitHub artifacts or queries workflow runs. Configure auth and ensure your fork remotes are correct.
 

--- a/Tooling/Resolve-GitHubRepo.ps1
+++ b/Tooling/Resolve-GitHubRepo.ps1
@@ -1,0 +1,111 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Repo,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteName = 'origin',
+
+    [switch]$SetGhDefault
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRootPath {
+    param([string]$PathOverride)
+
+    if (-not [string]::IsNullOrWhiteSpace($PathOverride)) {
+        return (Resolve-Path -Path $PathOverride -ErrorAction Stop).Path
+    }
+
+    $scriptRoot = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $PSCommandPath }
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($git) {
+        try {
+            $gitRoot = git -C $scriptRoot rev-parse --show-toplevel 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gitRoot)) {
+                return (Resolve-Path -Path $gitRoot.Trim() -ErrorAction Stop).Path
+            }
+        } catch {
+            Write-Verbose ("git rev-parse failed: {0}" -f $_.Exception.Message)
+        }
+    }
+
+    return (Resolve-Path -Path (Join-Path $scriptRoot '..') -ErrorAction Stop).Path
+}
+
+function ConvertTo-OwnerRepo {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Value,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Source
+    )
+
+    $trimmed = $Value.Trim()
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+        throw ("Repository value from {0} was empty." -f $Source)
+    }
+
+    $ownerRepoPattern = '^(?<owner>[A-Za-z0-9_.-]+)/(?<name>[A-Za-z0-9_.-]+)$'
+    if ($trimmed -match $ownerRepoPattern) {
+        return ("{0}/{1}" -f $Matches.owner, $Matches.name)
+    }
+
+    $urlPattern = '^(?:https://|ssh://git@|git@)github\.com[:/](?<owner>[A-Za-z0-9_.-]+)/(?<name>[A-Za-z0-9_.-]+?)(?:\.git)?/?$'
+    if ($trimmed -match $urlPattern) {
+        return ("{0}/{1}" -f $Matches.owner, $Matches.name)
+    }
+
+    throw ("Repository value from {0} was not in owner/name or GitHub URL format: {1}" -f $Source, $trimmed)
+}
+
+function Resolve-RepositoryName {
+    param(
+        [string]$RepoOverride,
+        [string]$RootPath,
+        [string]$Remote
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RepoOverride)) {
+        return ConvertTo-OwnerRepo -Value $RepoOverride -Source '-Repo'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GH_REPO)) {
+        return ConvertTo-OwnerRepo -Value $env:GH_REPO -Source 'GH_REPO'
+    }
+
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if (-not $git) {
+        throw "git is required to resolve repository from the '$Remote' remote."
+    }
+
+    $remoteUrl = git -C $RootPath remote get-url $Remote 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($remoteUrl)) {
+        throw ("Failed to resolve git remote URL for '{0}' in '{1}'." -f $Remote, $RootPath)
+    }
+
+    return ConvertTo-OwnerRepo -Value $remoteUrl.Trim() -Source ("git remote '{0}'" -f $Remote)
+}
+
+$resolvedRoot = Resolve-RepoRootPath -PathOverride $RepoRoot
+$resolvedRepo = Resolve-RepositoryName -RepoOverride $Repo -RootPath $resolvedRoot -Remote $RemoteName
+
+if ($SetGhDefault) {
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) {
+        throw "gh CLI is required for -SetGhDefault."
+    }
+
+    & gh repo set-default $resolvedRepo | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Failed to set gh default repository to '{0}'." -f $resolvedRepo)
+    }
+}
+
+Write-Output $resolvedRepo

--- a/Tooling/Test-RepoAgnosticIssueRouting.ps1
+++ b/Tooling/Test-RepoAgnosticIssueRouting.ps1
@@ -76,6 +76,11 @@ $rules = @(
         Id = 'fixed-repo-flag-fork'
         Pattern = '--repo\s+svelderrainruiz/labview-icon-editor'
         Message = 'Fixed --repo target is not allowed. Resolve current repository first and use --repo $repo.'
+    },
+    [pscustomobject]@{
+        Id = 'gh-repo-view-auto-resolution'
+        Pattern = 'gh repo view --json nameWithOwner --jq \.nameWithOwner'
+        Message = 'gh repo view auto-resolution is not allowed. Use Tooling/Resolve-GitHubRepo.ps1.'
     }
 )
 

--- a/Tooling/agents/ci-debt/Invoke-CiDebtAnalysis.ps1
+++ b/Tooling/agents/ci-debt/Invoke-CiDebtAnalysis.ps1
@@ -42,24 +42,23 @@ function Resolve-CiDebtRepoRoot {
 }
 
 function Resolve-CiDebtRepoName {
-    param([string]$RepoOverride)
+    param(
+        [string]$RepoOverride,
+        [string]$RepoRoot
+    )
 
-    if (-not [string]::IsNullOrWhiteSpace($RepoOverride)) {
-        return $RepoOverride.Trim()
+    $resolverScript = Join-Path $RepoRoot 'Tooling\Resolve-GitHubRepo.ps1'
+    if (-not (Test-Path -Path $resolverScript)) {
+        throw "Repository resolver script not found at $resolverScript"
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($env:GH_REPO)) {
-        return $env:GH_REPO.Trim()
+    $resolved = if (-not [string]::IsNullOrWhiteSpace($RepoOverride)) {
+        & $resolverScript -Repo $RepoOverride -RepoRoot $RepoRoot
+    } else {
+        & $resolverScript -RepoRoot $RepoRoot
     }
-
-    $gh = Get-Command gh -ErrorAction SilentlyContinue
-    if (-not $gh) {
-        throw "Unable to resolve repository: gh CLI not found and GH_REPO not set."
-    }
-
-    $resolved = gh repo view --json nameWithOwner --jq .nameWithOwner 2>$null
     if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($resolved)) {
-        throw "Unable to resolve repository via gh repo view."
+        throw "Unable to resolve repository via Tooling/Resolve-GitHubRepo.ps1."
     }
 
     return $resolved.Trim()
@@ -81,7 +80,7 @@ function Resolve-CiDebtOutPath {
     return Join-Path $RepoRoot ("TestResults\agent-logs\ci-debt\{0}" -f $fileName)
 }
 
-function Ensure-CiDebtParentDirectory {
+function Initialize-CiDebtParentDirectory {
     param([string]$Path)
     $parent = Split-Path -Path $Path -Parent
     if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -Path $parent)) {
@@ -89,7 +88,7 @@ function Ensure-CiDebtParentDirectory {
     }
 }
 
-function Load-CiDebtSignatures {
+function Get-CiDebtSignatureTable {
     param([string]$Path)
 
     if (-not (Test-Path -Path $Path)) {
@@ -273,13 +272,13 @@ function New-CiDebtMarkdown {
     $lines.Add('') | Out-Null
 
     $signatureIds = @($Incidents | ForEach-Object { $_.id })
-    $hasLint = $signatureIds -contains 'powershell-lint.gk-missing'
+    $hasLint = ($signatureIds -contains 'powershell-lint.gk-missing') -or ($signatureIds -contains 'powershell-lint.new-issues')
     $hasVerify = $signatureIds -contains 'verify-iepaths.setup-failed'
     $hasPipeline = $signatureIds -contains 'pipeline-contract.cascade-failure'
 
     $lines.Add('### Issue #74 Checklist') | Out-Null
     $lines.Add('') | Out-Null
-    $lines.Add(("{0} Lint fix (powershell-lint.gk-missing)" -f ($(if ($hasLint) { '[ ]' } else { '[x]' })))) | Out-Null
+    $lines.Add(("{0} Lint fix (powershell-lint.*)" -f ($(if ($hasLint) { '[ ]' } else { '[x]' })))) | Out-Null
     $lines.Add(("{0} Verify IE Paths 64/32 fix (verify-iepaths.setup-failed)" -f ($(if ($hasVerify) { '[ ]' } else { '[x]' })))) | Out-Null
     $lines.Add(("{0} Pipeline Contract fix (pipeline-contract.cascade-failure)" -f ($(if ($hasPipeline) { '[ ]' } else { '[x]' })))) | Out-Null
     $lines.Add(("{0} Hardening/tests updated for new signatures" -f ($(if ($UnknownCount -gt 0) { '[ ]' } else { '[x]' })))) | Out-Null
@@ -324,13 +323,13 @@ function Invoke-CiDebtAnalysis {
     )
 
     $repoRoot = Resolve-CiDebtRepoRoot
-    $repoName = Resolve-CiDebtRepoName -RepoOverride $Repo
+    $repoName = Resolve-CiDebtRepoName -RepoOverride $Repo -RepoRoot $repoRoot
     $resolvedSignaturePath = if (-not [string]::IsNullOrWhiteSpace($SignaturePath)) {
         $SignaturePath
     } else {
         Join-Path $repoRoot 'Tooling\agents\ci-debt\signatures.json'
     }
-    $signatures = Load-CiDebtSignatures -Path $resolvedSignaturePath
+    $signatures = Get-CiDebtSignatureTable -Path $resolvedSignaturePath
 
     $runPayload = if (-not [string]::IsNullOrWhiteSpace($FixturePath)) {
         Get-CiDebtRunFromFixture -Path $FixturePath
@@ -403,8 +402,8 @@ function Invoke-CiDebtAnalysis {
     $runIdentifier = [long]$run.databaseId
     $resolvedJson = Resolve-CiDebtOutPath -RepoRoot $repoRoot -RunIdentifier $runIdentifier -OutPath $OutJson -Extension 'json'
     $resolvedMarkdown = Resolve-CiDebtOutPath -RepoRoot $repoRoot -RunIdentifier $runIdentifier -OutPath $OutMarkdown -Extension 'md'
-    Ensure-CiDebtParentDirectory -Path $resolvedJson
-    Ensure-CiDebtParentDirectory -Path $resolvedMarkdown
+    Initialize-CiDebtParentDirectory -Path $resolvedJson
+    Initialize-CiDebtParentDirectory -Path $resolvedMarkdown
 
     $analysis = [ordered]@{
         schema_version = '1.0'

--- a/Tooling/agents/ci-debt/Test-CiDebtPolicyGate.ps1
+++ b/Tooling/agents/ci-debt/Test-CiDebtPolicyGate.ps1
@@ -132,7 +132,8 @@ $criticalScripts = @(
     'Tooling/Invoke-PSScriptAnalyzer.ps1',
     'Tooling/New-CIWorktree.ps1',
     'Tooling/New-CIWorktreeForJob.ps1',
-    'Tooling/Invoke-MissingIEFilesFromLVInstall.ps1'
+    'Tooling/Invoke-MissingIEFilesFromLVInstall.ps1',
+    'Tooling/Invoke-Preflight.ps1'
 )
 
 foreach ($scriptPath in $criticalScripts) {

--- a/Tooling/agents/ci-debt/Test-CiDebtPolicyGate.ps1
+++ b/Tooling/agents/ci-debt/Test-CiDebtPolicyGate.ps1
@@ -133,7 +133,8 @@ $criticalScripts = @(
     'Tooling/New-CIWorktree.ps1',
     'Tooling/New-CIWorktreeForJob.ps1',
     'Tooling/Invoke-MissingIEFilesFromLVInstall.ps1',
-    'Tooling/Invoke-Preflight.ps1'
+    'Tooling/Invoke-Preflight.ps1',
+    'Tooling/Ensure-RunnerCli.ps1'
 )
 
 foreach ($scriptPath in $criticalScripts) {

--- a/Tooling/agents/ci-debt/playbook.md
+++ b/Tooling/agents/ci-debt/playbook.md
@@ -8,6 +8,12 @@ This playbook is the deterministic remediation guide used by CI debt analysis.
 - Fix: Keep `gk` optional by default and use system `git` fallback unless `LVIE_REQUIRE_GITKRAKEN_CLI=1`.
 - Prevention: `CI Debt Policy Gate / Root Cause Contract` rejects strict-only `gk` assumptions in critical scripts.
 
+## Signature: `powershell-lint.new-issues`
+- Symptom: `PowerShell Lint` reports newly introduced PSScriptAnalyzer findings.
+- Detection rule: Lint log contains `New PSScriptAnalyzer issues detected` / baseline failure fragments.
+- Fix: Rename/refactor offending functions or code paths to satisfy analyzer rules, then rerun lint.
+- Prevention: Keep analyzer-clean changes in PRs and update baseline only through approved baseline update flow.
+
 ## Signature: `verify-iepaths.setup-failed`
 - Symptom: `Verify IE Paths Gate` fails during setup and no clear reason is surfaced.
 - Detection rule: Setup/fallback/exit fragments detected in the gate job log.

--- a/Tooling/agents/ci-debt/signatures.json
+++ b/Tooling/agents/ci-debt/signatures.json
@@ -5,8 +5,7 @@
       "id": "powershell-lint.gk-missing",
       "job": "PowerShell Lint",
       "containsAny": [
-        "GitKraken CLI 'gk' not found",
-        "Enable-GitKrakenGitShim -Require",
+        "GitKraken CLI 'gk' not found. Install it or add it to PATH.",
         "GitKraken CLI helper not found"
       ],
       "classification": "fatal-tool-dependency",
@@ -14,6 +13,21 @@
       "recommendedActions": [
         "Make gk optional by default and fall back to system git unless explicitly required.",
         "Use LVIE_REQUIRE_GITKRAKEN_CLI=1 only on call paths that truly require gk behavior."
+      ],
+      "preventiveCheck": "CI Debt Policy Gate / Root Cause Contract"
+    },
+    {
+      "id": "powershell-lint.new-issues",
+      "job": "PowerShell Lint",
+      "containsAny": [
+        "New PSScriptAnalyzer issues detected:",
+        "PSScriptAnalyzer detected new issues. Update baseline or fix the findings."
+      ],
+      "classification": "lint-regression",
+      "severity": "high",
+      "recommendedActions": [
+        "Fix newly introduced PSScriptAnalyzer findings in modified scripts.",
+        "Only update Tooling/PSScriptAnalyzerBaseline.json via approved baseline update workflow."
       ],
       "preventiveCheck": "CI Debt Policy Gate / Root Cause Contract"
     },

--- a/Tooling/tests/ResolveGitHubRepo.Tests.ps1
+++ b/Tooling/tests/ResolveGitHubRepo.Tests.ps1
@@ -1,0 +1,105 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+BeforeAll {
+    $Script:ToolingRoot = Split-Path -Parent $PSScriptRoot
+    $Script:ResolverScript = Join-Path $Script:ToolingRoot 'Resolve-GitHubRepo.ps1'
+    $Script:CiDebtScript = Join-Path $Script:ToolingRoot 'agents/ci-debt/Invoke-CiDebtAnalysis.ps1'
+    $Script:FixturePath = Join-Path $Script:ToolingRoot 'agents/ci-debt/fixtures/run-21840801109.json'
+
+    . $Script:CiDebtScript
+}
+
+Describe 'Resolve-GitHubRepo' {
+    It 'resolves owner/name from origin when GH_REPO is not set' {
+        $repoPath = Join-Path $TestDrive 'repo-origin'
+        New-Item -Path $repoPath -ItemType Directory -Force | Out-Null
+        git -C $repoPath init | Out-Null
+        git -C $repoPath remote add origin https://github.com/example-owner/example-repo.git
+
+        $oldGhRepo = $env:GH_REPO
+        try {
+            Remove-Item Env:GH_REPO -ErrorAction SilentlyContinue
+            $resolved = & $Script:ResolverScript -RepoRoot $repoPath
+        } finally {
+            if ($null -eq $oldGhRepo) {
+                Remove-Item Env:GH_REPO -ErrorAction SilentlyContinue
+            } else {
+                $env:GH_REPO = $oldGhRepo
+            }
+        }
+
+        $resolved.Trim() | Should -Be 'example-owner/example-repo'
+    }
+
+    It 'prefers GH_REPO override over origin' {
+        $repoPath = Join-Path $TestDrive 'repo-override'
+        New-Item -Path $repoPath -ItemType Directory -Force | Out-Null
+        git -C $repoPath init | Out-Null
+        git -C $repoPath remote add origin https://github.com/example-owner/example-repo.git
+
+        $oldGhRepo = $env:GH_REPO
+        try {
+            $env:GH_REPO = 'override-owner/override-repo'
+            $resolved = & $Script:ResolverScript -RepoRoot $repoPath
+        } finally {
+            if ($null -eq $oldGhRepo) {
+                Remove-Item Env:GH_REPO -ErrorAction SilentlyContinue
+            } else {
+                $env:GH_REPO = $oldGhRepo
+            }
+        }
+
+        $resolved.Trim() | Should -Be 'override-owner/override-repo'
+    }
+
+    It 'fails when origin cannot be parsed to owner/name' {
+        $repoPath = Join-Path $TestDrive 'repo-unparseable'
+        New-Item -Path $repoPath -ItemType Directory -Force | Out-Null
+        git -C $repoPath init | Out-Null
+        git -C $repoPath remote add origin https://example.com/not-github.git
+
+        $oldGhRepo = $env:GH_REPO
+        try {
+            Remove-Item Env:GH_REPO -ErrorAction SilentlyContinue
+            { & $Script:ResolverScript -RepoRoot $repoPath } | Should -Throw '*was not in owner/name or GitHub URL format*'
+        } finally {
+            if ($null -eq $oldGhRepo) {
+                Remove-Item Env:GH_REPO -ErrorAction SilentlyContinue
+            } else {
+                $env:GH_REPO = $oldGhRepo
+            }
+        }
+    }
+}
+
+Describe 'Invoke-CiDebtAnalysis repository resolution' {
+    It 'uses deterministic resolver path and not gh repo view fallback' {
+        $scriptContent = Get-Content -Path $Script:CiDebtScript -Raw
+        $scriptContent | Should -Match 'Resolve-GitHubRepo\.ps1'
+        $scriptContent | Should -Not -Match 'gh repo view --json nameWithOwner --jq \.nameWithOwner'
+    }
+
+    It 'respects GH_REPO override when Repo parameter is omitted' {
+        $outJson = Join-Path $TestDrive 'analysis.json'
+        $outMarkdown = Join-Path $TestDrive 'analysis.md'
+        $oldGhRepo = $env:GH_REPO
+
+        try {
+            $env:GH_REPO = 'override-owner/override-repo'
+            $result = Invoke-CiDebtAnalysis `
+                -RunId 21840801109 `
+                -FixturePath $Script:FixturePath `
+                -OutJson $outJson `
+                -OutMarkdown $outMarkdown
+        } finally {
+            if ($null -eq $oldGhRepo) {
+                Remove-Item Env:GH_REPO -ErrorAction SilentlyContinue
+            } else {
+                $env:GH_REPO = $oldGhRepo
+            }
+        }
+
+        $result.Repo | Should -Be 'override-owner/override-repo'
+    }
+}

--- a/docs/ci/actions/maintainers-guide.md
+++ b/docs/ci/actions/maintainers-guide.md
@@ -88,8 +88,8 @@ Debug-only/manual validation:
 - Use `labels-sync.yml` to create/update contract labels from
   `.github/labels/label-contract.json`.
 - Resolve the repository for `gh` commands:
-  - `$repo = if ($env:GH_REPO) { $env:GH_REPO } else { gh repo view --json nameWithOwner --jq .nameWithOwner }`
-  - `GH_REPO` is optional override when maintainers need to target a specific repo.
+  - `$repo = pwsh -NoProfile -File .\Tooling\Resolve-GitHubRepo.ps1`
+  - `GH_REPO` is optional override and takes precedence when maintainers need to target a specific repo.
 
 ## Label Metadata Automation
 


### PR DESCRIPTION
## Summary
- add canonical repo resolver (`Tooling/Resolve-GitHubRepo.ps1`) to prevent `gh repo view` auto-resolution drift
- route CI-debt analyzer through deterministic repo resolution (arg > `GH_REPO` > `origin`)
- make `Invoke-Preflight.ps1` use optional gk fallback (`LVIE_REQUIRE_GITKRAKEN_CLI=1` to enforce)
- add resolver tests and wire routing checks into CI workflows
- update signatures/playbook for lint-regression classification

## Validation
- `Invoke-Pester -Path .\Tooling\tests\CiDebtAnalysis.Tests.ps1 -Output Detailed`
- `Invoke-Pester -Path .\Tooling\tests\ResolveGitHubRepo.Tests.ps1 -Output Detailed`
- `pwsh -NoProfile -File .\Tooling\agents\ci-debt\Test-CiDebtPolicyGate.ps1 -Mode enforce`
- `pwsh -NoProfile -File .\Tooling\Test-RepoAgnosticIssueRouting.ps1`
- `pwsh -NoProfile -File .\Tooling\Invoke-PSScriptAnalyzer.ps1 -WriteSummary`
