### PR TITLE
ci: harden composite concurrency and prerelease gcli evidence

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -20,8 +20,8 @@ env:
   LVIE_PYLAVI_FAIL_ON_DELTA: ${{ vars.LVIE_PYLAVI_FAIL_ON_DELTA || '0' }}
 
 concurrency:
-  group: labview-${{ github.repository }}-${{ vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}
-  cancel-in-progress: false
+  group: labview-${{ github.repository }}-${{ vars.LVIE_RUNNER_LABEL || 'self-hosted-windows-lv' }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -1525,13 +1525,33 @@ jobs:
           name: ${{ steps.locate-vip.outputs.vip_artifact }}
           path: ${{ steps.locate-vip.outputs.vip_path }}
           if-no-files-found: error
+      - name: Ensure g-cli logs evidence exists
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $logsDir = Join-Path $env:REPO_ROOT 'builds/logs'
+          New-Item -Path $logsDir -ItemType Directory -Force | Out-Null
+
+          $existingFiles = Get-ChildItem -Path $logsDir -Recurse -File -ErrorAction SilentlyContinue
+          if (-not $existingFiles) {
+            $placeholderPath = Join-Path $logsDir 'gcli-logs-placeholder.txt'
+            $runUrl = "{0}/{1}/actions/runs/{2}" -f $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_RUN_ID
+            @(
+              'No g-cli log files were produced by this run.'
+              'This placeholder preserves the prerelease gcli-logs asset contract.'
+              ("Run URL: {0}" -f $runUrl)
+              ("Generated UTC: {0}" -f (Get-Date).ToUniversalTime().ToString('o'))
+            ) | Out-File -FilePath $placeholderPath -Encoding utf8
+            Write-Host ("Created g-cli logs placeholder at {0}" -f $placeholderPath)
+          }
       - name: Upload g-cli logs (if present)
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: gcli-logs
           path: ${{ env.REPO_ROOT }}/builds/logs
-          if-no-files-found: warn
+          if-no-files-found: error
       - name: Validate tag matches computed version (if provided)
         if: startsWith(github.ref, 'refs/tags/') || github.event.inputs.dispatch_tag != ''
         shell: pwsh

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -98,6 +98,9 @@ jobs:
           $publishPrerelease = '${{ github.event.inputs.publish_prerelease }}'
           $runUid = "{0}-{1}-{2}" -f $runId, $runAttempt, $sha
 
+          if ($eventName -eq 'workflow_dispatch' -and $publishPrerelease -eq 'true' -and $strictSha -ne 'true') {
+            throw "strict_sha=true is required when publish_prerelease=true."
+          }
           if ($eventName -eq 'workflow_dispatch' -and $publishPrerelease -eq 'true' -and [string]::IsNullOrWhiteSpace($expectedSha)) {
             throw "expected_sha is required when publish_prerelease=true."
           }
@@ -172,7 +175,17 @@ jobs:
             const forceGcliLunitInput = (process.env.FORCE_GCLI_LUNIT || 'false').toLowerCase() === 'true';
             const releasePriorityMode = context.eventName === 'workflow_dispatch' && forceGcliLunitInput;
 
-            async function findMergedPrTargetingDevelop() {
+            async function getCommitParentCount() {
+              const response = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.sha,
+              });
+              const parents = Array.isArray(response.data.parents) ? response.data.parents : [];
+              return parents.length;
+            }
+
+            async function findMergedPrsTargetingDevelop() {
               const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -181,7 +194,18 @@ jobs:
               const mergedDevelopPrs = response.data
                 .filter((pr) => pr.merged_at && pr.base && pr.base.ref === 'develop')
                 .sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
-              return mergedDevelopPrs.length > 0 ? mergedDevelopPrs[0] : null;
+              return mergedDevelopPrs;
+            }
+
+            function findMergedPrForCurrentSha(mergedDevelopPrs) {
+              const sha = String(context.sha || '').toLowerCase();
+              for (const pr of mergedDevelopPrs) {
+                const mergeSha = String(pr.merge_commit_sha || '').toLowerCase();
+                if (mergeSha === sha) {
+                  return pr;
+                }
+              }
+              return null;
             }
 
             function deriveBumpFromLabels(pr) {
@@ -209,24 +233,49 @@ jobs:
             let bumpConflict = false;
             let bumpConflictLabels = '';
 
-            const mergedPr = await findMergedPrTargetingDevelop();
+            const commitParentCount = await getCommitParentCount();
+            const isMergeCommit = commitParentCount > 1;
+            const mergedDevelopPrs = await findMergedPrsTargetingDevelop();
+            const hasMergedDevelopPrAssociation = mergedDevelopPrs.length > 0;
+            const mergedPr = findMergedPrForCurrentSha(mergedDevelopPrs);
             if (mergedPr) {
               mergedPrNumber = String(mergedPr.number);
             }
 
             if (context.eventName === 'push' && context.ref === 'refs/heads/develop') {
               publishMode = 'auto';
-              if (mergedPr) {
+              if (!isMergeCommit) {
+                shouldPublish = false;
+                publishReason = 'develop-push-not-merge-commit';
+              } else if (mergedPr) {
                 shouldPublish = true;
-                publishReason = 'develop-push-merged-pr';
+                publishReason = 'develop-push-merged-pr-merge-commit';
+              } else if (hasMergedDevelopPrAssociation) {
+                shouldPublish = false;
+                publishReason = 'develop-push-merged-pr-sha-mismatch';
               } else {
                 shouldPublish = false;
                 publishReason = 'develop-push-no-merged-pr';
               }
             } else if (context.eventName === 'workflow_dispatch') {
               publishMode = 'manual';
-              shouldPublish = publishInput;
-              publishReason = publishInput ? 'manual-intent-true' : 'manual-intent-false';
+              if (!publishInput) {
+                shouldPublish = false;
+                publishReason = 'manual-intent-false';
+              } else if (!isMergeCommit) {
+                core.setFailed('Manual prerelease publish requires expected_sha to reference a merged develop merge commit.');
+                return;
+              } else if (!mergedPr) {
+                if (hasMergedDevelopPrAssociation) {
+                  core.setFailed('Manual prerelease publish requires expected_sha to match the merged develop PR merge SHA.');
+                } else {
+                  core.setFailed('Manual prerelease publish requires expected_sha to be associated with a merged PR targeting develop.');
+                }
+                return;
+              } else {
+                shouldPublish = true;
+                publishReason = 'manual-intent-eligible-merged-pr-merge-commit';
+              }
             } else if (context.eventName === 'pull_request') {
               publishMode = 'pull-request';
               shouldPublish = false;
@@ -238,8 +287,8 @@ jobs:
             }
 
             const shouldDeriveMergedPrBump =
-              (context.eventName === 'push' && context.ref === 'refs/heads/develop' && !!mergedPr) ||
-              (context.eventName === 'workflow_dispatch' && publishInput && !!mergedPr);
+              (context.eventName === 'push' && context.ref === 'refs/heads/develop' && shouldPublish && !!mergedPr) ||
+              (context.eventName === 'workflow_dispatch' && publishInput && shouldPublish && !!mergedPr);
             if (shouldDeriveMergedPrBump) {
               const bumpInfo = deriveBumpFromLabels(mergedPr);
               bumpConflict = bumpInfo.conflict;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ When submitting a pull request, follow these guidelines to streamline reviews:
    - **Changes Made:** What you changed. If it’s a bug fix, describe the root cause and solution. If it’s a new feature, summarize how it works.
    - **Related Issues:** Reference any issue numbers (e.g., “Closes #123”).
    - **Testing:** Explain how you tested the changes. Include steps for reviewers to test, and mention any specific areas to focus on.
-3. **Commit Sign-off:** As mentioned, ensure your commits are signed off (DCO). Also, make sure each commit in the PR is self-contained and the overall branch history can be cleanly merged or squashed as the maintainers see fit.
+3. **Commit Sign-off:** As mentioned, ensure your commits are signed off (DCO). Also, make sure each commit in the PR is self-contained and the overall branch history can be cleanly merged. For prerelease-driving PRs targeting `develop`, maintainers use merge commits (`--merge`) rather than squash/rebase.
 
 Be patient and responsive during the review. We might ask you to make changes – that’s part of making sure the contribution is robust and fits well with the codebase.
 

--- a/Tooling/Test-VipPrereleaseRequirementsV1.ps1
+++ b/Tooling/Test-VipPrereleaseRequirementsV1.ps1
@@ -285,6 +285,14 @@ try {
         $computeActionContent = Get-Content -Raw -Path $computeVersionActionFile
 
         Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'workflow_dispatch:[\s\S]*publish_prerelease:' -Message "Workflow dispatch input 'publish_prerelease' is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'workflow_dispatch:[\s\S]*strict_sha:' -Message "Workflow dispatch input 'strict_sha' is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'strict_sha=true is required when publish_prerelease=true\.' -Message "run-metadata strict_sha publish-intent enforcement is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'github\.rest\.repos\.getCommit' -Message "prerelease-context merge-commit eligibility check hook is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'develop-push-not-merge-commit' -Message "prerelease-context merge-commit publish reason token is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'develop-push-merged-pr-sha-mismatch' -Message "prerelease-context merged PR SHA mismatch reason token is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'Manual prerelease publish requires expected_sha to reference a merged develop merge commit\.' -Message "manual prerelease merge-commit fail-fast enforcement is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'Manual prerelease publish requires expected_sha to match the merged develop PR merge SHA\.' -Message "manual prerelease merged PR SHA match fail-fast enforcement is missing."
+        Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'Manual prerelease publish requires expected_sha to be associated with a merged PR targeting develop\.' -Message "manual prerelease merged develop PR association fail-fast enforcement is missing."
         Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'prerelease-context:[\s\S]*outputs:[\s\S]*bump_conflict:' -Message "prerelease-context output 'bump_conflict' is missing."
         Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'prerelease-context:[\s\S]*outputs:[\s\S]*bump_conflict_labels:' -Message "prerelease-context output 'bump_conflict_labels' is missing."
         Test-PatternPresence -FilePath $workflowFile -Content $workflowContent -Pattern 'bump_type_override:\s*\$\{\{\s*needs\.prerelease-context\.outputs\.bump_type_override\s*\}\}' -Message "version job is not wiring prerelease-context bump_type_override into compute-version."

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -1,6 +1,6 @@
 # Local CI/CD Workflows
 
-**Last updated:** 2026-02-09
+**Last updated:** 2026-02-10
 
 Quick link: `.github/workflows/runner-cli.yml` (Runner CLI consolidated workflow).
 
@@ -76,11 +76,31 @@ Automating your Icon Editor builds and tests:
 This document is the canonical source for release/publication policy.
 
 - Normative contract: [VI Package Pre-Release Requirements](vip-prerelease-requirements.md).
-- Auto publish contract: prerelease publication runs for `push` events on `develop` when the pushed SHA is associated with a merged pull request targeting `develop`.
-- Manual publish contract: `workflow_dispatch` supports explicit prerelease backfill with `publish_prerelease=true` and SHA validation.
+- Merge strategy contract: pull requests intended to drive prerelease publication to `develop` must use merge commits (`--merge`), not squash or rebase.
+- Auto publish contract: prerelease publication runs for `push` events on `develop` when the pushed SHA is the merged `develop` SHA from a merged pull request targeting `develop`.
+- Manual publish contract: `workflow_dispatch` supports explicit prerelease backfill only with `publish_prerelease=true`, `expected_sha=<merged-develop-sha>`, and `strict_sha=true`.
 - LUnit escape hatch: `workflow_dispatch` also supports `force_gcli_lunit=true` to force g-cli in unit-test jobs while exercising release paths.
 - Asset contract: published prereleases attach `.vip`, release notes, `gcli-logs`, and `vip-build-status` assets from the same CI run.
 - Branch trigger reality for `ci-composite.yml`: `push` and `pull_request` run on `main`, `develop`, `release/*`, `feature/*`, and `hotfix/*`, plus `workflow_dispatch`.
+
+#### Deterministic Merge + Publish Procedure
+
+1. Merge the PR into `develop` with a merge commit:
+   ```powershell
+   gh pr merge <pr-number> --merge --delete-branch
+   ```
+2. Read the merged `develop` SHA:
+   ```powershell
+   $repo = pwsh -NoProfile -File .\Tooling\Resolve-GitHubRepo.ps1
+   $mergeSha = gh pr view <pr-number> --repo $repo --json mergeCommit --jq .mergeCommit.oid
+   ```
+3. Use manual publish/backfill only when needed, pinned to that merged SHA:
+   ```powershell
+   gh workflow run ci-composite.yml --repo $repo `
+     -f publish_prerelease=true `
+     -f expected_sha=$mergeSha `
+     -f strict_sha=true
+   ```
 
 ---
 
@@ -222,10 +242,11 @@ Although GitHub Actions primarily run on GitHub-hosted or self-hosted agents, yo
    - Assign `major`, `minor`, or `patch` to control the version bump.
    - The CI validates your code and produces versioned build artifacts.
 
-4. **Merge the PR** into `develop` (or `main`):
+4. **Merge the PR into `develop` with a merge commit**:
      - The **Build VI Package** workflow builds and uploads the `.vip` artifact.
+     - Use merge commits only (`gh pr merge <pr-number> --merge --delete-branch`); do not use squash/rebase for prerelease-driving PRs.
      - Merged PR commits into `develop` publish a GitHub prerelease automatically when eligibility checks pass.
-     - Manual backfill is available through `workflow_dispatch` using `publish_prerelease=true` with SHA pinning.
+     - Manual backfill is available through `workflow_dispatch` using `publish_prerelease=true`, `expected_sha=<merged-develop-sha>`, and `strict_sha=true`.
      - **Inside** that `.vip`, the **“Company Name”** and **“Author Name (Person or Company)”** fields are filled automatically using `github.repository_owner` and `github.event.repository.name`. Modify the “Generate display information JSON” step in `.github/workflows/ci-composite.yml` to override them.
 
 5. **Disable Development Mode**:  

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -53,7 +53,9 @@ Automating your Icon Editor builds and tests:
    Use the main CI workflow (`ci-composite.yml`) to confirm your environment is valid.
    - The workflow triggers on pushes to or pull requests targeting the branches configured in `ci-composite.yml` (`on.push.branches` / `on.pull_request.branches`), and supports manual `workflow_dispatch` runs.
      - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-     - A concurrency group cancels any previous run on the same branch, ensuring only the latest pipeline execution continues.
+     - Concurrency is isolated by repository, runner label, event name, and ref.
+     - Pull request runs auto-cancel earlier runs for the same PR ref.
+     - Push and `workflow_dispatch` runs are isolated by event/ref and are not canceled by pull request updates.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically using the Windows/self-hosted `build-vip` job in `ci-composite.yml`.

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -132,7 +132,7 @@ components remain unchanged and only the build number increases.
 ### 3.4 Artifact Publication
 - Packaging output: the `.vip` is uploaded as a run artifact by `build-vip`.
 - Publication contract: prerelease publication is defined by [`vip-prerelease-requirements.md`](../../vip-prerelease-requirements.md), including eligibility, version binding, and required asset rules.
-- Manual backfill: `workflow_dispatch` can republish eligible assets when `publish_prerelease=true` and SHA validation is satisfied.
+- Manual backfill: `workflow_dispatch` can republish eligible assets only when `publish_prerelease=true`, `expected_sha` is set to the merged `develop` SHA, and `strict_sha=true`.
 
 
 
@@ -231,7 +231,7 @@ components remain unchanged and only the build number increases.
 ### 7.1 Pull Requests with Labels
 - **Scenario**: You create a PR from a feature branch into `develop`.
 - **Action**: Add a label like `major` or `minor`.
-- **Result**: Upon merging, the workflow updates that version field (major/minor/patch) and applies a commit-based build number. If the PR has no version label, the patch version is bumped by default. The `.vip` artifact is uploaded, and the target policy is to publish a GitHub pre-release from that build on `develop`.
+- **Result**: Upon merge-commit merge (`--merge`), the workflow updates that version field (major/minor/patch) and applies a commit-based build number. If the PR has no version label, the patch version is bumped by default. The `.vip` artifact is uploaded, and the target policy is to publish a GitHub pre-release from that merged `develop` SHA.
 
 #### Example:
 1. PR labeled `minor`:
@@ -251,8 +251,8 @@ components remain unchanged and only the build number increases.
 
 ### 7.4 Manually Triggering (workflow_dispatch)
 - **Scenario**: A maintainer manually runs the workflow from the Actions tab (if enabled).
-- **Action**: Provide any input parameters (if configured), or rely on defaults like `none` for version bump.
-- **Result**: The script runs as if it were a push event and produces a `.vip` artifact. For prerelease publication, `develop` merged-PR runs publish automatically and `workflow_dispatch` supports explicit backfill intent.
+- **Action**: For prerelease backfill, set `publish_prerelease=true`, set `expected_sha` to the merged `develop` SHA, and set `strict_sha=true`.
+- **Result**: The script produces a `.vip` artifact. For prerelease publication, `develop` merged-PR merge commits publish automatically and `workflow_dispatch` supports explicit backfill only when pinned to the merged SHA.
 
 ## 8. **Testing & Verification**
 

--- a/docs/ci/actions/maintainers-guide.md
+++ b/docs/ci/actions/maintainers-guide.md
@@ -28,7 +28,8 @@ current.
    `develop` (or another appropriate branch).
 4. Run unit tests or scripted checks locally whenever possible.
 5. Ensure CI passes and obtain at least one maintainer approval before merging.
-6. After merging, delete the source branch to keep the repository tidy.
+6. For PRs targeting `develop` that drive prerelease publication, merge with a merge commit (`gh pr merge <pr-number> --merge --delete-branch`) and avoid squash/rebase.
+7. After merging, delete the source branch to keep the repository tidy.
 
 ## Workflow Administration
 

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -60,6 +60,8 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
 6. **Build VI Package**
     - Invoke the **Build VI Package** job within the CI Pipeline (Composite) workflow to produce a `.vip` using the version computed by the workflow's separate **version** job (see that job's output for the generated version).
    - Pre-release publication behavior is specified by [`vip-prerelease-requirements.md`](../../vip-prerelease-requirements.md), including eligibility, assets, and failure policy.
+   - Prerelease-driving PRs into `develop` must be merged with a merge commit (`--merge`), not squash/rebase.
+   - Manual prerelease backfill requires `publish_prerelease=true`, `expected_sha=<merged-develop-sha>`, and `strict_sha=true`.
    - **You can also** pass in **org/repository** info (e.g., `-CompanyName "MyOrg"` or `-AuthorName "myorg/myrepo"`) to brand the resulting package with your unique identifiers.
 
 7. **Disable Dev Mode** (Optional)  
@@ -183,8 +185,8 @@ With your runner online:
 
 3. **Build VI Package**
     - Produces `.vip` using the version computed in the **version** job (review that job's output for version details).
-   - Merged-PR pushes to `develop` publish prereleases per [`vip-prerelease-requirements.md`](../../vip-prerelease-requirements.md).
-   - `workflow_dispatch` backfill publishing is available with explicit publish intent input.
+   - Merged-PR merge-commit pushes to `develop` publish prereleases per [`vip-prerelease-requirements.md`](../../vip-prerelease-requirements.md).
+   - `workflow_dispatch` backfill publishing requires `publish_prerelease=true`, `expected_sha=<merged-develop-sha>`, and `strict_sha=true`.
    - **Pass** your **org/repo** info (e.g. `-CompanyName "AcmeCorp"` / `-AuthorName "AcmeCorp/IconEditor"`) to embed in the final package.
    - Artifacts appear in the run summary under **Artifacts**.
 
@@ -238,7 +240,15 @@ Notes:
    - The workflow checks this label upon merging.  
 4. **Merge**:
    - The **CI Pipeline (Composite)** workflow triggers, with the **version** job computing the version and the **Build VI Package** job using that version to package and upload the `.vip`.
-   - Direction: a merge to `develop` should result in a GitHub pre-release that includes the `.vip` and release notes.
+   - Use merge commits for prerelease-driving PRs: `gh pr merge <pr-number> --merge --delete-branch`.
+   - Direction: a merge-commit merge to `develop` should result in a GitHub pre-release that includes the `.vip` and release notes.
+   - Manual backfill is deterministic only when pinned to the merged SHA:
+     ```powershell
+     gh workflow run ci-composite.yml --repo <owner/repo> `
+       -f publish_prerelease=true `
+       -f expected_sha=<merged-develop-sha> `
+       -f strict_sha=true
+     ```
    - Publish status is reported by the `publish-prerelease` job and the `prerelease-publish-status` artifact.
    - **Metadata** (such as company/repo) is already integrated into the final `.vip`, so each build is easily identified.
 5. **Disable Dev Mode**: Return to a normal LabVIEW environment.  
@@ -247,6 +257,8 @@ Notes:
 #### Develop Pre-Release Direction
 
 - Use `develop` merges as the default pre-release publication event.
+- Use merge commits (`--merge`) for prerelease-driving merges into `develop`.
+- Use strict manual backfill inputs (`publish_prerelease=true`, `expected_sha`, `strict_sha=true`) when replaying publication.
 - Keep `main` focused on stable/final release handling.
 - Treat alpha/beta/rc channel branches as optional legacy behavior unless your repository explicitly enables that model.
 

--- a/docs/ci/troubleshooting-faq.md
+++ b/docs/ci/troubleshooting-faq.md
@@ -22,6 +22,7 @@ This document provides a collection of common **troubleshooting** scenarios (wit
    13. [No. 13: Repository Forks Not Displaying Correct Metadata](#no-13-repository-forks-not-displaying-correct-metadata)
    14. [No. 14: Dev Mode Failure Missing Paths](#no-14-dev-mode-failure-missing-paths)
    15. [No. 15: Verify IE Paths Gate Fails in CI](#no-15-verify-ie-paths-gate-fails-in-ci)
+   16. [No. 16: PR Merge Blocked Despite Green Required Checks](#no-16-pr-merge-blocked-despite-green-required-checks)
 
 
 2. [FAQ](#faq)
@@ -44,7 +45,7 @@ This document provides a collection of common **troubleshooting** scenarios (wit
 
 ## Troubleshooting
 
-Below are 14 possible issues you might encounter, along with suggested steps to resolve them.
+Below are 16 possible issues you might encounter, along with suggested steps to resolve them.
 
 ### No. 1: LabVIEW Not Found on Runner
 
@@ -286,6 +287,40 @@ Below are 14 possible issues you might encounter, along with suggested steps to 
 1. Open the “verify-iepaths-32-bit” or “verify-iepaths-64-bit” artifact attached to the failed job.
 2. Check the comma-separated list of missing paths in `missing_IE_paths.txt`.
 3. Restore the missing files (or revert dev mode) and re-run the workflow.
+
+---
+
+### No. 16: PR Merge Blocked Despite Green Required Checks
+
+**Symptoms**:
+- Pull request is `MERGEABLE` but `BLOCKED` even though required checks are green.
+- `gh pr merge` fails with: “the base branch policy prohibits the merge.”
+
+**Evidence Pattern**:
+- `gh pr checks <pr-number>` shows required checks passing.
+- `gh run view <run-id> --json status,conclusion,jobs` shows a `pending` or `queued` workflow run with `jobs: []`.
+- PR merge state remains blocked until the stale pending run is canceled or cleared.
+
+**Incident Reference (2026-02-10)**:
+- Pull request: `#82`
+- Stale pending run: `21853308619` (`CI Pipeline (Composite)`), head SHA `c5fc1ecf2175127cf4734cf7bde38ae9b648853c`
+- Older queued/in-progress run on same branch: `21852840202`
+- Merge commit after manual unblock: `aa5a705bc45f54f26f0b3b5ac0893958de4a3e5c`
+
+**Diagnostic Command Set**:
+```powershell
+gh pr view <pr-number> --json mergeStateStatus,mergeable,statusCheckRollup
+gh pr checks <pr-number>
+gh run list --branch <branch> --workflow "CI Pipeline (Composite)"
+gh run view <run-id> --json status,conclusion,jobs
+```
+
+**Immediate Unblock Playbook**:
+1. Cancel stale pending run(s): `gh run cancel <run-id>`.
+2. Re-run stale failed required checks if present (use `gh run rerun <run-id> --failed`).
+3. If required check context is still stale, push one empty refresh commit.
+4. Re-check merge state and required contexts.
+5. Use `--admin` merge only as a last resort when required checks are green but policy remains blocked.
 
 ## FAQ
 

--- a/docs/ci/troubleshooting-faq.md
+++ b/docs/ci/troubleshooting-faq.md
@@ -136,9 +136,20 @@ Below are 16 possible issues you might encounter, along with suggested steps to 
 - The publish step failed or was skipped due to eligibility, assets, or API errors.
 
 **Solution**:
-1. Confirm the run is an eligible publish path (`develop` merged-PR push, or `workflow_dispatch` with `publish_prerelease=true` and valid `expected_sha`).
-2. Inspect the `publish-prerelease` job logs for explicit failure/skip reason output.
-3. Inspect the `prerelease-publish-status` artifact for machine-readable failure details and required-asset validation results.
+1. Confirm the PR was merged into `develop` using a merge commit (not squash/rebase) and identify the merged `develop` SHA.
+2. Confirm the run is an eligible publish path (`develop` merged-PR push, or `workflow_dispatch` with `publish_prerelease=true`, `expected_sha=<merged-develop-sha>`, and `strict_sha=true`).
+3. Inspect the `publish-prerelease` job logs for explicit failure/skip reason output.
+4. Inspect the `prerelease-publish-status` artifact for machine-readable failure details and required-asset validation results.
+
+Deterministic backfill command:
+```powershell
+$repo = pwsh -NoProfile -File .\Tooling\Resolve-GitHubRepo.ps1
+$mergeSha = gh pr view <pr-number> --repo $repo --json mergeCommit --jq .mergeCommit.oid
+gh workflow run ci-composite.yml --repo $repo `
+  -f publish_prerelease=true `
+  -f expected_sha=$mergeSha `
+  -f strict_sha=true
+```
 
 ---
 
@@ -336,7 +347,7 @@ By default, the workflow calculates the build number with `git rev-list --count 
 ### Q2: How Do I Create a Release?
 
 **Answer**:
-Repository policy publishes a GitHub prerelease for eligible `develop` publication events. Use `workflow_dispatch` with `publish_prerelease=true` for explicit backfill operations, and review `prerelease-publish-status` when troubleshooting.
+Repository policy publishes a GitHub prerelease for eligible `develop` publication events from merge commits. Merge PRs with `--merge` (not squash/rebase) when commit-number determinism matters. For explicit backfill, dispatch `ci-composite.yml` with `publish_prerelease=true`, `expected_sha=<merged-develop-sha>`, and `strict_sha=true`, then review `prerelease-publish-status` when troubleshooting.
 
 ---
 

--- a/docs/vip-prerelease-requirements-v0-to-v1-trace.md
+++ b/docs/vip-prerelease-requirements-v0-to-v1-trace.md
@@ -5,12 +5,12 @@ This trace matrix maps v1 requirement changes for develop prerelease publication
 | Change ID | Affected prior VR IDs | v1 VR IDs | Profile | Change Type | Rationale | Verification |
 |---|---|---|---|---|---|---|
 | V1-C0 | none (new contract) | VR-SCOPE-001, VR-SCOPE-002, VR-SCOPE-003, VR-SCOPE-004, VR-PUR-001, VR-PUR-002, VR-PUR-003, VR-PUR-004, VR-PUR-005, VR-PUR-006 | Core | Clarifying | Establish profile semantics, applicability rules, and publication scope boundaries for the new requirement set. | A-001 |
-| V1-C1 | none (new contract) | VR-TRIG-001, VR-TRIG-002, VR-TRIG-003, VR-TRIG-006, VR-FAIL-001 | Core | Clarifying | Define develop merged-PR eligibility and explicit skip behavior for ineligible runs. | A-002, A-003, A-014 |
+| V1-C1 | none (new contract) | VR-TRIG-001, VR-TRIG-002, VR-TRIG-003, VR-TRIG-006, VR-TRIG-007, VR-TRIG-008, VR-FAIL-001 | Core | Breaking | Enforce merge-commit-only eligibility and merge SHA alignment for publish paths while preserving skip semantics for ineligible auto paths. | A-002, A-003, A-014 |
 | V1-C2 | none (new contract) | VR-VER-001 | Core | Clarifying | Bind release tag/title to computed workflow version output for deterministic publication identity. | A-007 |
 | V1-C3 | none (new contract) | VR-VER-002, VR-VER-003, VR-VER-004, VR-VER-005, VR-VER-006, VR-FAIL-004 | Core | Contract-expanding | Add merged-PR label-derived bump behavior and override interface for push-to-develop eligibility. | A-005, A-006 |
 | V1-C4 | none (new contract) | VR-PUB-001, VR-PUB-002, VR-PUB-003, VR-PUB-004, VR-PUB-005, VR-PUB-006, VR-PUB-007, VR-AST-003, VR-FAIL-002 | Core | Clarifying | Define prerelease upsert semantics, release body/failure behavior, publish outputs, and status artifact contract. | A-008, A-009, A-013, A-014 |
 | V1-C5 | none (new contract) | VR-AST-001, VR-AST-002, VR-AST-004, VR-FAIL-003 | Core | Clarifying | Require fixed asset set including diagnostics plus Linux and Windows container packed libraries, and fail when required assets are missing. | A-010, A-011 |
-| V1-C6 | none (new contract) | VR-TRIG-004, VR-TRIG-005, VR-OPS-001, VR-OPS-002, VR-OPS-003, VR-OPS-004, VR-SEC-001, VR-SEC-002, VR-SEC-003, VR-GOV-001, VR-GOV-002, VR-GOV-003, VR-GOV-004 | Extended/Full | Contract-expanding | Add manual backfill dispatch controls, SHA pinning contract, security expectations, and governance/traceability requirements. | A-004, A-012, A-015 |
+| V1-C6 | none (new contract) | VR-TRIG-004, VR-TRIG-005, VR-OPS-001, VR-OPS-002, VR-OPS-003, VR-OPS-004, VR-OPS-005, VR-OPS-006, VR-FAIL-005, VR-SEC-001, VR-SEC-002, VR-SEC-003, VR-GOV-001, VR-GOV-002, VR-GOV-003, VR-GOV-004 | Extended/Full | Breaking | Harden manual backfill policy with strict SHA intent, merged-develop merge-commit resolution, and fail-fast semantics for invalid publish intent, plus governance/traceability controls. | A-004, A-012, A-015 |
 
 Coverage summary:
 - Changed/new v1 VR IDs are fully mapped to trace rows.

--- a/docs/vip-prerelease-requirements-v1-acceptance.md
+++ b/docs/vip-prerelease-requirements-v1-acceptance.md
@@ -5,9 +5,9 @@ This matrix defines executable acceptance scenarios for `docs/vip-prerelease-req
 | Scenario ID | Scope/Profile | Target VR IDs | Setup | Execution | Pass Criteria |
 |---|---|---|---|---|---|
 | A-001 | Core | VR-SCOPE-001, VR-SCOPE-002, VR-SCOPE-003, VR-SCOPE-004, VR-PUR-001, VR-PUR-002, VR-PUR-003, VR-PUR-004, VR-PUR-005, VR-PUR-006 | Load requirements document. | Parse `VR-` requirement IDs and normative statements. | IDs are unique and monotonic within each VR family; each `shall` statement is independently testable. |
-| A-002 | Core | VR-TRIG-001, VR-TRIG-006 | Push merge commit to `develop` associated with merged PR targeting `develop`. | Run `ci-composite.yml`. | Publish context marks run eligible with reason output indicating auto merged-PR path. |
-| A-003 | Core | VR-TRIG-002, VR-FAIL-001 | Push direct commit to `develop` without merged PR association. | Run `ci-composite.yml`. | Publish job reports `publish_status=skipped` and workflow remains successful. |
-| A-004 | Extended | VR-TRIG-004, VR-TRIG-005, VR-OPS-001, VR-OPS-002, VR-OPS-003, VR-OPS-004 | Dispatch workflow manually with `publish_prerelease=true` and then with `publish_prerelease=false`. | Compare publish job behavior across both runs. | Publish occurs only when input is `true`; `false` run is skipped; SHA pinning contract is enforced for manual publish intent. |
+| A-002 | Core | VR-TRIG-001, VR-TRIG-006, VR-TRIG-007, VR-TRIG-008 | Push merge commit to `develop` associated with merged PR targeting `develop`, where commit parent count is greater than 1 and PR `merge_commit_sha` equals `github.sha`. | Run `ci-composite.yml`. | Publish context marks run eligible with reason output indicating merged-PR merge-commit auto path. |
+| A-003 | Core | VR-TRIG-002, VR-TRIG-007, VR-FAIL-001 | Push direct commit to `develop` without merged PR association. | Run `ci-composite.yml`. | Publish path is ineligible, `publish_status=skipped` is emitted, and workflow remains successful. |
+| A-004 | Extended | VR-TRIG-004, VR-TRIG-005, VR-TRIG-007, VR-TRIG-008, VR-OPS-001, VR-OPS-002, VR-OPS-003, VR-OPS-004, VR-OPS-005, VR-OPS-006, VR-FAIL-005 | Dispatch workflow manually with three cases: valid publish intent (`publish_prerelease=true`, `expected_sha=<merged develop merge SHA>`, `strict_sha=true`), false intent (`publish_prerelease=false`), and invalid publish intent (missing `strict_sha=true` or non-eligible SHA). | Compare publish behavior and failure semantics across all dispatch runs. | Valid manual intent publishes; false intent skips; invalid publish intent fails fast with explicit policy errors before publication. |
 | A-005 | Core | VR-VER-002, VR-VER-004, VR-VER-005, VR-VER-006 | Use merged PR labels on develop merge (`major`, `minor`, `patch`, none). | Execute version computation in eligible publish runs. | Bump type follows merged PR labels, with default `patch` when no release label exists; override interface behavior is valid. |
 | A-006 | Core | VR-VER-003, VR-FAIL-004 | Apply conflicting merged PR release labels (for example `major` and `minor`). | Execute eligible develop publish run. | Version resolution fails with non-zero exit and explicit conflict error. |
 | A-007 | Core | VR-VER-001 | Prepare run with known computed `VERSION` output. | Publish prerelease and inspect release metadata. | Release tag and title equal `needs.version.outputs.VERSION` exactly. |
@@ -27,7 +27,7 @@ This matrix defines executable acceptance scenarios for `docs/vip-prerelease-req
 | A-001 | Pass | local | local | Revalidated on 2026-02-08 via `pwsh -NoProfile -File .\\Tooling\\Test-VipPrereleaseRequirementsV1.ps1`; VR ID uniqueness/ordering and shall-atomicity checks passed. |
 | A-002 | Planned | N/A | N/A | Populate after first merged-PR-to-develop publish run. |
 | A-003 | Planned | N/A | N/A | Populate after direct-push develop validation run. |
-| A-004 | Planned | N/A | N/A | Populate after two workflow_dispatch intent runs. |
+| A-004 | Planned | N/A | N/A | Populate after valid, false-intent, and invalid workflow_dispatch intent runs. |
 | A-005 | Planned | N/A | N/A | Populate after merged PR label matrix validation. |
 | A-006 | Planned | N/A | N/A | Populate after conflicting-label negative test. |
 | A-007 | Planned | N/A | N/A | Populate after metadata verification run. |

--- a/docs/vip-prerelease-requirements.md
+++ b/docs/vip-prerelease-requirements.md
@@ -56,6 +56,8 @@ VR-TRIG-003: `pull_request` events shall never publish prereleases.
 VR-TRIG-004: `workflow_dispatch` runs shall publish only when the boolean input `publish_prerelease` is `true`.
 VR-TRIG-005: `workflow_dispatch` runs with `publish_prerelease` not equal to `true` shall skip prerelease publication.
 VR-TRIG-006: Trigger evaluation shall emit publish intent and reason outputs for downstream jobs.
+VR-TRIG-007: Eligible publish paths shall require `github.sha` to be a merge commit with at least two parents.
+VR-TRIG-008: Eligible publish paths shall require merged pull-request association where `merge_commit_sha` equals `github.sha`.
 
 ## 3. Version and Bump Contract (Core)
 
@@ -64,7 +66,7 @@ VR-VER-002: Eligible develop publish runs shall derive bump type from merged pul
 VR-VER-003: Conflicting merged pull-request release labels shall fail version resolution.
 VR-VER-004: The compute-version interface shall support optional `bump_type_override` input values `major`, `minor`, `patch`, or `none`.
 VR-VER-005: When `bump_type_override` is provided, compute-version shall use it instead of event-derived bump type.
-VR-VER-006: Manual backfill runs without merged pull-request association may use `none` bump override.
+VR-VER-006: Manual workflow_dispatch runs with `publish_prerelease` not equal to `true` shall allow `none` bump override behavior.
 
 ## 4. Publish Contract (Core)
 
@@ -89,6 +91,8 @@ VR-OPS-001: Manual backfill shall be available through `workflow_dispatch` with 
 VR-OPS-002: Manual backfill shall pin and validate the target SHA using `expected_sha` contract checks.
 VR-OPS-003: Manual backfill publication shall reuse Core upsert and asset replacement rules.
 VR-OPS-004: Manual backfill shall emit publish status outputs even when publication is skipped.
+VR-OPS-005: Manual backfill with `publish_prerelease=true` shall require `strict_sha=true`.
+VR-OPS-006: Manual backfill with `publish_prerelease=true` shall require `expected_sha` to resolve to an eligible merged `develop` merge commit.
 
 ## 7. Security and Permissions (Core)
 
@@ -98,10 +102,11 @@ VR-SEC-003: Publish behavior shall be repository-agnostic without requiring cano
 
 ## 8. Failure Semantics (Core)
 
-VR-FAIL-001: Ineligible publish paths shall complete with `publish_status=skipped` without failing the workflow.
+VR-FAIL-001: Ineligible auto-publish paths and manual runs with `publish_prerelease` not equal to `true` shall complete with `publish_status=skipped` without failing the workflow.
 VR-FAIL-002: Eligible publish API failures shall terminate publish job execution with a non-zero exit code.
 VR-FAIL-003: Required asset validation failures shall terminate publish job execution with a non-zero exit code.
 VR-FAIL-004: Label-conflict failures in bump derivation shall terminate version resolution with a non-zero exit code.
+VR-FAIL-005: Manual runs with `publish_prerelease=true` that fail strict SHA eligibility checks shall terminate workflow execution with a non-zero exit code.
 
 ## 9. Governance and Traceability (Full)
 
@@ -112,7 +117,7 @@ VR-GOV-004: All changed or new VR IDs shall map to at least one acceptance scena
 
 ## 10. Public Interface Summary (Normative)
 
-- `ci-composite.yml` dispatch input `publish_prerelease` (boolean, default `false`).
+- `ci-composite.yml` dispatch inputs `publish_prerelease` (boolean, default `false`), `expected_sha` (string), and `strict_sha` (boolean).
 - `.github/actions/compute-version/action.yml` input `bump_type_override` (optional).
 - `build-vip` job outputs for VIP and release-notes artifact identifiers.
 - `publish-prerelease` job outputs: `release_tag`, `release_url`, `release_id`, `publish_status`.


### PR DESCRIPTION
## Summary
Land CI RCA + prevention hardening for the PR #82 merge-blocker pattern and publish asset stability.

### What changed
- Hardened ci-composite.yml concurrency to isolate by event/ref and auto-cancel stale PR runs.
- Added troubleshooting RCA entry for the blocked-merge-with-green-checks scenario.
- Hardened prerelease asset path by ensuring gcli-logs evidence artifact always exists (placeholder when no logs are produced).

### Evidence links
- Historical failure run (missing gcli-logs): https://github.com/svelderrainruiz/labview-icon-editor/actions/runs/21853505128
- Fixed publish-path run: https://github.com/svelderrainruiz/labview-icon-editor/actions/runs/21875008148
- Baseline run (publish_prerelease=false): https://github.com/svelderrainruiz/labview-icon-editor/actions/runs/21875003872

### Scope
- .github/workflows/ci-composite.yml
- docs/ci/troubleshooting-faq.md
- docs/ci-workflows.md