### PR TITLE
Fix unit-tests workflow invocation for fallback flag

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1139,16 +1139,19 @@ jobs:
           $env:LVIE_LUNIT_BACKEND = $backendMode
           Write-Host ("LUnit backend mode for unit-tests job: {0}" -f $env:LVIE_LUNIT_BACKEND)
 
-          $runUnitTestArgs = @(
-            '-LabVIEWVersion', $env:LABVIEW_VERSION_YEAR,
-            '-SupportedBitness', '${{ matrix.bitness }}',
-            '-ProjectPath', "$env:PROJECT_PATH"
-          )
           if ($backendMode -ne 'gcli') {
-            $runUnitTestArgs += '-EnableGcliFallback'
             Write-Host 'Enabled LUnit g-cli fallback for labviewcli mode.'
+            & ".github/actions/run-unit-tests/RunUnitTests.ps1" `
+              -LabVIEWVersion $env:LABVIEW_VERSION_YEAR `
+              -SupportedBitness ${{ matrix.bitness }} `
+              -ProjectPath "$env:PROJECT_PATH" `
+              -EnableGcliFallback
+          } else {
+            & ".github/actions/run-unit-tests/RunUnitTests.ps1" `
+              -LabVIEWVersion $env:LABVIEW_VERSION_YEAR `
+              -SupportedBitness ${{ matrix.bitness }} `
+              -ProjectPath "$env:PROJECT_PATH"
           }
-          & ".github/actions/run-unit-tests/RunUnitTests.ps1" @runUnitTestArgs
       - name: Summarize unit-test backend mode
         if: always()
         shell: pwsh


### PR DESCRIPTION
## Summary
- replace array splat invocation with explicit named-parameter calls in unit-tests workflow step
- keep g-cli fallback enabled for `labviewcli` mode only

## Why
The previous workflow change passed named arguments via array splatting and failed in Actions with:
`A positional parameter cannot be found that accepts argument '-LabVIEWVersion'`
This prevented unit tests from running and kept `Pipeline Contract` red.

## Validation
- `pwsh -NoProfile -File .\Tooling\agents\ci-debt\Test-CiDebtPolicyGate.ps1 -Mode enforce`
- `pwsh -NoProfile -File .\Tooling\Test-RepoAgnosticIssueRouting.ps1`