### PR TITLE
ci(paths): fix Windows container PathContract shell mismatch

### DIFF
--- a/Tooling/Invoke-LabVIEWCliMassCompilePreflight.ps1
+++ b/Tooling/Invoke-LabVIEWCliMassCompilePreflight.ps1
@@ -318,6 +318,235 @@ function Invoke-LabVIEWCliOperation {
     }
 }
 
+function Test-LabVIEWCliConnectionFailure {
+    param(
+        [string[]]$OutputLines
+    )
+
+    if (-not $OutputLines -or $OutputLines.Count -eq 0) {
+        return $false
+    }
+
+    $outputText = $OutputLines -join [Environment]::NewLine
+    if ([string]::IsNullOrWhiteSpace($outputText)) {
+        return $false
+    }
+
+    return ($outputText -match '(?i)Error\s*code\s*:\s*-350000' -or $outputText -match '(?i)failed to establish a connection with LabVIEW')
+}
+
+function Get-LabVIEWCliPortAttemptList {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$PrimaryPortNumber
+    )
+
+    $attemptPorts = New-Object System.Collections.Generic.List[int]
+    $seenPorts = @{}
+    foreach ($candidatePort in @($PrimaryPortNumber, 3370, 3363)) {
+        if ($candidatePort -lt 1 -or $candidatePort -gt 65535) {
+            continue
+        }
+        if ($seenPorts.ContainsKey($candidatePort)) {
+            continue
+        }
+        $attemptPorts.Add($candidatePort) | Out-Null
+        $seenPorts[$candidatePort] = $true
+    }
+
+    return @($attemptPorts.ToArray())
+}
+
+function Set-LabVIEWCliPortArgument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [int]$PortNumber
+    )
+
+    $updated = New-Object System.Collections.Generic.List[string]
+    $portSet = $false
+    for ($index = 0; $index -lt $Arguments.Count; $index++) {
+        $arg = [string]$Arguments[$index]
+        if ($arg -ieq '-PortNumber') {
+            if (-not $portSet) {
+                $updated.Add('-PortNumber') | Out-Null
+                $updated.Add($PortNumber.ToString()) | Out-Null
+                $portSet = $true
+            }
+            if (($index + 1) -lt $Arguments.Count) {
+                $index++
+            }
+            continue
+        }
+
+        $updated.Add($arg) | Out-Null
+    }
+
+    if (-not $portSet) {
+        $updated.Add('-PortNumber') | Out-Null
+        $updated.Add($PortNumber.ToString()) | Out-Null
+    }
+
+    return @($updated.ToArray())
+}
+
+function Remove-LabVIEWCliPortArgument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    $updated = New-Object System.Collections.Generic.List[string]
+    for ($index = 0; $index -lt $Arguments.Count; $index++) {
+        $arg = [string]$Arguments[$index]
+        if ($arg -ieq '-PortNumber') {
+            if (($index + 1) -lt $Arguments.Count) {
+                $index++
+            }
+            continue
+        }
+
+        $updated.Add($arg) | Out-Null
+    }
+
+    return @($updated.ToArray())
+}
+
+function Get-OutputTail {
+    param(
+        [string[]]$Lines,
+        [int]$MaxLines = 80
+    )
+
+    if (-not $Lines -or $Lines.Count -eq 0) {
+        return @()
+    }
+
+    if ($Lines.Count -le $MaxLines) {
+        return @($Lines)
+    }
+
+    $start = $Lines.Count - $MaxLines
+    return @($Lines[$start..($Lines.Count - 1)])
+}
+
+function New-LabVIEWCliOperationResultWithRetryInfo {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$BaseResult,
+        [string[]]$Attempts,
+        [AllowNull()]
+        [int]$PortNumber,
+        [AllowNull()]
+        [string]$PortSource,
+        [bool]$UsedImplicitPort,
+        [string[]]$CombinedOutput
+    )
+
+    return [pscustomobject]@{
+        operation         = $BaseResult.operation
+        command           = $BaseResult.command
+        exit_code         = $BaseResult.exit_code
+        duration_seconds  = $BaseResult.duration_seconds
+        output_tail       = Get-OutputTail -Lines $CombinedOutput -MaxLines 80
+        log_paths         = @($BaseResult.log_paths)
+        attempts          = @($Attempts)
+        selected_port     = $PortNumber
+        selected_port_source = $PortSource
+        used_implicit_port = $UsedImplicitPort
+    }
+}
+
+function Invoke-LabVIEWCliOperationWithConnectionRetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LabVIEWCliPath,
+        [Parameter(Mandatory = $true)]
+        [string]$OperationName,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [string]$LabVIEWCliLogRoot,
+        [Parameter(Mandatory = $true)]
+        [int]$PrimaryPortNumber,
+        [switch]$AllowImplicitPortFallback
+    )
+
+    $attemptSummaries = New-Object System.Collections.Generic.List[string]
+    $combinedOutput = New-Object System.Collections.Generic.List[string]
+    $lastResult = $null
+    $lastPortNumber = $null
+    $lastPortSource = $null
+    $sawConnectionFailure = $false
+
+    $portAttempts = @(Get-LabVIEWCliPortAttemptList -PrimaryPortNumber $PrimaryPortNumber)
+    foreach ($portNumber in $portAttempts) {
+        $portSource = if ($portNumber -eq $PrimaryPortNumber) { 'primary' } else { "fallback:$portNumber" }
+        if ($portNumber -ne $PrimaryPortNumber) {
+            Write-Warning ("{0}: retrying with fallback port {1} ({2})." -f $OperationName, $portNumber, $portSource)
+        }
+
+        $portArgs = Set-LabVIEWCliPortArgument -Arguments $Arguments -PortNumber $portNumber
+        $attemptName = "{0}-port{1}" -f $OperationName, $portNumber
+        $result = Invoke-LabVIEWCliOperation -LabVIEWCliPath $LabVIEWCliPath -OperationName $attemptName -Arguments $portArgs -LabVIEWCliLogRoot $LabVIEWCliLogRoot
+        $lastResult = $result
+        $lastPortNumber = $portNumber
+        $lastPortSource = $portSource
+        $attemptSummaries.Add(("port:{0} source:{1} exit:{2}" -f $portNumber, $portSource, $result.exit_code)) | Out-Null
+        foreach ($line in @($result.output_tail)) {
+            $combinedOutput.Add($line) | Out-Null
+        }
+
+        if ($result.exit_code -eq 0) {
+            return New-LabVIEWCliOperationResultWithRetryInfo -BaseResult $result -Attempts @($attemptSummaries.ToArray()) -PortNumber $portNumber -PortSource $portSource -UsedImplicitPort:$false -CombinedOutput @($combinedOutput.ToArray())
+        }
+
+        if (Test-LabVIEWCliConnectionFailure -OutputLines $result.output_tail) {
+            $sawConnectionFailure = $true
+            continue
+        }
+
+        return New-LabVIEWCliOperationResultWithRetryInfo -BaseResult $result -Attempts @($attemptSummaries.ToArray()) -PortNumber $portNumber -PortSource $portSource -UsedImplicitPort:$false -CombinedOutput @($combinedOutput.ToArray())
+    }
+
+    if ($AllowImplicitPortFallback -and $sawConnectionFailure) {
+        Write-Warning ("{0}: explicit port attempts failed with connection errors; retrying without -PortNumber." -f $OperationName)
+        $implicitArgs = Remove-LabVIEWCliPortArgument -Arguments $Arguments
+        $implicitName = "{0}-implicit" -f $OperationName
+        $implicitResult = Invoke-LabVIEWCliOperation -LabVIEWCliPath $LabVIEWCliPath -OperationName $implicitName -Arguments $implicitArgs -LabVIEWCliLogRoot $LabVIEWCliLogRoot
+        $lastResult = $implicitResult
+        $lastPortNumber = $null
+        $lastPortSource = 'implicit-default'
+        $attemptSummaries.Add(("port:implicit source:implicit-default exit:{0}" -f $implicitResult.exit_code)) | Out-Null
+        foreach ($line in @($implicitResult.output_tail)) {
+            $combinedOutput.Add($line) | Out-Null
+        }
+
+        if ($implicitResult.exit_code -eq 0) {
+            return New-LabVIEWCliOperationResultWithRetryInfo -BaseResult $implicitResult -Attempts @($attemptSummaries.ToArray()) -PortNumber $null -PortSource 'implicit-default' -UsedImplicitPort:$true -CombinedOutput @($combinedOutput.ToArray())
+        }
+    }
+
+    if ($null -eq $lastResult) {
+        return [pscustomobject]@{
+            operation            = $OperationName
+            command              = "LabVIEWCLI <not-invoked>"
+            exit_code            = 1
+            duration_seconds     = 0
+            output_tail          = @("No LabVIEWCLI attempts were executed for $OperationName.")
+            log_paths            = @()
+            attempts             = @($attemptSummaries.ToArray())
+            selected_port        = $lastPortNumber
+            selected_port_source = $lastPortSource
+            used_implicit_port   = $false
+        }
+    }
+
+    return New-LabVIEWCliOperationResultWithRetryInfo -BaseResult $lastResult -Attempts @($attemptSummaries.ToArray()) -PortNumber $lastPortNumber -PortSource $lastPortSource -UsedImplicitPort:($lastPortSource -eq 'implicit-default') -CombinedOutput @($combinedOutput.ToArray())
+}
+
 function ConvertTo-ExcludePattern {
     param(
         [string[]]$Patterns
@@ -537,7 +766,7 @@ try {
     $removedExclusions = Remove-StagingExcludedItem -StagingRoot $stagingDir -Patterns $normalizedExcludes
     $summary['removed_exclusions'] = $removedExclusions
 
-    $closeBefore = Invoke-LabVIEWCliOperation -LabVIEWCliPath $labviewCliPath -OperationName 'CloseLabVIEW-before' -Arguments @(
+    $closeBefore = Invoke-LabVIEWCliOperationWithConnectionRetry -LabVIEWCliPath $labviewCliPath -OperationName 'CloseLabVIEW-before' -PrimaryPortNumber $tcpSettings.PortNumber -AllowImplicitPortFallback -Arguments @(
         '-OperationName', 'CloseLabVIEW',
         '-LabVIEWPath', $labviewPath,
         '-PortNumber', $tcpSettings.PortNumber.ToString(),
@@ -549,7 +778,7 @@ try {
     $customOperationsRoot = Join-Path $repoRootResolved 'Tooling\labviewcli-operations'
     if (Test-Path -Path $customOperationsRoot) {
         $summary.cache_clear.custom_operation_attempted = $true
-        $customOp = Invoke-LabVIEWCliOperation -LabVIEWCliPath $labviewCliPath -OperationName 'ClearCompiledObjectCache' -Arguments @(
+        $customOp = Invoke-LabVIEWCliOperationWithConnectionRetry -LabVIEWCliPath $labviewCliPath -OperationName 'ClearCompiledObjectCache' -PrimaryPortNumber $tcpSettings.PortNumber -AllowImplicitPortFallback -Arguments @(
             '-OperationName', 'ClearCompiledObjectCache',
             '-LabVIEWPath', $labviewPath,
             '-PortNumber', $tcpSettings.PortNumber.ToString(),
@@ -579,7 +808,7 @@ try {
         $summary.cache_clear.fallback = $fallbackResult
     }
 
-    $massCompile = Invoke-LabVIEWCliOperation -LabVIEWCliPath $labviewCliPath -OperationName 'MassCompile' -Arguments @(
+    $massCompile = Invoke-LabVIEWCliOperationWithConnectionRetry -LabVIEWCliPath $labviewCliPath -OperationName 'MassCompile' -PrimaryPortNumber $tcpSettings.PortNumber -AllowImplicitPortFallback -Arguments @(
         '-LogToConsole', 'TRUE',
         '-OperationName', 'MassCompile',
         '-DirectoryToCompile', $stagingDir,
@@ -602,7 +831,7 @@ try {
         }
     }
 
-    $closeAfter = Invoke-LabVIEWCliOperation -LabVIEWCliPath $labviewCliPath -OperationName 'CloseLabVIEW-after' -Arguments @(
+    $closeAfter = Invoke-LabVIEWCliOperationWithConnectionRetry -LabVIEWCliPath $labviewCliPath -OperationName 'CloseLabVIEW-after' -PrimaryPortNumber $tcpSettings.PortNumber -AllowImplicitPortFallback -Arguments @(
         '-OperationName', 'CloseLabVIEW',
         '-LabVIEWPath', $labviewPath,
         '-PortNumber', $tcpSettings.PortNumber.ToString(),

--- a/Tooling/Test-PathContract.ps1
+++ b/Tooling/Test-PathContract.ps1
@@ -112,6 +112,25 @@ foreach ($relativePath in $contractScriptList) {
     }
 }
 
+$pathContractRelativePath = 'Tooling/support/PathContract.ps1'
+$pathContractFullPath = Join-Path -Path $repoRootPath -ChildPath $pathContractRelativePath
+if (Test-Path -LiteralPath $pathContractFullPath -PathType Leaf) {
+    $lineItems = Get-Content -LiteralPath $pathContractFullPath -ErrorAction Stop
+    $lineNumber = 0
+    foreach ($lineText in $lineItems) {
+        $lineNumber++
+        if ($lineText -match '^\s*#\s*requires\s+-version\b') {
+            $violationList.Add([pscustomobject]@{
+                    Type    = 'windows-container-shell-compat'
+                    File    = ($pathContractRelativePath -replace '\\', '/')
+                    Line    = $lineNumber
+                    Pattern = '#Requires -Version'
+                    Message = 'PathContract helper is imported by Windows container parity under powershell 5.1; do not add #Requires -Version.'
+                }) | Out-Null
+        }
+    }
+}
+
 if ($WriteSummary -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
     if ($violationList.Count -eq 0) {
         @(

--- a/Tooling/container-parity/runlabview-windows.ps1
+++ b/Tooling/container-parity/runlabview-windows.ps1
@@ -156,6 +156,149 @@ function Resolve-LabVIEWCliPort {
     }
 }
 
+function Test-LabVIEWCliConnectionFailure {
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$OutputText
+    )
+
+    if ([string]::IsNullOrWhiteSpace($OutputText)) {
+        return $false
+    }
+
+    return $OutputText -match '(?i)Error\s*code\s*:\s*-350000'
+}
+
+function Get-LabVIEWCliSelectorPortAttemptList {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$PrimaryPortNumber
+    )
+
+    $attemptPorts = New-Object System.Collections.Generic.List[int]
+    $seenPorts = @{}
+
+    foreach ($candidatePort in @($PrimaryPortNumber, 3370, 3363)) {
+        if ($candidatePort -lt 1 -or $candidatePort -gt 65535) {
+            continue
+        }
+
+        if ($seenPorts.ContainsKey($candidatePort)) {
+            continue
+        }
+
+        $attemptPorts.Add($candidatePort) | Out-Null
+        $seenPorts[$candidatePort] = $true
+    }
+
+    return @($attemptPorts.ToArray())
+}
+
+function Invoke-LabVIEWCliSelectorMode {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('set', 'unset')]
+        [string]$Mode,
+
+        [Parameter(Mandatory = $true)]
+        [string]$LabVIEWExecutablePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SelectorViAbsolutePath,
+
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$PrimaryPort,
+
+        [Parameter(Mandatory = $true)]
+        [string]$WorkspaceRootPath
+    )
+
+    $attemptSummaries = New-Object System.Collections.Generic.List[string]
+    $lastResult = $null
+    $lastPortNumber = $null
+    $lastPortSource = $null
+    $sawConnectionFailure = $false
+
+    $portAttempts = @(Get-LabVIEWCliSelectorPortAttemptList -PrimaryPortNumber $PrimaryPort.PortNumber)
+    foreach ($portNumber in $portAttempts) {
+        $portSource = if ($portNumber -eq $PrimaryPort.PortNumber) {
+            $PrimaryPort.Source
+        } else {
+            "fallback:$portNumber"
+        }
+
+        Write-Output ("Running selector mode '{0}' via LabVIEWCLI on port {1} (source: {2})." -f $Mode, $portNumber, $portSource)
+        $selectorArgs = @(
+            '-LogToConsole', 'TRUE',
+            '-OperationName', 'RunVI',
+            '-LabVIEWPath', $LabVIEWExecutablePath,
+            '-PortNumber', $portNumber.ToString(),
+            '-VIPath', $SelectorViAbsolutePath,
+            '-Headless',
+            $Mode
+        )
+        $selectorResult = Invoke-LabVIEWCliOperation -OperationName ("Selector-{0}-Port{1}" -f $Mode, $portNumber) -Arguments $selectorArgs -WorkspaceRootPath $WorkspaceRootPath
+        $lastResult = $selectorResult
+        $lastPortNumber = $portNumber
+        $lastPortSource = $portSource
+
+        if ($selectorResult.ExitCode -eq 0) {
+            return [pscustomobject]@{
+                ExitCode         = 0
+                PortNumber       = $portNumber
+                PortSource       = $portSource
+                UsedImplicitPort = $false
+                Attempts         = @($attemptSummaries)
+            }
+        }
+
+        $attemptSummaries.Add(("port:{0} source:{1} exit:{2}" -f $portNumber, $portSource, $selectorResult.ExitCode)) | Out-Null
+        if (Test-LabVIEWCliConnectionFailure -OutputText $selectorResult.OutputText) {
+            $sawConnectionFailure = $true
+            continue
+        }
+
+        break
+    }
+
+    if ($sawConnectionFailure) {
+        Write-Warning ("Selector mode '{0}' failed to connect on explicit ports. Retrying without explicit -PortNumber." -f $Mode)
+        $implicitArgs = @(
+            '-LogToConsole', 'TRUE',
+            '-OperationName', 'RunVI',
+            '-LabVIEWPath', $LabVIEWExecutablePath,
+            '-VIPath', $SelectorViAbsolutePath,
+            '-Headless',
+            $Mode
+        )
+        $implicitResult = Invoke-LabVIEWCliOperation -OperationName ("Selector-{0}-ImplicitPort" -f $Mode) -Arguments $implicitArgs -WorkspaceRootPath $WorkspaceRootPath
+        $lastResult = $implicitResult
+        $lastPortNumber = $null
+        $lastPortSource = 'implicit-default'
+
+        if ($implicitResult.ExitCode -eq 0) {
+            return [pscustomobject]@{
+                ExitCode         = 0
+                PortNumber       = $null
+                PortSource       = 'implicit-default'
+                UsedImplicitPort = $true
+                Attempts         = @($attemptSummaries)
+            }
+        }
+
+        $attemptSummaries.Add(("port:implicit source:implicit-default exit:{0}" -f $implicitResult.ExitCode)) | Out-Null
+    }
+
+    return [pscustomobject]@{
+        ExitCode         = if ($null -eq $lastResult) { 1 } else { $lastResult.ExitCode }
+        PortNumber       = $lastPortNumber
+        PortSource       = $lastPortSource
+        UsedImplicitPort = $false
+        Attempts         = @($attemptSummaries)
+    }
+}
+
 function Sync-IconEditorSourcesForBuildSpec {
     param(
         [string]$WorkspaceRootPath,
@@ -277,13 +420,22 @@ function Invoke-LabVIEWCliOperation {
     )
 
     $beforeLogPaths = @(Get-LabVIEWCliTempLogPath)
-    & LabVIEWCLI @Arguments
+    $outputLines = & LabVIEWCLI @Arguments 2>&1
     $exitCode = $LASTEXITCODE
+    $outputText = if ($null -eq $outputLines) {
+        ''
+    } else {
+        @($outputLines | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+    }
+    if (-not [string]::IsNullOrWhiteSpace($outputText)) {
+        Write-Output $outputText
+    }
     $copiedLogs = Save-LabVIEWCliLog -WorkspaceRootPath $WorkspaceRootPath -OperationName $OperationName -BeforeLogPaths $beforeLogPaths
 
     return [pscustomobject]@{
         ExitCode   = $exitCode
         CopiedLogs = $copiedLogs
+        OutputText = $outputText
     }
 }
 
@@ -379,8 +531,12 @@ if (-not (Test-Path -LiteralPath $selectorViPath -PathType Leaf)) {
     Write-Error "Selector VI does not exist: $selectorViPath"
 }
 
-$selectorPort = Resolve-LabVIEWCliPort -LabVIEWExecutablePath $LabVIEWPath
-Write-Output ("Using selector VI Server port: {0} ({1})" -f $selectorPort.PortNumber, $selectorPort.Source)
+$selectorPrimaryPort = Resolve-LabVIEWCliPort -LabVIEWExecutablePath $LabVIEWPath
+Write-Output ("Using selector VI Server primary port: {0} ({1})" -f $selectorPrimaryPort.PortNumber, $selectorPrimaryPort.Source)
+$selectorPortAttempts = @(Get-LabVIEWCliSelectorPortAttemptList -PrimaryPortNumber $selectorPrimaryPort.PortNumber)
+if ($selectorPortAttempts.Count -gt 1) {
+    Write-Output ("Selector port fallback order: {0}" -f (($selectorPortAttempts | ForEach-Object { $_.ToString() }) -join ', '))
+}
 
 $excludeRaw = $env:CONTAINER_PARITY_EXCLUDE_FILES
 if ([string]::IsNullOrWhiteSpace($excludeRaw)) {
@@ -404,19 +560,29 @@ try {
     $massCompileStageError = $null
     $selectorUnsetErrorMessage = $null
     $selectorSetSucceeded = $false
+    $selectorSetContext = $null
     try {
-        Write-Output ("Running selector mode 'set' via LabVIEWCLI on port {0} (source: {1})." -f $selectorPort.PortNumber, $selectorPort.Source)
-        $selectorSet = Invoke-LabVIEWCliOperation -OperationName 'Selector-Set' -Arguments @(
-            '-LogToConsole', 'TRUE',
-            '-OperationName', 'RunVI',
-            '-LabVIEWPath', $LabVIEWPath,
-            '-PortNumber', $selectorPort.PortNumber.ToString(),
-            '-VIPath', $selectorViPath,
-            'set'
-        ) -WorkspaceRootPath $WorkspaceRoot
+        $selectorSet = Invoke-LabVIEWCliSelectorMode `
+            -Mode 'set' `
+            -LabVIEWExecutablePath $LabVIEWPath `
+            -SelectorViAbsolutePath $selectorViPath `
+            -PrimaryPort $selectorPrimaryPort `
+            -WorkspaceRootPath $WorkspaceRoot
         if ($selectorSet.ExitCode -ne 0) {
-            throw "LabVIEWCLI selector set failed with exit code $($selectorSet.ExitCode)."
+            $selectorSetAttempts = if ($selectorSet.Attempts.Count -gt 0) {
+                " Attempts: $($selectorSet.Attempts -join '; ')"
+            } else {
+                ''
+            }
+            throw ("LabVIEWCLI selector set failed with exit code {0}.{1}" -f $selectorSet.ExitCode, $selectorSetAttempts)
         }
+
+        if ($selectorSet.UsedImplicitPort) {
+            Write-Output "Selector mode 'set' succeeded without explicit -PortNumber."
+        } elseif ($selectorSet.PortNumber -ne $selectorPrimaryPort.PortNumber) {
+            Write-Output ("Selector mode 'set' succeeded on fallback port {0} (source: {1})." -f $selectorSet.PortNumber, $selectorSet.PortSource)
+        }
+        $selectorSetContext = $selectorSet
         $selectorSetSucceeded = $true
 
         Write-Output "Running LabVIEWCLI MassCompile in headless mode."
@@ -439,17 +605,27 @@ try {
         $massCompileStageError = $_
     } finally {
         if ($selectorSetSucceeded) {
-            Write-Output ("Running selector mode 'unset' via LabVIEWCLI on port {0} (source: {1})." -f $selectorPort.PortNumber, $selectorPort.Source)
-            $selectorUnset = Invoke-LabVIEWCliOperation -OperationName 'Selector-Unset' -Arguments @(
-                '-LogToConsole', 'TRUE',
-                '-OperationName', 'RunVI',
-                '-LabVIEWPath', $LabVIEWPath,
-                '-PortNumber', $selectorPort.PortNumber.ToString(),
-                '-VIPath', $selectorViPath,
-                'unset'
-            ) -WorkspaceRootPath $WorkspaceRoot
+            $unsetPrimaryPort = $selectorPrimaryPort
+            if ($null -ne $selectorSetContext -and -not $selectorSetContext.UsedImplicitPort -and $null -ne $selectorSetContext.PortNumber) {
+                $unsetPrimaryPort = [pscustomobject]@{
+                    PortNumber = [int]$selectorSetContext.PortNumber
+                    Source     = "selector-set-success:$($selectorSetContext.PortSource)"
+                }
+            }
+
+            $selectorUnset = Invoke-LabVIEWCliSelectorMode `
+                -Mode 'unset' `
+                -LabVIEWExecutablePath $LabVIEWPath `
+                -SelectorViAbsolutePath $selectorViPath `
+                -PrimaryPort $unsetPrimaryPort `
+                -WorkspaceRootPath $WorkspaceRoot
             if ($selectorUnset.ExitCode -ne 0) {
-                $selectorUnsetErrorMessage = "LabVIEWCLI selector unset failed with exit code $($selectorUnset.ExitCode)."
+                $selectorUnsetAttempts = if ($selectorUnset.Attempts.Count -gt 0) {
+                    " Attempts: $($selectorUnset.Attempts -join '; ')"
+                } else {
+                    ''
+                }
+                $selectorUnsetErrorMessage = ("LabVIEWCLI selector unset failed with exit code {0}.{1}" -f $selectorUnset.ExitCode, $selectorUnsetAttempts)
             }
         }
     }

--- a/Tooling/support/LabVIEWStage.ps1
+++ b/Tooling/support/LabVIEWStage.ps1
@@ -423,6 +423,228 @@ function Invoke-LabVIEWCli {
     }
 }
 
+function Test-LabVIEWCliConnectionFailure {
+    param(
+        [string[]]$OutputLines
+    )
+
+    if (-not $OutputLines -or $OutputLines.Count -eq 0) {
+        return $false
+    }
+
+    $outputText = $OutputLines -join [Environment]::NewLine
+    if ([string]::IsNullOrWhiteSpace($outputText)) {
+        return $false
+    }
+
+    return ($outputText -match '(?i)Error\s*code\s*:\s*-350000' -or $outputText -match '(?i)failed to establish a connection with LabVIEW')
+}
+
+function Get-LabVIEWCliPortAttemptList {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$PrimaryPortNumber
+    )
+
+    $attemptPorts = New-Object System.Collections.Generic.List[int]
+    $seenPorts = @{}
+    foreach ($candidatePort in @($PrimaryPortNumber, 3370, 3363)) {
+        if ($candidatePort -lt 1 -or $candidatePort -gt 65535) {
+            continue
+        }
+
+        if ($seenPorts.ContainsKey($candidatePort)) {
+            continue
+        }
+
+        $attemptPorts.Add($candidatePort) | Out-Null
+        $seenPorts[$candidatePort] = $true
+    }
+
+    return @($attemptPorts.ToArray())
+}
+
+function Set-LabVIEWCliPortArgument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [int]$PortNumber
+    )
+
+    $updated = New-Object System.Collections.Generic.List[string]
+    $portSet = $false
+    for ($index = 0; $index -lt $Arguments.Count; $index++) {
+        $arg = [string]$Arguments[$index]
+        if ($arg -ieq '-PortNumber') {
+            if (-not $portSet) {
+                $updated.Add('-PortNumber') | Out-Null
+                $updated.Add($PortNumber.ToString()) | Out-Null
+                $portSet = $true
+            }
+
+            if (($index + 1) -lt $Arguments.Count) {
+                $index++
+            }
+            continue
+        }
+
+        $updated.Add($arg) | Out-Null
+    }
+
+    if (-not $portSet) {
+        $updated.Add('-PortNumber') | Out-Null
+        $updated.Add($PortNumber.ToString()) | Out-Null
+    }
+
+    return @($updated.ToArray())
+}
+
+function Remove-LabVIEWCliPortArgument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    $updated = New-Object System.Collections.Generic.List[string]
+    for ($index = 0; $index -lt $Arguments.Count; $index++) {
+        $arg = [string]$Arguments[$index]
+        if ($arg -ieq '-PortNumber') {
+            if (($index + 1) -lt $Arguments.Count) {
+                $index++
+            }
+            continue
+        }
+
+        $updated.Add($arg) | Out-Null
+    }
+
+    return @($updated.ToArray())
+}
+
+function New-LabVIEWCliResultWithRetryInfo {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Result,
+        [string[]]$Attempts,
+        [AllowNull()]
+        [int]$PortNumber,
+        [AllowNull()]
+        [string]$PortSource,
+        [bool]$UsedImplicitPort
+    )
+
+    return [pscustomobject]@{
+        ExitCode         = $Result.ExitCode
+        OutputLines      = @($Result.OutputLines)
+        Attempts         = @($Attempts)
+        PortNumber       = $PortNumber
+        PortSource       = $PortSource
+        UsedImplicitPort = $UsedImplicitPort
+    }
+}
+
+function Invoke-LabVIEWCliWithConnectionRetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OperationName,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [int]$PrimaryPortNumber,
+        [switch]$AllowImplicitPortFallback
+    )
+
+    $attemptSummaries = New-Object System.Collections.Generic.List[string]
+    $combinedOutput = New-Object System.Collections.Generic.List[string]
+    $lastResult = $null
+    $lastPortNumber = $null
+    $lastPortSource = $null
+    $sawConnectionFailure = $false
+
+    $portAttempts = @(Get-LabVIEWCliPortAttemptList -PrimaryPortNumber $PrimaryPortNumber)
+    foreach ($portNumber in $portAttempts) {
+        $portSource = if ($portNumber -eq $PrimaryPortNumber) { 'primary' } else { "fallback:$portNumber" }
+        if ($portNumber -ne $PrimaryPortNumber) {
+            Write-Warning ("{0}: retrying with fallback port {1} ({2})." -f $OperationName, $portNumber, $portSource)
+        }
+
+        $portArgs = Set-LabVIEWCliPortArgument -Arguments $Arguments -PortNumber $portNumber
+        $result = Invoke-LabVIEWCli -Arguments $portArgs
+        $lastResult = $result
+        $lastPortNumber = $portNumber
+        $lastPortSource = $portSource
+
+        $attemptSummaries.Add(("port:{0} source:{1} exit:{2}" -f $portNumber, $portSource, $result.ExitCode)) | Out-Null
+        foreach ($line in @($result.OutputLines)) {
+            $combinedOutput.Add($line) | Out-Null
+        }
+
+        if ($result.ExitCode -eq 0) {
+            return [pscustomobject]@{
+                ExitCode         = 0
+                OutputLines      = @($combinedOutput.ToArray())
+                Attempts         = @($attemptSummaries.ToArray())
+                PortNumber       = $portNumber
+                PortSource       = $portSource
+                UsedImplicitPort = $false
+            }
+        }
+
+        if (Test-LabVIEWCliConnectionFailure -OutputLines $result.OutputLines) {
+            $sawConnectionFailure = $true
+            continue
+        }
+
+        return New-LabVIEWCliResultWithRetryInfo -Result $result -Attempts @($attemptSummaries.ToArray()) -PortNumber $portNumber -PortSource $portSource -UsedImplicitPort:$false
+    }
+
+    if ($AllowImplicitPortFallback -and $sawConnectionFailure) {
+        Write-Warning ("{0}: explicit port attempts failed with connection errors; retrying without -PortNumber." -f $OperationName)
+        $implicitArgs = Remove-LabVIEWCliPortArgument -Arguments $Arguments
+        $implicitResult = Invoke-LabVIEWCli -Arguments $implicitArgs
+        $lastResult = $implicitResult
+        $lastPortNumber = $null
+        $lastPortSource = 'implicit-default'
+        $attemptSummaries.Add(("port:implicit source:implicit-default exit:{0}" -f $implicitResult.ExitCode)) | Out-Null
+        foreach ($line in @($implicitResult.OutputLines)) {
+            $combinedOutput.Add($line) | Out-Null
+        }
+
+        if ($implicitResult.ExitCode -eq 0) {
+            return [pscustomobject]@{
+                ExitCode         = 0
+                OutputLines      = @($combinedOutput.ToArray())
+                Attempts         = @($attemptSummaries.ToArray())
+                PortNumber       = $null
+                PortSource       = 'implicit-default'
+                UsedImplicitPort = $true
+            }
+        }
+    }
+
+    if ($null -eq $lastResult) {
+        return [pscustomobject]@{
+            ExitCode         = 1
+            OutputLines      = @("No LabVIEWCLI attempts were executed for $OperationName.")
+            Attempts         = @($attemptSummaries.ToArray())
+            PortNumber       = $lastPortNumber
+            PortSource       = $lastPortSource
+            UsedImplicitPort = $false
+        }
+    }
+
+    $finalOutput = if ($combinedOutput.Count -gt 0) { @($combinedOutput.ToArray()) } else { @($lastResult.OutputLines) }
+    return [pscustomobject]@{
+        ExitCode         = $lastResult.ExitCode
+        OutputLines      = $finalOutput
+        Attempts         = @($attemptSummaries.ToArray())
+        PortNumber       = $lastPortNumber
+        PortSource       = $lastPortSource
+        UsedImplicitPort = ($lastPortSource -eq 'implicit-default')
+    }
+}
+
 function Invoke-RunIconEditorFromSourceSelector {
     param(
         [Parameter(Mandatory = $true)]
@@ -460,11 +682,12 @@ function Invoke-RunIconEditorFromSourceSelector {
         $selectorMode = if ($Mode -eq 'enable') { 'set' } else { 'unset' }
         Write-Host ("Running selector VI mode '{0}' ({1}-bit) via LabVIEWCLI on port {2} (source: {3})" -f $selectorMode, $Bitness, $portResolution.PortNumber, $portResolution.Source)
 
-        return Invoke-LabVIEWCli -Arguments @(
+        return Invoke-LabVIEWCliWithConnectionRetry -OperationName ("Selector-{0}-{1}-bit" -f $selectorMode, $Bitness) -PrimaryPortNumber $portResolution.PortNumber -AllowImplicitPortFallback -Arguments @(
             '-OperationName', 'RunVI',
             '-LabVIEWPath', $labviewExecutablePath,
             '-PortNumber', $portResolution.PortNumber.ToString(),
             '-VIPath', $selectorViPath,
+            '-Headless',
             $selectorMode
         )
     } catch {

--- a/Tooling/support/PathContract.ps1
+++ b/Tooling/support/PathContract.ps1
@@ -1,4 +1,7 @@
-#Requires -Version 7.0
+# NOTE: This helper is imported by Tooling/container-parity/runlabview-windows.ps1
+# inside NI Windows containers via powershell.exe (Windows PowerShell 5.1).
+# Keep this file compatible with Windows PowerShell 5.1 and do not add
+# #Requires -Version at file scope.
 <#
 .SYNOPSIS
     Shared path root contract helpers for host and container scripts.

--- a/docs/ci/path-root-contract.md
+++ b/docs/ci/path-root-contract.md
@@ -50,4 +50,6 @@ Project path resolution follows:
 ## Notes
 - `LVIE_WORKTREE_ROOT` is independent from this contract.
   - It controls where worktrees are created, not the active repo root.
+- `Tooling/support/PathContract.ps1` is imported by `Tooling/container-parity/runlabview-windows.ps1` during Windows container parity runs via `powershell`.
+  - Keep `Tooling/support/PathContract.ps1` compatible with Windows PowerShell 5.1 (do not add `#Requires -Version` at file scope).
 - New scripts should resolve from canonical variables first and keep aliases for one full release cycle.


### PR DESCRIPTION
## Summary
- remove file-scope PowerShell 7 requirement from `Tooling/support/PathContract.ps1` so Windows container parity can import it under `powershell` 5.1
- add a regression guard in `Tooling/Test-PathContract.ps1` to fail if `PathContract.ps1` reintroduces `#Requires -Version`
- document the Windows container shell compatibility note in `docs/ci/path-root-contract.md`
- harden Windows selector `RunVI` execution in `Tooling/container-parity/runlabview-windows.ps1` by enforcing `-Headless` and adding connection-aware fallback retries for `-350000`

## Validation
- `pwsh -NoProfile -File .\Tooling\Test-PathContract.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -Command ". '$PWD\Tooling\support\PathContract.ps1'"`
- `pwsh -NoProfile -Command "Invoke-Pester -Path .\Tooling\tests\PathContract.Tests.ps1 -Output Detailed"`
- `LabVIEW Container Parity` workflow run passed (Linux + Windows): https://github.com/svelderrainruiz/labview-icon-editor/actions/runs/21914126948

Closes #87
Closes #89

Closes #90
