### PR TITLE
Fix unit-test LUnit fallback path for Pipeline Contract

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1139,10 +1139,16 @@ jobs:
           $env:LVIE_LUNIT_BACKEND = $backendMode
           Write-Host ("LUnit backend mode for unit-tests job: {0}" -f $env:LVIE_LUNIT_BACKEND)
 
-          & ".github/actions/run-unit-tests/RunUnitTests.ps1" `
-            -LabVIEWVersion $env:LABVIEW_VERSION_YEAR `
-            -SupportedBitness ${{ matrix.bitness }} `
-            -ProjectPath "$env:PROJECT_PATH"
+          $runUnitTestArgs = @(
+            '-LabVIEWVersion', $env:LABVIEW_VERSION_YEAR,
+            '-SupportedBitness', '${{ matrix.bitness }}',
+            '-ProjectPath', "$env:PROJECT_PATH"
+          )
+          if ($backendMode -ne 'gcli') {
+            $runUnitTestArgs += '-EnableGcliFallback'
+            Write-Host 'Enabled LUnit g-cli fallback for labviewcli mode.'
+          }
+          & ".github/actions/run-unit-tests/RunUnitTests.ps1" @runUnitTestArgs
       - name: Summarize unit-test backend mode
         if: always()
         shell: pwsh


### PR DESCRIPTION
## Summary
- update `ci-composite` unit-tests step to pass `-EnableGcliFallback` when backend mode is `labviewcli`
- keep forced `gcli` backend path unchanged

## Why
`Run Unit Tests (LV 64/32-bit)` failed in CI because LabVIEWCLI operation discovery could not resolve `LUnit` and fallback was disabled, causing `Pipeline Contract` to fail (`unit-tests:failure`).

## Validation
- `pwsh -NoProfile -File .\Tooling\agents\ci-debt\Test-CiDebtPolicyGate.ps1 -Mode enforce`
- `pwsh -NoProfile -File .\Tooling\Test-RepoAgnosticIssueRouting.ps1`